### PR TITLE
Fix - Expose security level

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,70 +8,134 @@ An C# implementation of Shamir's Secret Sharing.
 
 # Usage
 ## Basics
-Use the function `MakeShares` to generate the secret shares based on a random or pre-defined secret.
-Afterwards use the function `Reconstruction` to re-constructing the original secret
+Use the function `MakeShares` to generate the shares based on a random or pre-defined secret.
+Afterwards use the function `Reconstruction` to re-constructing the original secret.
+
+The length of shares based on the security level. It's possible to pre-define a security level by `ctor` or the `SecurityLevel` property. The pre-defined security level will be overriden if secret size is greater than the Mersenne prime which is calculated by means of security level. It is not necessary to define a security level for re-construction.
 
 ## Random Secret
-Here is an example:
+Create a random secret in conjunction with the generation of shares. The length of the generated shares and the secret based on the security level. Here is an example with a pre-defined security level of 127:
 ```csharp
-//// Create Shamir's Secret Sharing instance with BigInteger and
-//// security level 127 (Mersenne prime exponent)
-var sss = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 
-//// Minimum number of shared secrets for reconstruction: 3
-//// Maximum number of shared secrets: 7
-var x = sss.MakeShares (3, 7);
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Math;
 
-//// Item1 represents the random secret
-var secret = x.Item1;
+namespace Example1
+{
+  public class Program
+  {
+    public static void Main(string[] args)
+    {
+      var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
 
-//// Item 2 contains the shared secrets
-var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
-var recoveredSecret1 = sss.Reconstruction(subSet1.ToArray());
-var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
-var recoveredSecret2 = sss.Reconstruction(subSet2.ToArray());
+      //// Create Shamir's Secret Sharing instance with BigInteger
+      //// and security level 127 (Mersenne prime exponent)
+      var split = new ShamirsSecretSharing<BigInteger>(gcd, 127);
+
+      //// Minimum number of shared secrets for reconstruction: 3
+      //// Maximum number of shared secrets: 7
+      var x = split.MakeShares (3, 7);
+
+      //// Item1 represents the random secret
+      var secret = x.Item1;
+
+      //// Item 2 contains the shared secrets
+      var combine = new ShamirsSecretSharing<BigInteger>(gcd);
+      var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
+      var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
+      var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
+      var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
+    }
+  }
+}
 ```
 ## Pre-defined Secret: Text
-Here is an example:
+Use a text as secret which can be divided into shares. The length of the generated shares based on the security level.
+Here is an example with auto-detected security level:
 ```csharp
-//// Create Shamir's Secret Sharing instance with BigInteger and
-//// security level 127 (Mersenne prime exponent)
-var sss = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 
-string password = "Hello World!!";
-//// Minimum number of shared secrets for reconstruction: 3
-//// Maximum number of shared secrets: 7
-//// Attention: The password length changes the security level set by the ctor
-var x = sss.MakeShares (3, 7, password);
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Math;
 
-//// Item1 represents the password (original secret)
-var secret = x.Item1;
+namespace Example2
+{
+  public class Program
+  {
+    public static void Main(string[] args)
+    {
+      var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
 
-//// Item 2 contains the shared secrets
-var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
-var recoveredSecret1 = sss.Reconstruction(subSet1.ToArray());
-var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
-var recoveredSecret2 = sss.Reconstruction(subSet2.ToArray());
+      //// Create Shamir's Secret Sharing instance with BigInteger
+      var split = new ShamirsSecretSharing<BigInteger>(gcd);
+
+      string password = "Hello World!!";
+      //// Minimum number of shared secrets for reconstruction: 3
+      //// Maximum number of shared secrets: 7
+      //// Attention: The password length changes the security level set by the ctor
+      var x = split.MakeShares (3, 7, password);
+
+      //// Item1 represents the password (original secret)
+      var secret = x.Item1;
+
+      //// Item 2 contains the shared secrets
+      var combine = new ShamirsSecretSharing<BigInteger>(gcd);
+      var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
+      var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
+      var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
+      var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
+    }
+  }
+}
 ```
 
 ## Pre-defined Secret: Number
-Here is an example:
+Use an integer number as secret which can be divided into shares. The length of the generated shares based on the security level.
+Here is an example with a pre-defined security level of 521:
 ```csharp
-//// Create Shamir's Secret Sharing instance with BigInteger and
-//// security level 127 (Mersenne prime exponent)
-var sss = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 
-BigInteger number = 20000;
-//// Minimum number of shared secrets for reconstruction: 3
-//// Maximum number of shared secrets: 7
-var x = sss.MakeShares (3, 7, number);
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Math;
 
-//// Item1 represents the number (original secret)
-var secret = x.Item1;
+namespace Example3
+{
+  public class Program
+  {
+    public static void Main(string[] args)
+    {
+      var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
 
-//// Item 2 contains the shared secrets
-var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
-var recoveredSecret1 = sss.Reconstruction(subSet1.ToArray());
-var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
-var recoveredSecret2 = sss.Reconstruction(subSet2.ToArray());
+      //// Create Shamir's Secret Sharing instance with BigInteger
+      //// and security level 521 (Mersenne prime exponent)
+      var split = new ShamirsSecretSharing<BigInteger>(gcd, 521);
+
+      BigInteger number = 20000;
+      //// Minimum number of shared secrets for reconstruction: 3
+      //// Maximum number of shared secrets: 7
+      //// Attention: The number size changes the security level set by the ctor
+      var x = split.MakeShares (3, 7, number);
+
+      //// Item1 represents the number (original secret)
+      var secret = x.Item1;
+
+      //// Item 2 contains the shared secrets
+      var combine = new ShamirsSecretSharing<BigInteger>(gcd);
+      var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
+      var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
+      var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
+      var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
+    }
+  }
+}
 ```

