### PR TITLE
Fix - Issue # 60 "Reconstruction fails at random"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed bug #60 "Reconstruction fails at random" which occurs when the secret is created from a base64 string
+
 ### Removed
 - Removed .NET Core 2.1 (LTS) support
 

--- a/src/Cryptography/Secret.cs
+++ b/src/Cryptography/Secret.cs
@@ -212,7 +212,8 @@ namespace SecretSharingDotNet.Cryptography
         /// <returns>The <see cref="string"/> representation in base 64</returns>
         public string ToBase64()
         {
-            return Convert.ToBase64String(this.secretNumber.ByteRepresentation.ToArray(), 0, this.secretNumber.ByteCount);
+            var bytes = this.secretNumber.ByteRepresentation.ToArray();
+            return Convert.ToBase64String(bytes, 1, bytes.Length - 2);
         }
 
         /// <summary>
@@ -228,7 +229,10 @@ namespace SecretSharingDotNet.Cryptography
                 throw new ArgumentNullException(nameof(encoded));
             }
 
-            return Calculator.Create(Convert.FromBase64String(encoded), typeof(TNumber)) as Calculator<TNumber>;
+            var bytes = Convert.FromBase64String(encoded).ToList();
+            bytes.Insert(0, 0x00);
+            bytes.Add(0x78);
+            return Calculator.Create(bytes.ToArray(), typeof(TNumber)) as Calculator<TNumber>;
         }
     }
 }

--- a/tests/TestData.cs
+++ b/tests/TestData.cs
@@ -113,5 +113,20 @@ namespace SecretSharingDotNet
             "06-6B946F401839E3578D8842F8673607564422A9F838B202DFA6571A50160BAAC39B7ABB9B55893759403FE17E735436FD615A0311364DD0725EA2DFD9358B1CAAE001",
             "07-FEC9430509166E5BF75F195E6B0A01DD7C1AD65089E35270D1318CA34ADB3F7E149C71F3D52303D514190C8D53AE3F61735F52B2FBB6E16F8C8881ADF25FE70DB001"
         };
+
+        /// <summary>
+        /// Gets a list of byte array sizes for several tests
+        /// </summary>
+        public static IEnumerable<object[]> ByteArraySize =>
+            new List<object[]>
+            {
+                new object[] { 1},
+                new object[] { 27},
+                new object[] { 32},
+                new object[] { 53},
+                new object[] { 64},
+                new object[] { 77},
+                new object[] { 128}
+            };
     }
 }


### PR DESCRIPTION
Fixes the bug #60 reported by @Helios-vmg. The bug affects the methods `ToBase64` and `ParseBase64` in `Secret.cs`.

Bug:
The big integer data type doesn't keep the original byte array from a decoded base64 string. Based on the MSB in the array, additional bytes are added for the sign interpretation of the big integer structure which represents a numeric value (see none fix length and complement of two). 
If this byte representation of the numeric value is used to encode back the base64 string, the additional bytes will be part of the encoded base64 string. So the reconstructed base64 string is not equal to the original one. 

Fix:
To avoid this behavior, the mask bytes will be added to the byte array if a base64 string is decoded. On the other side if a base64 string is encoded, the mask bytes will be removed.
