### PR TITLE
Feature - Extends .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@
 # Ignore directory meta info as created by KDE
 .directory
 
+# Ignore JetBrains Rider / IntelliJ IDEA meta info
+.idea
+
 # Ignore swap files
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # Ignore directory meta info as created by KDE
 .directory
+
+# Ignore swap files
+*.swp


### PR DESCRIPTION
- Add .idea files  to the list of ignored files. The .idea files are generated by JetBrains Rider and IntelliJ IDEA.
- Add .swp files to the list of ignored files. The .swp files are created by Vi/Vim/gVIM for recovery reasons.
    