--- a/src/Cryptography/FinitePoint.cs
+++ b/src/Cryptography/FinitePoint.cs
@@ -68,6 +68,17 @@ namespace SecretSharingDotNet.Cryptography
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="FinitePoint{TNumber}"/> struct.
+        /// </summary>
+        /// <param name="x">X coordinate</param>
+        /// <param name="y">Y coordinate</param>
+        private FinitePoint(Calculator<TNumber> x, Calculator<TNumber> y)
+        {
+            this.x = x;
+            this.y = y;
+        }
+
+        /// <summary>
         /// Gets the X coordinate
         /// </summary>
         public Calculator<TNumber> X => this.x;

--- a/src/Cryptography/FinitePoint.cs
+++ b/src/Cryptography/FinitePoint.cs
@@ -181,7 +181,7 @@ namespace SecretSharingDotNet.Cryptography
         /// Returns the string representation of the <see cref="FinitePoint{TNumber}"/> structure.
         /// </summary>
         /// <returns></returns>
-        public override string ToString () => string.Format (CultureInfo.InvariantCulture, "x={0}; y={1}", this.x, this.y);
+        public override string ToString() => string.Format(CultureInfo.InvariantCulture, "{0}-{1}", ToHexString(this.x.ByteRepresentation), ToHexString(this.y.ByteRepresentation));
 
         /// <summary>
         /// Evaluates polynomial (coefficient tuple) at x, used to generate a shamir pool.
@@ -215,6 +215,26 @@ namespace SecretSharingDotNet.Cryptography
 
             string[] s = share.Split(new char[] { '-' });
             return new FinitePoint<TNumber>(Calculator<TNumber>.Create(ToByteArray(s[0])), Calculator<TNumber>.Create(ToByteArray(s[1])));
+        }
+
+        /// <summary>
+        /// Converts a byte collection to hexadecimal string.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns>human readable / printable string</returns>
+        /// <remarks>
+        /// Based on discussion on <see href="https://stackoverflow.com/questions/623104/byte-to-hex-string/5919521#5919521">stackoverflow</see>
+        /// </remarks>
+        private static string ToHexString(ReadOnlyCollection<byte> bytes)
+        {
+            StringBuilder hexRepresentation = new StringBuilder(bytes.Count * 2);
+            foreach (byte b in bytes)
+            {
+                const string HexAlphabet = "0123456789ABCDEF";
+                hexRepresentation.Append(new char[] { HexAlphabet[(int)(b >> 4)], HexAlphabet[(int)(b & 0xF)] });
+            }
+
+            return hexRepresentation.ToString();
         }
 
         /// <summary>

--- a/src/Cryptography/FinitePoint.cs
+++ b/src/Cryptography/FinitePoint.cs
@@ -202,6 +202,22 @@ namespace SecretSharingDotNet.Cryptography
         }
 
         /// <summary>
+        /// Parses the string representation of the <see cref="FinitePoint{TNumber}"/> struct.
+        /// </summary>
+        /// <param name="share">string representation of the <see cref="FinitePoint{TNumber}"/> struct</param>
+        /// <returns>A <see cref="FinitePoint{TNumber}"/> structure representing the deserialization of <paramref name="share"/> string</returns>
+        public static FinitePoint<TNumber> Parse(string share)
+        {
+            if (string.IsNullOrWhiteSpace(share))
+            {
+                throw new ArgumentNullException(nameof(share));
+            }
+
+            string[] s = share.Split(new char[] { '-' });
+            return new FinitePoint<TNumber>(Calculator<TNumber>.Create(ToByteArray(s[0])), Calculator<TNumber>.Create(ToByteArray(s[1])));
+        }
+
+        /// <summary>
         /// Converts a hexadecimal string to a byte array.
         /// </summary>
         /// <param name="hextString">hexadecimal string</param>

--- a/src/Cryptography/FinitePoint.cs
+++ b/src/Cryptography/FinitePoint.cs
@@ -58,13 +58,13 @@ namespace SecretSharingDotNet.Cryptography
         /// <summary>
         /// Initializes a new instance of the <see cref="FinitePoint{TNumber}"/> struct.
         /// </summary>
