### PR TITLE
Fix - Native crash during unit testing

### DIFF
--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -20,21 +20,21 @@ jobs:
     - name: Setup .NET Core 2.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.1.802
+        dotnet-version: 2.1.816
 
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.201
+        dotnet-version: 3.1.410
 
     - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100
+        dotnet-version: 5.0.301
 
     - name: .NET Core SxS
       run: |
-        rsync -a ${DOTNET_ROOT/5.0.100/3.1.201/2.1.802}/* $DOTNET_ROOT/
+        rsync -a ${DOTNET_ROOT/5.0.301/3.1.410/2.1.816}/* $DOTNET_ROOT/
 
     - name: Restore
       run: dotnet restore SecretSharingDotNet.sln

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -13,7 +13,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
     - uses: actions/checkout@v1
 

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: [ '2.1.802', '3.1.100', '5.0.100']
+        dotnet: [ '2.1.816', '3.1.410', '5.0.301']
     name: Dotnet ${{ matrix.dotnet }}
 
     steps:
@@ -25,20 +25,20 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Build with dotnet SDK v2.1
-      if: matrix.dotnet == '2.1.802'
+      if: matrix.dotnet == '2.1.816'
       run: dotnet build --configuration Release SecretSharingDotNetCore2.1.sln
     - name: Test with donet SDK v2.1
-      if: matrix.dotnet == '2.1.802'
+      if: matrix.dotnet == '2.1.816'
       run: dotnet test -v d --configuration Release SecretSharingDotNetCore2.1.sln
     - name: Build with dotnet SDK v3.1
-      if: matrix.dotnet == '3.1.100'
+      if: matrix.dotnet == '3.1.410'
       run: dotnet build --configuration Release SecretSharingDotNetCore3.1.sln
     - name: Test with donet SDK v3.1
-      if: matrix.dotnet == '3.1.100'
+      if: matrix.dotnet == '3.1.410'
       run: dotnet test -v d --configuration Release SecretSharingDotNetCore3.1.sln
     - name: Build with dotnet SDK v5.0
-      if: matrix.dotnet == '5.0.100'
+      if: matrix.dotnet == '5.0.301'
       run: dotnet build --configuration Release SecretSharingDotNet5.sln
     - name: Test with dotnet SDK v5.0
-      if: matrix.dotnet == '5.0.100'
+      if: matrix.dotnet == '5.0.301'
       run: dotnet test --configuration Release SecretSharingDotNet5.sln

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -13,6 +13,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
     strategy:
       matrix:
         dotnet: [ '2.1.816', '3.1.410', '5.0.301']

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -11,7 +11,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
     - uses: actions/checkout@v1
 

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -18,21 +18,21 @@ jobs:
     - name: Setup .NET Core 2.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.1.802
+        dotnet-version: 2.1.816
 
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.201
+        dotnet-version: 3.1.410
 
     - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100
+        dotnet-version: 5.0.301
 
     - name: .NET Core SxS
       run: |
-        rsync -a ${DOTNET_ROOT/5.0.100/3.1.201/2.1.802}/* $DOTNET_ROOT/
+        rsync -a ${DOTNET_ROOT/5.0.301/3.1.410/2.1.816}/* $DOTNET_ROOT/
 
     - name: Decrypt large secret
       run: ./.github/secrets/decrypt_publisher_snk.sh

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/SecretSharingDotNet5Test.csproj
+++ b/tests/SecretSharingDotNet5Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/tests/SecretSharingDotNetCore2.1Test.csproj
+++ b/tests/SecretSharingDotNetCore2.1Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/tests/SecretSharingDotNetCore3.1Test.csproj
+++ b/tests/SecretSharingDotNetCore3.1Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\src\SecretSharingDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
A native crash occurred during unit testing of the SecretSharingDotNet (All supported TFM) solution.

The fix based on the assumption that OOM kills occur. So the idea is to save memory space to avoid crashes.