### PR TITLE
Fix - Maximum exceeded! (Parameter 'value') Actual value was 10912

### DIFF
--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -48,7 +48,12 @@ namespace SecretSharingDotNet.Cryptography
         /// <summary>
         /// Saves the known security levels (Mersenne prime exponents)
         /// </summary>
-        private readonly List<int> securityLevels = new List<int>(new int[] { 5, 7, 13, 17, 19, 31, 61, 89, 107, 127, 521, 607, 1279, 2203, 2281, 3217 });
+        private readonly List<int> securityLevels = new List<int>(new int[]
+        {
+            5, 7, 13, 17, 19, 31, 61, 89, 107, 127, 521, 607, 1279, 2203, 2281, 3217, 4253, 4423, 9689, 9941, 11213,
+            19937, 21701, 23209, 44497, 86243, 110503, 132049, 216091, 756839, 859433, 1257787, 1398269, 2976221,
+            3021377, 6972593, 13466917, 20996011, 24036583, 25964951, 30402457, 32582657, 37156667, 42643801, 43112609
+        });
 
         /// <summary>
         /// Saves the security level

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -288,5 +288,23 @@ namespace SecretSharingDotNet.Test
             var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
             Assert.Throws<InvalidOperationException>(() => sss.MakeShares(2, 7));
         }
+
+        /// <summary>
+        /// Tests whether or not bug #40 occurs [Maximum exceeded! (Parameter 'value') Actual value was 10912." #40].
+        /// </summary>
+        [Fact]
+        public void MaximumExceeded()
+        {
+            string longSecret = "-----BEGIN EC PRIVATE KEY-----MIIBUQIBAQQgxq7AWG9L6uleuTB9q5FGqnHjXF+kD4y9154SLYYKMDqggeMwgeACAQEwLAYHKoZIzj0BAQIhAP////////////////////////////////////7///wvMEQEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwRBBHm+Zn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW+BeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////+uq7c5q9IoDu/0l6M0DZBQQIBAaFEA0IABE0XO6I8lZYzXqRQnHP/knSwLex7q77g4J2AN0cVyrADicGlUr6QjVIlIu9NXCHxD2i++ToWjO1zLVdxgNJbUUc=-----END EC PRIVATE KEY-----";
+            var split = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 1024);
+            var combine = new ShamirsSecretSharing<BigInteger> (new ExtendedEuclideanAlgorithm<BigInteger> (), 5);
+            var x = split.MakeShares (3, 7, longSecret);
+            var subSet1 = x.Item2.Where (p => p.X.IsEven).ToList ();
+            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
+            var subSet2 = x.Item2.Where (p => !p.X.IsEven).ToList ();
+            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
+            Assert.Equal(longSecret, recoveredSecret1);
+            Assert.Equal(longSecret, recoveredSecret2);
+        }
     }
 }


### PR DESCRIPTION
The security level list was extended to fix this issue. The password length is limited by the highest mersenne prime (Currently number 47: 3,112,609). 