### PR TITLE
Calculator: Fix Sqrt property

### DIFF
--- a/src/Cryptography/FinitePoint.cs
+++ b/src/Cryptography/FinitePoint.cs
@@ -31,12 +31,13 @@
 
 namespace SecretSharingDotNet.Cryptography
 {
+    using Math;
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Globalization;
     using System.Linq;
-
-    using Math;
+    using System.Text;
 
     /// <summary>
     /// Represents the support point of the polynomial
@@ -129,9 +130,8 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="other"></param>
         /// <returns></returns>
-        public int CompareTo (FinitePoint<TNumber> other)
-        {
-            return System.Math.Sign ((this.X * this.X + this.Y * this.Y).Sqrt - (other.X * other.X + other.Y * other.Y).Sqrt);
+        public int CompareTo (FinitePoint<TNumber> other) {
+            return ((this.X * this.X + this.Y * this.Y).Sqrt - (other.X * other.X + other.Y * other.Y).Sqrt).Sign;
         }
 
         /// <summary>

--- a/src/Cryptography/Secret.cs
+++ b/src/Cryptography/Secret.cs
@@ -144,7 +144,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <returns></returns>
         public int CompareTo (Secret<TNumber> other)
         {
-            return System.Math.Sign ((this.secretNumber * this.secretNumber).Sqrt - (other.secretNumber * other.secretNumber).Sqrt);
+            return ((this.secretNumber * this.secretNumber).Sqrt - (other.secretNumber * other.secretNumber).Sqrt).Sign;
         }
 
         /// <summary>

--- a/src/Math/BigIntCalculator.cs
+++ b/src/Math/BigIntCalculator.cs
@@ -8,6 +8,7 @@
 
 namespace SecretSharingDotNet.Math
 {
+    using System;
     using System.Collections.ObjectModel;
     using System.Numerics;
 
@@ -20,41 +21,41 @@ namespace SecretSharingDotNet.Math
         /// Initializes a new instance of the <see cref="BigIntCalculator"/> class.
         /// </summary>
         /// <param name="val">Numeric value</param>
-        public BigIntCalculator (BigInteger val) : base (val) { }
+        public BigIntCalculator(BigInteger val) : base(val) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BigIntCalculator"/> class.
         /// </summary>
         /// <param name="data">byte stream representation of numeric value</param>
-        public BigIntCalculator (byte[] data) : base (new BigInteger (data)) { }
+        public BigIntCalculator(byte[] data) : base(new BigInteger(data)) { }
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="b"></param>
         /// <returns></returns>
-        public override bool GreaterThan (BigInteger b) => this.Value > b;
+        public override bool GreaterThan(BigInteger b) => this.Value > b;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="b"></param>
         /// <returns></returns>
-        public override bool LowerThan (BigInteger b) => this.Value < b;
+        public override bool LowerThan(BigInteger b) => this.Value < b;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="b"></param>
         /// <returns></returns>
-        public override bool EqualOrGreaterThan (BigInteger b) => this.Value >= b;
+        public override bool EqualOrGreaterThan(BigInteger b) => this.Value >= b;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="b"></param>
         /// <returns></returns>
-        public override bool EqualOrLowerThan (BigInteger b) => this.Value <= b;
+        public override bool EqualOrLowerThan(BigInteger b) => this.Value <= b;
 
         /// <summary>
         /// Adds the current <see cref="BigIntCalculator"/> instance with the <paramref name="right"/> 
@@ -63,65 +64,65 @@ namespace SecretSharingDotNet.Math
         /// <param name="right">Right value to add (right summand).</param>
         /// <returns>The sum of the current <see cref="BigIntCalculator"/> instance and the <paramref name="right"/> 
         /// <see cref="BigIntCalculator"/> instance.</returns>
-        public override Calculator<BigInteger> Add (BigInteger right) => this.Value + right;
+        public override Calculator<BigInteger> Add(BigInteger right) => this.Value + right;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="b"></param>
         /// <returns></returns>
-        public override Calculator<BigInteger> Subtract (BigInteger b) => this.Value - b;
+        public override Calculator<BigInteger> Subtract(BigInteger b) => this.Value - b;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="b"></param>
         /// <returns></returns>
-        public override Calculator<BigInteger> Multiply (BigInteger b) => this.Value * b;
+        public override Calculator<BigInteger> Multiply(BigInteger b) => this.Value * b;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="b"></param>
         /// <returns></returns>
-        public override Calculator<BigInteger> Division (BigInteger b) => this.Value / b;
+        public override Calculator<BigInteger> Division(BigInteger b) => this.Value / b;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="b"></param>
         /// <returns></returns>
-        public override Calculator<BigInteger> Modulo (BigInteger b) => this.Value % b;
+        public override Calculator<BigInteger> Modulo(BigInteger b) => this.Value % b;
 
         /// <summary>
         /// 
         /// </summary>
         /// <returns></returns>
-        public override Calculator<BigInteger> Increase () => ++this.Clone ().Value;
+        public override Calculator<BigInteger> Increase() => ++this.Clone().Value;
 
         /// <summary>
         /// 
         /// </summary>
         /// <returns></returns>
-        public override Calculator<BigInteger> Decrease () => --this.Clone ().Value;
+        public override Calculator<BigInteger> Decrease() => --this.Clone().Value;
 
         /// <summary>
         /// Returns the absolute value of the current <see cref="BigIntCalculator"> object.
         /// </summary>
         /// <returns></returns>
-        public override Calculator<BigInteger> Abs () => BigInteger.Abs (this.Value);
+        public override Calculator<BigInteger> Abs() => BigInteger.Abs(this.Value);
 
         /// <summary>
         /// Raises this <see cref="BigIntCalculator"> value to the power of a specified value.
         /// </summary>
         /// <param name="expo">The exponent to raise this <see cref="BigIntCalculator"> value by.</param>
         /// <returns></returns>
-        public override Calculator<BigInteger> Pow (int expo) => BigInteger.Pow (this.Value, expo);
+        public override Calculator<BigInteger> Pow(int expo) => BigInteger.Pow(this.Value, expo);
 
         /// <summary>
         /// Gets the number of elements of the byte representation of the <see cref="BigIntCalculator"/> object.
         /// </summary>
-        public override int ByteCount => this.Value.ToByteArray ().Length;
+        public override int ByteCount => this.Value.ToByteArray().Length;
 
         /// <summary>
         /// Gets the byte representation of the <see cref="BigIntCalculator"/> object.
@@ -142,7 +143,7 @@ namespace SecretSharingDotNet.Math
         /// Gets a value indicating whether or not the current <see cref="BigIntCalculator"> object is an even number.
         /// </summary>
         public override bool IsEven => this.Value % 2 == 0;
-        
+
         /// <summary>
         /// Gets a number that indicates the sign (negative, positive, or zero) of the current <see cref="BigIntCalculator"> object.
         /// </summary>
@@ -151,6 +152,30 @@ namespace SecretSharingDotNet.Math
         /// <summary>
         /// Returns the square root of the current <see cref="BigIntCalculator"> object.
         /// </summary>
-        public override double Sqrt => System.Math.Exp(BigInteger.Log(this.Value) / 2);
+        public override Calculator<BigInteger> Sqrt 
+        {
+            get 
+            {
+                if (this.Value == BigInteger.Zero)
+                {
+                    return Zero;
+                }
+
+                if (this.Value < BigInteger.Zero)
+                {
+                    throw new ArithmeticException("NaN");
+                }
+
+                int bitLength = Convert.ToInt32(Math.Ceiling(BigInteger.Log(this.Value, 2)));
+                BigInteger root = BigInteger.One << (bitLength >> 1);
+                bool isSqrt(BigInteger n, BigInteger r) => n >= r * r && n < (r + 1) * (r + 1);
+                while (!isSqrt(this.Value, root))
+                {
+                    root = (root + (this.Value / root)) >> 1;
+                }
+
+                return root;
+            }
+        }
     }
 }

--- a/src/Math/Calculator.cs
+++ b/src/Math/Calculator.cs
@@ -49,11 +49,6 @@ namespace SecretSharingDotNet.Math
         /// Gets a number that indicates the sign (negative, positive, or zero) of the current <see cref="Calculator"/> object.
         /// </summary>
         public abstract int Sign { get; }
-
-        /// <summary>
-        /// Returns the square root of the current <see cref="Calculator"/>.
-        /// </summary>
-        public abstract double Sqrt { get; }
     }
 
     /// <summary>
@@ -146,6 +141,11 @@ namespace SecretSharingDotNet.Math
         /// <param name="expo">The exponent.</param>
         /// <returns></returns>
         public abstract Calculator<TNumber> Pow (int expo);
+
+        /// <summary>
+        /// Returns the square root of the current <see cref="Calculator{TNumber}"/>.
+        /// </summary>
+        public abstract Calculator<TNumber> Sqrt { get; }
 
         /// <summary>
         /// 


### PR DESCRIPTION
In the past the **Sqrt** property of the `BigIntCalculator` class returns a `double` value which can be infinity while a `BigInteger` value reaches a certain size.
Therefor the return value of **Sqrt** is changed from double to `Calculator{TNumber}`.
It is also necessary to re-implement **Sqrt** algorithm for the `BigIntCalculator`.
The algorithm based on Heron's method.

Resolves: No entry