-        /// <param name="x"></param>
-        /// <param name="polynomial"></param>
-        /// <param name="prime"></param>
-        public FinitePoint (Calculator<TNumber> x, ICollection<Calculator<TNumber>> polynomial, Calculator<TNumber> prime)
+        /// <param name="x">X coordinate as known as share index</param>
+        /// <param name="polynomial">Polynomial</param>
+        /// <param name="prime">The prime number given by the security level.</param>
+        public FinitePoint(Calculator<TNumber> x, ICollection<Calculator<TNumber>> polynomial, Calculator<TNumber> prime)
         {
-            this.x = x ?? throw new ArgumentNullException (nameof (x));
-            this.y = Evaluate (polynomial??throw new ArgumentNullException (nameof (polynomial)), this.x, prime??throw new ArgumentNullException (nameof (prime)));
+            this.x = x ?? throw new ArgumentNullException(nameof(x));
+            this.y = Evaluate(polynomial ?? throw new ArgumentNullException(nameof(polynomial)), this.x, prime ?? throw new ArgumentNullException(nameof(prime)));
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="left"></param>
         /// <param name="right"></param>
         /// <returns></returns>
-        public static bool operator == (FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.Equals (right);
+        public static bool operator ==(FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.Equals(right);
 
         /// <summary>
         /// 
@@ -91,7 +91,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="left"></param>
         /// <param name="right"></param>
         /// <returns></returns>
-        public static bool operator != (FinitePoint<TNumber> left, FinitePoint<TNumber> right) => !left.Equals (right);
+        public static bool operator !=(FinitePoint<TNumber> left, FinitePoint<TNumber> right) => !left.Equals(right);
 
         /// <summary>
         /// 
@@ -99,7 +99,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="left"></param>
         /// <param name="right"></param>
         /// <returns></returns>
-        public static bool operator > (FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.CompareTo (right) == 1;
+        public static bool operator >(FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.CompareTo(right) == 1;
 
         /// <summary>
         /// 
@@ -107,7 +107,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="left"></param>
         /// <param name="right"></param>
         /// <returns></returns>
-        public static bool operator < (FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.CompareTo (right) == -1;
+        public static bool operator <(FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.CompareTo(right) == -1;
 
         /// <summary>
         /// 
@@ -115,7 +115,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="left"></param>
         /// <param name="right"></param>
         /// <returns></returns>
-        public static bool operator >= (FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.CompareTo (right) >= 0;
+        public static bool operator >=(FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.CompareTo(right) >= 0;
 
         /// <summary>
         /// 
@@ -123,14 +123,15 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="left"></param>
         /// <param name="right"></param>
         /// <returns></returns>
-        public static bool operator <= (FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.CompareTo (right) <= 0;
+        public static bool operator <=(FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.CompareTo(right) <= 0;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="other"></param>
         /// <returns></returns>
-        public int CompareTo (FinitePoint<TNumber> other) {
+        public int CompareTo(FinitePoint<TNumber> other)
+        {
             return ((this.X * this.X + this.Y * this.Y).Sqrt - (other.X * other.X + other.Y * other.Y).Sqrt).Sign;
         }
 
@@ -139,9 +140,9 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="other"></param>
         /// <returns></returns>
-        public bool Equals (FinitePoint<TNumber> other)
+        public bool Equals(FinitePoint<TNumber> other)
         {
-            return this.X.Equals (other.X) && this.Y.Equals (other.Y);
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y);
         }
 
         /// <summary>
@@ -149,21 +150,21 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="obj"></param>
         /// <returns></returns>
-        public override bool Equals (object obj)
+        public override bool Equals(object obj)
         {
             if (obj == null)
             {
                 return false;
             }
 
-            return this.Equals ((FinitePoint<TNumber>) obj);
+            return this.Equals((FinitePoint<TNumber>)obj);
         }
 
         /// <summary>
         /// Returns the hash code for the current <see cref="FinitePoint{TNumber}"/> structure.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode () => this.X.GetHashCode () ^ this.y.GetHashCode ();
+        public override int GetHashCode() => this.X.GetHashCode() ^ this.y.GetHashCode();
 
         /// <summary>
         /// Returns the string representation of the <see cref="FinitePoint{TNumber}"/> structure.
@@ -178,10 +179,10 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="x"></param>
         /// <param name="prime">Mersenne prime greater or equal 5</param>
         /// <returns></returns>
-        private static Calculator<TNumber> Evaluate (ICollection<Calculator<TNumber>> polynomial, Calculator<TNumber> x, Calculator<TNumber> prime)
+        private static Calculator<TNumber> Evaluate(ICollection<Calculator<TNumber>> polynomial, Calculator<TNumber> x, Calculator<TNumber> prime)
         {
             Calculator<TNumber> accum = Calculator<TNumber>.Zero;
-            foreach (Calculator<TNumber> coeff in polynomial.Reverse<Calculator<TNumber>> ())
+            foreach (Calculator<TNumber> coeff in polynomial.Reverse<Calculator<TNumber>>())
             {
                 accum = (accum * x + coeff) % prime;
             }

--- a/src/Cryptography/FinitePoint.cs
+++ b/src/Cryptography/FinitePoint.cs
@@ -200,5 +200,48 @@ namespace SecretSharingDotNet.Cryptography
 
             return accum;
         }
+
+        /// <summary>
+        /// Converts a hexadecimal string to a byte array.
+        /// </summary>
+        /// <param name="hextString">hexadecimal string</param>
+        /// <returns></returns>
+        private static byte[] ToByteArray(string hextString)
+        {
+            byte[] bytes = new byte[hextString.Length / 2];
+            var hexValues = Array.AsReadOnly(new[] {
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05,
+                0x06,
+                0x07,
+                0x08,
+                0x09,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x0A,
+                0x0B,
+                0x0C,
+                0x0D,
+                0x0E,
+                0x0F
+            });
+
+            for (int x = 0, i = 0; i < hextString.Length; i += 2, x += 1)
+            {
+                const char ZeroDigit = '0';
+                bytes[x] = (byte)((hexValues[char.ToUpper(hextString[i + 0]) - ZeroDigit] << 4) | hexValues[char.ToUpper(hextString[i + 1]) - ZeroDigit]);
+            }
+
+            return bytes;
+        }
     }
 }

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -341,7 +341,15 @@ namespace SecretSharingDotNet.Cryptography
                 throw new ArgumentOutOfRangeException(nameof(shares));
             }
 
-            return this.LagrangeInterpolate (new List<FinitePoint<TNumber>> (shares), this.mersennePrime);
+            this.SecurityLevel = shares.Max().Y.ByteCount * 8;
+            int index = this.securityLevels.IndexOf(this.SecurityLevel);
+            while (((shares.Max().Y % this.mersennePrime) + this.mersennePrime) % this.mersennePrime == shares.Max().Y && index > 0 && this.SecurityLevel > 5)
+            {
+                this.SecurityLevel = this.securityLevels[--index];
+            }
+
+            this.SecurityLevel = this.securityLevels[this.SecurityLevel > 5 ? ++index : index];
+            return this.LagrangeInterpolate(new List<FinitePoint<TNumber>>(shares), this.mersennePrime);
         }
     }
 }

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -69,6 +69,20 @@ namespace SecretSharingDotNet.Cryptography
         /// Initializes a new instance of the <see cref="ShamirsSecretSharing"/> class.
         /// </summary>
         /// <param name="extendedGcd">Extended greatest common divisor algorithm</param>
+        public ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd)
+        {
+            if (extendedGcd == null)
+            {
+                throw new ArgumentNullException(nameof(extendedGcd));
+            }
+
+            this.extendedGcd = extendedGcd;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShamirsSecretSharing"/> class.
+        /// </summary>
+        /// <param name="extendedGcd">Extended greatest common divisor algorithm</param>
         /// <param name="securityLevel">Security level (in number of bits). Minimum is 5.</param>
         public ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd, int securityLevel)
         {

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -151,6 +151,11 @@ namespace SecretSharingDotNet.Cryptography
                 throw new ArgumentOutOfRangeException("The pool secret would be irrecoverable.");
             }
 
+            if (this.mersennePrime == null)
+            {
+                throw new InvalidOperationException("Security Level is not initialized!");
+            }
+
             var polynomial = CreatePolynomial(min);
             var points = CreateSharedSecrets(shrs, polynomial);
 
@@ -184,7 +189,12 @@ namespace SecretSharingDotNet.Cryptography
                 throw new ArgumentOutOfRangeException("The pool secret would be irrecoverable.");
             }
 
-            this.SecurityLevel = secret.ToString().Length * sizeof(char) * 8;
+            int securityLevel = secret.ToString().Length * sizeof(char) * 8;
+            if (this.SecurityLevel < securityLevel)
+            {
+                this.SecurityLevel = securityLevel;
+            }
+
             var polynomial = CreatePolynomial(min);
             polynomial[0] = secret;
             var points = CreateSharedSecrets(shrs, polynomial);

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -184,8 +184,8 @@ namespace SecretSharingDotNet.Cryptography
                 throw new ArgumentOutOfRangeException("The pool secret would be irrecoverable.");
             }
 
-            var polynomial = CreatePolynomial(min);
             this.SecurityLevel = secret.ToString().Length * sizeof(char) * 8;
+            var polynomial = CreatePolynomial(min);
             polynomial[0] = secret;
             var points = CreateSharedSecrets(shrs, polynomial);
 

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -48,8 +48,8 @@ namespace SecretSharingDotNet.Cryptography
         /// <summary>
         /// Saves the known security levels (Mersenne prime exponents)
         /// </summary>
-        private readonly List<int> securityLevels = new List<int> (new int[] { 5, 7, 13, 17, 19, 31, 61, 89, 107, 127, 521, 607, 1279, 2203, 2281, 3217 });
-        
+        private readonly List<int> securityLevels = new List<int>(new int[] { 5, 7, 13, 17, 19, 31, 61, 89, 107, 127, 521, 607, 1279, 2203, 2281, 3217 });
+
         /// <summary>
         /// Saves the security level
         /// </summary>
@@ -70,11 +70,11 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="extendedGcd">Extended greatest common divisor algorithm</param>
         /// <param name="securityLevel">Security level (in number of bits). Minimum is 5.</param>
-        public ShamirsSecretSharing (IExtendedGcdAlgorithm<TNumber> extendedGcd, int securityLevel)
+        public ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd, int securityLevel)
         {
             if (extendedGcd == null)
             {
-                throw new ArgumentNullException (nameof (extendedGcd));
+                throw new ArgumentNullException(nameof(extendedGcd));
             }
 
             this.extendedGcd = extendedGcd;
@@ -84,7 +84,7 @@ namespace SecretSharingDotNet.Cryptography
             }
             catch (ArgumentOutOfRangeException e)
             {
-                throw new ArgumentOutOfRangeException (nameof (securityLevel), securityLevel, e.Message);
+                throw new ArgumentOutOfRangeException(nameof(securityLevel), securityLevel, e.Message);
             }
         }
 
