### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2021-11-25
 ### Added
 - Add .NET 6 support
 
 ### Changed
-- Use RandomNumberGenerator class instead RNGCryptoServiceProvider class to create the polynomial. For details see [dotnet runtime issue 40169](https://github.com/dotnet/runtime/issues/40169)
+- Use RandomNumberGenerator class instead RNGCryptoServiceProvider class to create the polynomial. For details see dotnet runtime issue [40169](https://github.com/dotnet/runtime/issues/40169)
 
 ### Fixed
-- Fixed bug #60 "Reconstruction fails at random" which occurs when the secret is created from a base64 string
+- Fixed bug [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) "Reconstruction fails at random" which occurs when the secret is created from a base64 string
 
 ### Removed
 - Removed .NET Core 2.1 (LTS) support

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=13><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.5.0" alt="SecretSharingDotNet NuGet"/></a></td>
-          <td rowspan=13><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.5.0"/></a></td>
-          <td rowspan=13><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.5.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.5.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=13><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.6.0" alt="SecretSharingDotNet NuGet"/></a></td>
+          <td rowspan=13><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.6.0"/></a></td>
+          <td rowspan=13><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.6.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.6.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
@@ -138,10 +138,10 @@ An C# implementation of Shamir's Secret Sharing.
 
 1. Open a console and switch to the directory, containing your project file.
 
-2. Use the following command to install version 0.5.0 of the SecretSharingDotNet package:
+2. Use the following command to install version 0.6.0 of the SecretSharingDotNet package:
 
     ```dotnetcli
-    dotnet add package SecretSharingDotNet -v 0.5.0 -f <FRAMEWORK>
+    dotnet add package SecretSharingDotNet -v 0.6.0 -f <FRAMEWORK>
     ```
 
 3. After the completition of the command, look at the project file to make sure that the package is successfuly installed.
@@ -150,7 +150,7 @@ An C# implementation of Shamir's Secret Sharing.
 
     ```xml
     <ItemGroup>
-      <PackageReference Include="SecretSharingDotNet" Version="0.5.0" />
+      <PackageReference Include="SecretSharingDotNet" Version="0.6.0" />
     </ItemGroup>
     ```
 ## Remove SecretSharingDotNet package

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("1c21b99c-2de4-4ca5-b4ce-bc95cf89369e")]
 
-[assembly: AssemblyVersion("0.5.0")]
-[assembly: AssemblyFileVersion("0.5.0")]
+[assembly: AssemblyVersion("0.6.0")]
+[assembly: AssemblyFileVersion("0.6.0")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -9,13 +9,13 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>SecretSharingDotNet</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>This version introduces a 'shares' return type for the split method. The 'tuple' return type is obsolete.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added support for .NET 6. Removed .NET Core 2.1 (LTS) support. Uses RandomNumberGenerator class instead RNGCryptoServiceProvider class to create the polynomial. Fixed bug #60 "Reconstruction fails at random" (base64 only).</PackageReleaseNotes>
     <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
     <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
     <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <Authors>Sebastian Walther</Authors>
     <Company>Private Person</Company>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
### Added
- Add .NET 6 support

### Changed
- Use RandomNumberGenerator class instead RNGCryptoServiceProvider class to create the polynomial. For details see dotnet runtime issue [40169](https://github.com/dotnet/runtime/issues/40169)

### Fixed
- Fixed bug [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) "Reconstruction fails at random" which occurs when the secret is created from a base64 string