### PR TITLE
.gitignore: Add .directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 *.suo
 *.user
 
+# Ignore directory meta info as created by KDE
+.directory


### PR DESCRIPTION
Ignores .directory files which are created by KDE.

Resolves: No entry