@@ -102,30 +102,30 @@ namespace SecretSharingDotNet.Cryptography
             {
                 if (value < 5)
                 {
-                    throw new ArgumentOutOfRangeException (nameof (value), value, "Minimum exceeded!");
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "Minimum exceeded!");
                 }
 
-                int index = this.securityLevels.BinarySearch (value);
+                int index = this.securityLevels.BinarySearch(value);
                 if (index < 0)
                 {
                     try
                     {
-                        value = this.securityLevels.ElementAt (~index);
+                        value = this.securityLevels.ElementAt(~index);
                     }
                     catch (ArgumentOutOfRangeException)
                     {
-                        throw new ArgumentOutOfRangeException (nameof (value), value, "Maximum exceeded!");
+                        throw new ArgumentOutOfRangeException(nameof(value), value, "Maximum exceeded!");
                     }
                 }
 
                 try
                 {
-                    this.mersennePrime = Calculator<TNumber>.Two.Pow (value) - Calculator<TNumber>.One;
+                    this.mersennePrime = Calculator<TNumber>.Two.Pow(value) - Calculator<TNumber>.One;
                     this.securityLevel = value;
                 }
                 catch (NotSupportedException e)
                 {
-                    Console.WriteLine (e);
+                    Console.WriteLine(e);
                     throw;
                 }
             }
@@ -137,24 +137,24 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
         /// <param name="numberOfShares">Maximum number of shared secrets</param>
         /// <returns></returns>
