### PR TITLE
Fix - .Net Core Solution

### DIFF
--- a/SecretSharingDotNetCore2.2.sln
+++ b/SecretSharingDotNetCore2.2.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNet", "src\SecretSharingDotNet.csproj", "{EF113114-267C-4CA0-B22A-62A326FF73B2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNet", "src\SecretSharingDotNetCore2.2.csproj", "{EF113114-267C-4CA0-B22A-62A326FF73B2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNetTest", "tests\SecretSharingDotNetTest.csproj", "{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}"
 EndProject

--- a/SecretSharingDotNetCore2.2.sln
+++ b/SecretSharingDotNetCore2.2.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNet", "src\SecretSharingDotNetCore2.2.csproj", "{EF113114-267C-4CA0-B22A-62A326FF73B2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNetTest", "tests\SecretSharingDotNetTest.csproj", "{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNetTest", "tests\SecretSharingDotNetCore2.2Test.csproj", "{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Fix project file name declarations within the solution file `SecretSharingDotNetCore2.2.sln`
The project files were renamed but the solution file wasn't modified with the last #1 .

Resolves: No entry