### PR TITLE
Feature - .NET Core 2.1 LTS Support

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,8 +12,8 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.108
+        dotnet-version: 2.1.802
     - name: Build with dotnet
-      run: dotnet build --configuration Release SecretSharingDotNetCore2.2.sln
+      run: dotnet build --configuration Release SecretSharingDotNetCore2.1.sln
     - name: Test with donet
-      run: dotnet test -v d --configuration Release SecretSharingDotNetCore2.2.sln
+      run: dotnet test -v d --configuration Release SecretSharingDotNetCore2.1.sln

--- a/SecretSharingDotNetCore2.1.sln
+++ b/SecretSharingDotNetCore2.1.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNet", "src\SecretSharingDotNetCore2.2.csproj", "{EF113114-267C-4CA0-B22A-62A326FF73B2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNet", "src\SecretSharingDotNetCore2.1.csproj", "{EF113114-267C-4CA0-B22A-62A326FF73B2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNetTest", "tests\SecretSharingDotNetCore2.2Test.csproj", "{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNetTest", "tests\SecretSharingDotNetCore2.1Test.csproj", "{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/SecretSharingDotNetCore2.1.csproj
+++ b/src/SecretSharingDotNetCore2.1.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SecretSharingDotNetCore</AssemblyName>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyOriginatorKeyFile>SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tests/SecretSharingDotNetCore2.1Test.csproj
+++ b/tests/SecretSharingDotNetCore2.1Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyOriginatorKeyFile>..\src\SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <IsPackable>false</IsPackable>
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\SecretSharingDotNetCore2.2.csproj" />
+    <ProjectReference Include="..\src\SecretSharingDotNetCore2.1.csproj" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Don't ride a dead horse:

1. Change to: .NET Core 2.1 (LTS version 2021-08-21 EoS)
2. From: .NET Core 2.2. (EOL/has expired since 2019-12-23)