-        public Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>> MakeShares (TNumber numberOfMinimumShares, TNumber numberOfShares)
+        public Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares)
         {
             Calculator<TNumber> min = numberOfMinimumShares;
             Calculator<TNumber> shrs = numberOfShares;
             if (min < Calculator<TNumber>.Two)
             {
-                throw new ArgumentOutOfRangeException (nameof (numberOfMinimumShares));
+                throw new ArgumentOutOfRangeException(nameof(numberOfMinimumShares));
             }
 
             if (min > shrs)
             {
-                throw new ArgumentOutOfRangeException ("The pool secret would be irrecoverable.");
+                throw new ArgumentOutOfRangeException("The pool secret would be irrecoverable.");
             }
 
-            var polynomial = CreatePolynomial (min);
-            var points = CreateSharedSecrets (shrs, polynomial);
+            var polynomial = CreatePolynomial(min);
+            var points = CreateSharedSecrets(shrs, polynomial);
 
-            return new Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>> (polynomial[0], points);
+            return new Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>>(polynomial[0], points);
         }
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="secret">secret text as <see cref="Secret{TNumber}"/> or see cref="string"/></param>
         /// <returns></returns>
         /// <remarks>This method modifies the <see cref="SecurityLevel"/> based on the <paramref name="secret"/> length</remarks>
