### PR TITLE
Fix - Add missing traget framework in SecretSharingDotNetTest.csproj

### DIFF
--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\src\SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Add .NET 5 as target framework in SecretSharingDotNetTest.csproj.

Resolves: No entry