### PR TITLE
Feature - .NET 6 support

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,24 +41,24 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Setup .NET Core 2.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 2.1.816
-
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.410
+        dotnet-version: 3.1.415
 
     - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.301
+        dotnet-version: 5.0.403
+
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.100
 
     - name: .NET Core SxS
       run: |
-        rsync -a ${DOTNET_ROOT/5.0.301/3.1.410/2.1.816}/* $DOTNET_ROOT/
+        rsync -a ${DOTNET_ROOT/6.0.100/5.0.403/3.1.415}/* $DOTNET_ROOT/
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -21,16 +21,21 @@ jobs:
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.410
+        dotnet-version: 3.1.415
 
     - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.301
+        dotnet-version: 5.0.403
+
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.100
 
     - name: .NET Core SxS
       run: |
-        rsync -a ${DOTNET_ROOT/5.0.301/3.1.410}/* $DOTNET_ROOT/
+        rsync -a ${DOTNET_ROOT/6.0.100/5.0.403/3.1.415}/* $DOTNET_ROOT/
 
     - name: Restore
       run: dotnet restore SecretSharingDotNet.sln

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -17,7 +17,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     strategy:
       matrix:
-        dotnet: [ '3.1.410', '5.0.301']
+        dotnet: [ '3.1.415', '5.0.403', '6.0.100']
     name: Dotnet ${{ matrix.dotnet }}
 
     steps:
@@ -27,14 +27,21 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Build with dotnet SDK v3.1
-      if: matrix.dotnet == '3.1.410'
+      if: matrix.dotnet == '3.1.415'
       run: dotnet build --configuration Release SecretSharingDotNetCore3.1.sln
     - name: Test with donet SDK v3.1
-      if: matrix.dotnet == '3.1.410'
+      if: matrix.dotnet == '3.1.415'
       run: dotnet test -v d --configuration Release SecretSharingDotNetCore3.1.sln
     - name: Build with dotnet SDK v5.0
-      if: matrix.dotnet == '5.0.301'
+      if: matrix.dotnet == '5.0.403'
       run: dotnet build --configuration Release SecretSharingDotNet5.sln
     - name: Test with dotnet SDK v5.0
-      if: matrix.dotnet == '5.0.301'
+      if: matrix.dotnet == '5.0.403'
       run: dotnet test --configuration Release SecretSharingDotNet5.sln
+    - name: Build with dotnet SDK v6.0
+      if: matrix.dotnet == '6.0.100'
+      run: dotnet build --configuration Release SecretSharingDotNet6.sln
+    - name: Test with dotnet SDK v6.0
+      if: matrix.dotnet == '6.0.100'
+      run: dotnet test --configuration Release SecretSharingDotNet6.sln
+

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -19,16 +19,21 @@ jobs:
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.410
+        dotnet-version: 3.1.415
 
     - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.301
+        dotnet-version: 5.0.403
+
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.100
 
     - name: .NET Core SxS
       run: |
-        rsync -a ${DOTNET_ROOT/5.0.301/3.1.410}/* $DOTNET_ROOT/
+        rsync -a ${DOTNET_ROOT/6.0.100/5.0.403/3.1.415}/* $DOTNET_ROOT/
 
     - name: Decrypt large secret
       run: ./.github/secrets/decrypt_publisher_snk.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add .NET 6 support
 
+### Changed
+- Use RandomNumberGenerator class instead RNGCryptoServiceProvider class to create the polynomial. For details see [dotnet runtime issue 40169](https://github.com/dotnet/runtime/issues/40169)
+
 ### Fixed
 - Fixed bug #60 "Reconstruction fails at random" which occurs when the secret is created from a base64 string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add .NET 6 support
+
 ### Fixed
 - Fixed bug #60 "Reconstruction fails at random" which occurs when the secret is created from a base64 string
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=12><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
-          <td rowspan=12><code>SecretSharingDotNet.sln</code></td>
-          <td rowspan=12>Core</td>
+          <td rowspan=13><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
+          <td rowspan=13><code>SecretSharingDotNet.sln</code></td>
+          <td rowspan=13>Core</td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
@@ -52,14 +52,21 @@ An C# implementation of Shamir's Secret Sharing.
           <td>.NET 5</td>
       </tr>
       <tr>
-          <td rowspan=2><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+.NET+Core%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20.NET%20Core/badge.svg" alt="Build status"></a></td>
+          <td>.NET 6</td>
+      </tr>
+      <tr>
+          <td rowspan=3><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+.NET+Core%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20.NET%20Core/badge.svg" alt="Build status"></a></td>
           <td><code>SecretSharingDotNetCore3.1.sln</code></td>
-          <td rowspan=2>Core</td>
+          <td rowspan=3>Core</td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
           <td rowspan=1><code>SecretSharingDotNet5.sln</code></td>
           <td>.NET 5</td>
+      </tr>
+      <tr>
+          <td rowspan=1><code>SecretSharingDotNet6.sln</code></td>
+          <td>.NET 6</td>
       </tr>
       <tr>
           <td><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+.NET+FX%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20.NET%20FX/badge.svg" alt="Build status"></a></td>
@@ -83,13 +90,16 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=12><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.5.0" alt="SecretSharingDotNet NuGet"/></a></td>
-          <td rowspan=12><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.5.0"/></a></td>
-          <td rowspan=12><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.5.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.5.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=13><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.5.0" alt="SecretSharingDotNet NuGet"/></a></td>
+          <td rowspan=13><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.5.0"/></a></td>
+          <td rowspan=13><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.5.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.5.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
           <td>.NET 5</td>
+      </tr>
+      <tr>
+          <td>.NET 6</td>
       </tr>
       <tr>
           <td>Standard 2.0</td>
@@ -292,15 +302,16 @@ namespace Example3
 ```
 # CLI building instructions
 For the following instructions, please make sure that you are connected to the internet. If necessary, NuGet will try to restore the [xUnit](https://xunit.net/) packages.
-## Using dotnet to build for .NET 5, .NET Core and .NET FX 4.x
+## Using dotnet to build for .NET6, .NET 5, .NET Core and .NET FX 4.x
 Use one of the following solutions with `dotnet` to build [SecretSharingDotNet](#secretsharingdotnet):
 * `SecretSharingDotNet.sln` (all, [see table](#build--test-status-of-default-branch))
 * `SecretSharingDotNet5.sln` (.NET 5 only)
+* `SecretSharingDotNet6.sln` (.NET 6 only)
 * `SecretSharingDotNetCore3.1.sln` (.NET Core 3.1 only)
 
 The syntax is:
 ```dotnetcli
-dotnet {build|test} -c {Debug|Release} SecretSharingDotNet{5|Core3.1}.sln
+dotnet {build|test} -c {Debug|Release} SecretSharingDotNet{6|5|Core3.1}.sln
 ```
 
 The instructions below are examples, which operate on the `SecretSharingDotNet5.sln`.

--- a/SecretSharingDotNet6.sln
+++ b/SecretSharingDotNet6.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNet", "src\SecretSharingDotNet6.csproj", "{EF113114-267C-4CA0-B22A-62A326FF73B2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNetTest", "tests\SecretSharingDotNet6Test.csproj", "{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Debug|x64.Build.0 = Debug|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Debug|x86.Build.0 = Debug|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Release|x64.ActiveCfg = Release|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Release|x64.Build.0 = Release|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Release|x86.ActiveCfg = Release|Any CPU
+		{EF113114-267C-4CA0-B22A-62A326FF73B2}.Release|x86.Build.0 = Release|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Debug|x64.Build.0 = Debug|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Debug|x86.Build.0 = Debug|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Release|x64.ActiveCfg = Release|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Release|x64.Build.0 = Release|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Release|x86.ActiveCfg = Release|Any CPU
+		{1754AFBB-73DF-4AEB-9CBC-5C46B3708D8F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -215,11 +215,11 @@ namespace SecretSharingDotNet.Cryptography
         {
             var polynomial = new List<Calculator<TNumber>>(); //// pre-init
             var randomNumber = new byte[this.mersennePrime.ByteCount];
-            using (RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider())
+            using (var rng = RandomNumberGenerator.Create())
             {
                 for (var i = Calculator<TNumber>.Zero; i < numberOfMinimumShares; i++)
                 {
-                    rngCsp.GetBytes(randomNumber);
+                    rng.GetBytes(randomNumber);
                     polynomial.Add((Calculator.Create(randomNumber, typeof(TNumber)) as Calculator<TNumber>)?.Abs() % this.mersennePrime);
                 }
             }

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SecretSharingDotNet</AssemblyName>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1;net452;net46;net461;net462;net47;net471;net472;net48;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1;net452;net46;net461;net462;net47;net471;net472;net48;net5.0;net6.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/SecretSharingDotNet6.csproj
+++ b/src/SecretSharingDotNet6.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>SecretSharingDotNetCore</AssemblyName>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <AssemblyOriginatorKeyFile>SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>True</SignAssembly>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+</Project>

--- a/tests/SecretSharingDotNet6Test.csproj
+++ b/tests/SecretSharingDotNet6Test.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <AssemblyOriginatorKeyFile>..\src\SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>True</SignAssembly>
+    <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AssemblyName>SecretSharingDotNetTest</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\SecretSharingDotNet6.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\src\SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Supports .NET 6.
Therefor the [RandomNumberGenerator](https://docs.microsoft.com/de-de/dotnet/api/system.security.cryptography.randomnumbergenerator?view=net-6.0) class is used instead the [RNGCryptoServiceProvider](https://docs.microsoft.com/de-de/dotnet/api/system.security.cryptography.rngcryptoserviceprovider?view=net-6.0) class to create the polynomial. For details see the dotnet runtime issue [40169](https://github.com/dotnet/runtime/issues/40169).