-        public Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>> MakeShares (TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret)
+        public Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret)
         {
             if (ReferenceEquals(secret, null))
             {
@@ -176,20 +176,20 @@ namespace SecretSharingDotNet.Cryptography
             Calculator<TNumber> shrs = numberOfShares;
             if (min < Calculator<TNumber>.Two)
             {
-                throw new ArgumentOutOfRangeException (nameof (numberOfMinimumShares));
+                throw new ArgumentOutOfRangeException(nameof(numberOfMinimumShares));
             }
 
             if (min > shrs)
             {
-                throw new ArgumentOutOfRangeException ("The pool secret would be irrecoverable.");
+                throw new ArgumentOutOfRangeException("The pool secret would be irrecoverable.");
             }
 
-            var polynomial = CreatePolynomial (min);
-            this.SecurityLevel = secret.ToString ().Length * sizeof (char) * 8;
+            var polynomial = CreatePolynomial(min);
+            this.SecurityLevel = secret.ToString().Length * sizeof(char) * 8;
             polynomial[0] = secret;
-            var points = CreateSharedSecrets (shrs, polynomial);
+            var points = CreateSharedSecrets(shrs, polynomial);
 
-            return new Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>> (polynomial[0], points);
+            return new Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>>(polynomial[0], points);
         }
 
         /// <summary>
@@ -197,16 +197,16 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
         /// <returns></returns>
-        private List<Calculator<TNumber>> CreatePolynomial (Calculator<TNumber> numberOfMinimumShares)
+        private List<Calculator<TNumber>> CreatePolynomial(Calculator<TNumber> numberOfMinimumShares)
         {
-            var polynomial = new List<Calculator<TNumber>> (); /// pre-init
+            var polynomial = new List<Calculator<TNumber>>(); /// pre-init
             var randomNumber = new byte[this.mersennePrime.ByteCount];
-            using (RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider ())
+            using (RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider())
             {
                 for (var i = Calculator<TNumber>.Zero; i < numberOfMinimumShares; i++)
                 {
-                    rngCsp.GetBytes (randomNumber);
-                    polynomial.Add (Calculator<TNumber>.Create (randomNumber).Abs () % this.mersennePrime);
+                    rngCsp.GetBytes(randomNumber);
+                    polynomial.Add(Calculator<TNumber>.Create(randomNumber).Abs() % this.mersennePrime);
                 }
             }
 
@@ -219,12 +219,12 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="numberOfShares">Maximum number of shared secrets</param>
         /// <param name="polynomial"></param>
         /// <returns>A list of finite points representing the shared secrets</returns>
-        private List<FinitePoint<TNumber>> CreateSharedSecrets (Calculator<TNumber> numberOfShares, List<Calculator<TNumber>> polynomial)
+        private List<FinitePoint<TNumber>> CreateSharedSecrets(Calculator<TNumber> numberOfShares, List<Calculator<TNumber>> polynomial)
         {
-            var points = new List<FinitePoint<TNumber>> (); /// pre-init
+            var points = new List<FinitePoint<TNumber>>(); /// pre-init
             for (var i = Calculator<TNumber>.One; i < (numberOfShares + Calculator<TNumber>.One); i++)
             {
-                points.Add (new FinitePoint<TNumber> (i, polynomial, this.mersennePrime));
+                points.Add(new FinitePoint<TNumber>(i, polynomial, this.mersennePrime));
             }
 
             return points;
@@ -240,12 +240,12 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="denominator"></param>
         /// <param name="prime"></param>
         /// <returns></returns>
-        private Calculator<TNumber> DivMod (
+        private Calculator<TNumber> DivMod(
             Calculator<TNumber> numerator,
             Calculator<TNumber> denominator,
             Calculator<TNumber> prime)
         {
-            var result = this.extendedGcd.Compute (denominator, prime);
+            var result = this.extendedGcd.Compute(denominator, prime);
             return numerator * result.BezoutCoefficients[0] * result.GreatestCommonDivisor;
         }
 
@@ -255,7 +255,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="values"></param>
         /// <returns></returns>
         /// <remarks>Helper method for LagrangeInterpolate</remarks>
-        private static Calculator<TNumber> Product (IEnumerable<Calculator<TNumber>> values)
+        private static Calculator<TNumber> Product(IEnumerable<Calculator<TNumber>> values)
         {
             var accum = Calculator<TNumber>.One;
             foreach (var v in values)
@@ -274,45 +274,45 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="prime">A prime number must be defined to avoid computation with real numbers. In fact it is finite field arithmetic.
         /// The prime number must be the same as used for the construction of shares.</param>
         /// <returns>The re-constructed secret.</returns>
-        private Calculator<TNumber> LagrangeInterpolate (List<FinitePoint<TNumber>> finitePoints, Calculator<TNumber> prime)
+        private Calculator<TNumber> LagrangeInterpolate(List<FinitePoint<TNumber>> finitePoints, Calculator<TNumber> prime)
         {
-            if (finitePoints.Distinct ().Count () != finitePoints.Count)
+            if (finitePoints.Distinct().Count() != finitePoints.Count)
             {
-                throw new ArgumentException (nameof (finitePoints));
+                throw new ArgumentException(nameof(finitePoints));
             }
 
             int k = finitePoints.Count;
-            var numerators = new List<Calculator<TNumber>> (k - 1);
-            var denominators = new List<Calculator<TNumber>> (k - 1);
+            var numerators = new List<Calculator<TNumber>>(k - 1);
+            var denominators = new List<Calculator<TNumber>>(k - 1);
             for (int i = 0; i < k; i++)
             {
-                var others = new List<FinitePoint<TNumber>> (finitePoints.ToArray ());
+                var others = new List<FinitePoint<TNumber>>(finitePoints.ToArray());
                 var current = others[i];
-                others.RemoveAt (i);
-                var numTask = Task<Calculator<TNumber>>.Run (() =>
+                others.RemoveAt(i);
+                var numTask = Task<Calculator<TNumber>>.Run(() =>
                 {
-                    return Product (others.AsParallel ().Select (o => { return Calculator<TNumber>.Zero - o.X; }).ToList ());
+                    return Product(others.AsParallel().Select(o => { return Calculator<TNumber>.Zero - o.X; }).ToList());
                 });
 
-                var denTask = Task<Calculator<TNumber>>.Run (() =>
+                var denTask = Task<Calculator<TNumber>>.Run(() =>
                 {
-                    return Product (others.AsParallel ().Select (o => { return current.X - o.X; }).ToList ());
+                    return Product(others.AsParallel().Select(o => { return current.X - o.X; }).ToList());
                 });
 
-                numerators.Add (numTask.Result);
-                denominators.Add (denTask.Result);
+                numerators.Add(numTask.Result);
+                denominators.Add(denTask.Result);
             }
 
             var numerator = Calculator<TNumber>.Zero;
-            var denominator = Product (denominators);
+            var denominator = Product(denominators);
 
-            object sync = new object ();
-            var rangePartitioner = Partitioner.Create (0, k);
-            Parallel.ForEach (rangePartitioner, (range, loopState) =>
+            object sync = new object();
+            var rangePartitioner = Partitioner.Create(0, k);
+            Parallel.ForEach(rangePartitioner, (range, loopState) =>
             {
                 for (int i = range.Item1; i < range.Item2; i++)
                 {
-                    var result = this.DivMod (numerators[i] * denominator * (((finitePoints[i].Y % prime) + prime) % prime), denominators[i], prime);
+                    var result = this.DivMod(numerators[i] * denominator * (((finitePoints[i].Y % prime) + prime) % prime), denominators[i], prime);
                     lock (sync)
                     {
                         numerator += result;
@@ -320,7 +320,7 @@ namespace SecretSharingDotNet.Cryptography
                 }
             });
 
-            var a = this.DivMod (numerator, denominator, prime) + prime;
+            var a = this.DivMod(numerator, denominator, prime) + prime;
             return ((a % prime) + prime) % prime; /// mathematical modulo
         }
 
@@ -329,16 +329,16 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="shares">two or more shares</param>
         /// <returns>Re-constructed secret</returns>
-        public Secret<TNumber> Reconstruction (params FinitePoint<TNumber>[] shares)
+        public Secret<TNumber> Reconstruction(params FinitePoint<TNumber>[] shares)
         {
             if (shares == null)
             {
-                throw new ArgumentNullException (nameof (shares));
+                throw new ArgumentNullException(nameof(shares));
             }
 
             if (shares.Length < 2)
             {
-                throw new ArgumentOutOfRangeException (nameof (shares));
+                throw new ArgumentOutOfRangeException(nameof(shares));
             }
 
             return this.LagrangeInterpolate (new List<FinitePoint<TNumber>> (shares), this.mersennePrime);

--- a/tests/FinitePointTest.cs
+++ b/tests/FinitePointTest.cs
@@ -1,0 +1,55 @@
+// ----------------------------------------------------------------------------
+// <copyright file="FinitePointTest.cs" company="Private">
+// Copyright (c) 2019 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>04/20/2019 10:52:28 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2019 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Test
+{
+    using System.Linq;
+    using System.Numerics;
+    using Cryptography;
+    using Math;
+    using Xunit;
+
+    public class FinitePointTest
+    {
+        /// <summary>
+        /// Check <see cref="FinitePoint{TNumber}"/> to <see cref="System.String"/> convertion conversion and vice vera.
+        /// </summary>
+        [Fact]
+        public void FinitePointSting()
+        {
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 500);
+            FinitePoint<BigInteger> fp = split.MakeShares(3, 7).Item2.First();
+            string s1 = fp.ToString();
+            string s2 = FinitePoint<BigInteger>.Parse(s1).ToString();
+            Assert.Equal(s1, s2);
+        }
+    }
+}

--- a/tests/SecretSharingDotNetFx4.5.2Test.csproj
+++ b/tests/SecretSharingDotNetFx4.5.2Test.csproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <Compile Include="ExtendedEuclideanAlgorithmTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="FinitePointTest.cs" />
     <Compile Include="SecretTest.cs" />
     <Compile Include="ShamirsSecretSharingTest.cs" />
   </ItemGroup>

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -277,5 +277,16 @@ namespace SecretSharingDotNet.Test
             var subSet1 = x.Item2.Where (p => p.X == Calculator<BigInteger>.One).ToList ();
             Assert.Throws<ArgumentOutOfRangeException>(() => sss.Reconstruction(subSet1.ToArray()));
         }
+
+        /// <summary>
+        /// Tests whether or not the <see cref="InvalidOperationException"/> is thrown if the security level
+        /// is not initialized.
+        /// </summary>
+        [Fact]
+        public void TestUninitializedSecurityLevel()
+        {
+            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            Assert.Throws<InvalidOperationException>(() => sss.MakeShares(2, 7));
+        }
     }
 }

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -31,14 +31,12 @@
 
 namespace SecretSharingDotNet.Test
 {
+    using Cryptography;
+    using Math;
     using System;
     using System.Linq;
     using System.Numerics;
-    using System.Reflection;
     using Xunit;
-
-    using Cryptography;
-    using Math;
 
     public class ShamirsSecretSharingTest
     {
@@ -69,15 +67,18 @@ namespace SecretSharingDotNet.Test
         public void TestPassword()
         {
             string password = "Hello World!!";
-            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
-            var x = sss.MakeShares (3, 7, password);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
+            split.SecurityLevel = 256;
+            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 32);
+            var x = split.MakeShares (3, 7, password);
             var secret = x.Item1;
             var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
-            var recoveredSecret1 = sss.Reconstruction(subSet1.ToArray());
+            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
             var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
-            var recoveredSecret2 = sss.Reconstruction(subSet2.ToArray());
+            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
             Assert.Equal(secret, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret2);
+            Assert.Equal(521, split.SecurityLevel);
         }
 
         /// <summary>
@@ -87,15 +88,17 @@ namespace SecretSharingDotNet.Test
         public void TestNumber()
         {
             BigInteger number = 20000;
-            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
-            var x = sss.MakeShares (3, 7, number);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
+            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 32);
+            var x = split.MakeShares (3, 7, number);
             var secret = x.Item1;
             var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
-            var recoveredSecret1 = sss.Reconstruction(subSet1.ToArray());
+            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
             var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
-            var recoveredSecret2 = sss.Reconstruction(subSet2.ToArray());
+            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
             Assert.Equal(secret, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret2);
+            Assert.Equal(17, split.SecurityLevel);
         }
 
         /// <summary>
@@ -104,15 +107,17 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void TestRandomSecretWithSecruityLevel127()
         {
-            var sss = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
-            var x = sss.MakeShares (3, 7);
+            var split = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
+            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 32);
+            var x = split.MakeShares (3, 7);
             var secret = x.Item1;
             var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
-            var recoveredSecret1 = sss.Reconstruction(subSet1.ToArray());
+            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
             var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
-            var recoveredSecret2 = sss.Reconstruction(subSet2.ToArray());
+            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
             Assert.Equal(secret, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret2);
+            Assert.Equal(127, split.SecurityLevel);
         }
 
         /// <summary>
@@ -121,15 +126,17 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void TestRandomSecretWithSecruityLevel5 ()
         {
-            var sss = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 5);
-            var x = sss.MakeShares (2, 7);
+            var split = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 5);
+            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 32);
+            var x = split.MakeShares (2, 7);
             var secret = x.Item1;
             var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
-            var recoveredSecret1 = sss.Reconstruction(subSet1.ToArray());
+            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
             var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
-            var recoveredSecret2 = sss.Reconstruction(subSet2.ToArray());
+            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
             Assert.Equal(secret, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret2);
+            Assert.Equal(5, split.SecurityLevel);
         }
 
         /// <summary>
@@ -140,15 +147,17 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void TestRandomSecretWithSecruityLevel130 ()
         {
-            var sss = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 130);
-            var x = sss.MakeShares (3, 7);
+            var split = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 130);
+            var combine = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 5);
+            var x = split.MakeShares (3, 7);
             var secret = x.Item1;
             var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
-            var recoveredSecret1 = sss.Reconstruction(subSet1.ToArray());
+            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
             var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
-            var recoveredSecret2 = sss.Reconstruction(subSet2.ToArray());
+            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
             Assert.Equal(secret, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret2);
+            Assert.Equal(521, split.SecurityLevel);
         }
 
         /// <summary>
@@ -159,15 +168,38 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void TestRandomSecretWithSecruityLevel500 ()
         {
-            var sss = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 500);
-            var x = sss.MakeShares (3, 7);
+            var split = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 500);
+            var combine = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 5);
+            var x = split.MakeShares (3, 7);
             var secret = x.Item1;
             var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
-            var recoveredSecret1 = sss.Reconstruction(subSet1.ToArray());
+            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
             var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
-            var recoveredSecret2 = sss.Reconstruction(subSet2.ToArray());
+            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
             Assert.Equal(secret, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret2);
+            Assert.Equal(521, split.SecurityLevel);
+        }
+        
+        /// <summary>
+        /// Tests <see cref="ShamirsSecretSharing{TNumber}"/> with random <see cref="BigInteger"/> value as secret and security level 1024
+        /// which is not a Mersenne prime exponent. Next Mersenne prime exponent is 1279. The ctor of <see cref="ShamirsSecretSharing{TNumber}"/>
+        /// must find 1279 as the next Mersenne prime exponent of 1024
+        /// </summary>
+        [Fact]
+        public void TestRandomSecretWithSecruityLevel1279 ()
+        {
+            var split = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 1024);
+            var combine = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 5);
+            var x = split.MakeShares (2, 7);
+            var secret = x.Item1;
+            var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
+            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
+            var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
+            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
+            Assert.Equal(secret, recoveredSecret1);
+            Assert.Equal(secret, recoveredSecret2);
+            Assert.Equal(1279, split.SecurityLevel);
         }
 
         /// <summary>

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -71,43 +71,84 @@ namespace SecretSharingDotNet.Test
         }
 
         /// <summary>
-        /// Tests <see cref="ShamirsSecretSharing{TNumber}"/> with <see cref="string"/> as secret
+        /// Tests <see cref="ShamirsSecretSharing{TNumber}"/> with <see cref="string"/> as secret.
+        /// (Minimum security level is auto detected)
         /// </summary>
         [Fact]
-        public void TestPassword()
+        public void TestPasswordWithSecurityLevelAutoDetected()
         {
-            string password = "Hello World!!";
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
-            split.SecurityLevel = 256;
-            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 32);
-            var x = split.MakeShares (3, 7, password);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var x = split.MakeShares(3, 7, TestPassword);
             var secret = x.Item1;
-            var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
+            var subSet1 = x.Item2.Where(p => p.X.IsEven).ToList();
             var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
-            var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
+            var subSet2 = x.Item2.Where(p => !p.X.IsEven).ToList();
             var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
-            Assert.Equal(password, recoveredSecret1);
+            Assert.Equal(TestPassword, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret2);
             Assert.Equal(521, split.SecurityLevel);
         }
 
         /// <summary>
-        /// Tests <see cref="ShamirsSecretSharing{TNumber}"/> with <see cref="BigInteger"/> as secret
+        /// Tests <see cref="ShamirsSecretSharing{TNumber}"/> with <see cref="string"/> as secret.
+        /// (Secrutiy level is pre-defined)
         /// </summary>
         [Fact]
-        public void TestNumber()
+        public void TestPasswordWithSecurityLevel1279()
         {
-            BigInteger number = 20000;
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 127);
-            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger> (), 32);
-            var x = split.MakeShares (3, 7, number);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 1279);
+            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var x = split.MakeShares(3, 7, TestPassword);
             var secret = x.Item1;
-            var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
+            var subSet1 = x.Item2.Where(p => p.X.IsEven).ToList();
             var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
-            var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
+            var subSet2 = x.Item2.Where(p => !p.X.IsEven).ToList();
             var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
-            Assert.Equal(number, (BigInteger)recoveredSecret1);
+            Assert.Equal(TestPassword, recoveredSecret1);
+            Assert.Equal(secret, recoveredSecret1);
+            Assert.Equal(secret, recoveredSecret2);
+            Assert.Equal(1279, split.SecurityLevel);
+        }
+
+        /// <summary>
+        /// Tests <see cref="ShamirsSecretSharing{TNumber}"/> with <see cref="BigInteger"/> as secret.
+        /// (Minimum security level is auto detected)
+        /// </summary>
+        [Fact]
+        public void TestNumberWithSecurityLevelAutoDetected()
+        {
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var x = split.MakeShares(3, 7, TestNumber);
+            var secret = x.Item1;
+            var subSet1 = x.Item2.Where(p => p.X.IsEven).ToList();
+            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
+            var subSet2 = x.Item2.Where(p => !p.X.IsEven).ToList();
+            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
+            Assert.Equal(TestNumber, (BigInteger)recoveredSecret1);
+            Assert.Equal(secret, recoveredSecret1);
+            Assert.Equal(secret, recoveredSecret2);
+            Assert.Equal(17, split.SecurityLevel);
+        }
+
+        /// <summary>
+        /// Tests <see cref="ShamirsSecretSharing{TNumber}"/> with <see cref="BigInteger"/> as secret.
+        /// (Secrutiy level is pre-defined)
+        /// </summary>
+        [Fact]
+        public void TestNumberWithSecurityLevell1279()
+        {
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var x = split.MakeShares(3, 7, TestNumber);
+            var secret = x.Item1;
+            var subSet1 = x.Item2.Where(p => p.X.IsEven).ToList();
+            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
+            var subSet2 = x.Item2.Where(p => !p.X.IsEven).ToList();
+            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
+            Assert.Equal(TestNumber, (BigInteger)recoveredSecret1);
             Assert.Equal(secret, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret2);
             Assert.Equal(17, split.SecurityLevel);

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -76,6 +76,7 @@ namespace SecretSharingDotNet.Test
             var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
             var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
             var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
+            Assert.Equal(password, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret2);
             Assert.Equal(521, split.SecurityLevel);

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -41,6 +41,11 @@ namespace SecretSharingDotNet.Test
     public class ShamirsSecretSharingTest
     {
         /// <summary>
+        /// A test password as secret.
+        /// </summary>
+        public const string TestPassword = "Hello World!!";
+
+        /// <summary>
         /// Checks the following condition: denominator * DivMod(numerator, denominator, prime) % prime == numerator
         /// ToDo: Find another technical solution for this test. Code redundancy.
         /// </summary>

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -97,6 +97,7 @@ namespace SecretSharingDotNet.Test
             var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
             var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
             var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
+            Assert.Equal(number, (BigInteger)recoveredSecret1);
             Assert.Equal(secret, recoveredSecret1);
             Assert.Equal(secret, recoveredSecret2);
             Assert.Equal(17, split.SecurityLevel);

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -46,6 +46,11 @@ namespace SecretSharingDotNet.Test
         public const string TestPassword = "Hello World!!";
 
         /// <summary>
+        /// A test number as secret.
+        /// </summary>
+        public readonly BigInteger TestNumber = 20000;
+
+        /// <summary>
         /// Checks the following condition: denominator * DivMod(numerator, denominator, prime) % prime == numerator
         /// ToDo: Find another technical solution for this test. Code redundancy.
         /// </summary>


### PR DESCRIPTION
Now two independent SecretSharingDotNet instances can be used to split a secret and to combine shares to re-construct the secret.