### PR TITLE
Remove Microsoft .NET Framework 4.5.2 support

### DIFF
--- a/.github/workflows/dotnetfx.yml
+++ b/.github/workflows/dotnetfx.yml
@@ -24,14 +24,14 @@ jobs:
           nuget-version: latest
 
       - name: Nuget Restore
-        run: nuget restore $Env:GITHUB_WORKSPACE\SecretSharingDotNetFx4.5.2.sln
+        run: nuget restore $Env:GITHUB_WORKSPACE\SecretSharingDotNetFx4.6.2.sln
 
       - name: Build with mbsuild
         run: |
            cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
-           .\MSBuild.exe /p:Configuration=Release $Env:GITHUB_WORKSPACE\SecretSharingDotNetFx4.5.2.sln
+           .\MSBuild.exe /p:Configuration=Release $Env:GITHUB_WORKSPACE\SecretSharingDotNetFx4.6.2.sln
 
       - name: Test with xUnit.net console runner
         run: |
-           cd "$Env:GITHUB_WORKSPACE\packages\xunit.runner.console.2.4.0\tools\net452"
+           cd "$Env:GITHUB_WORKSPACE\packages\xunit.runner.console.2.4.1\tools\net462"
            .\xunit.console $Env:GITHUB_WORKSPACE\tests\bin\Release\SecretSharingDotNetTest.dll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+- Removed .NET FX 4.5.2 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy.](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
+
+
 ## [0.6.0] - 2021-11-25
 ### Added
 - Add .NET 6 support

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=13><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
-          <td rowspan=13><code>SecretSharingDotNet.sln</code></td>
-          <td rowspan=13>Core</td>
+          <td rowspan=12><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
+          <td rowspan=12><code>SecretSharingDotNet.sln</code></td>
+          <td rowspan=12>Core</td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
@@ -23,9 +23,6 @@ An C# implementation of Shamir's Secret Sharing.
       </tr>
       <tr>
           <td>Standard 2.1</td>
-      </tr>
-      <tr>
-          <td>FX 4.5.2</td>
       </tr>
       <tr>
           <td>FX 4.6</td>
@@ -70,9 +67,9 @@ An C# implementation of Shamir's Secret Sharing.
       </tr>
       <tr>
           <td><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+.NET+FX%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20.NET%20FX/badge.svg" alt="Build status"></a></td>
-          <td><code>SecretSharingDotNetFx4.5.2.sln</code></td>
+          <td><code>SecretSharingDotNetFx4.6.2.sln</code></td>
           <td>FX</td>
-          <td>FX 4.5.2</td>
+          <td>FX 4.6.2</td>
       </tr>
   </tbody>
 </table>
@@ -90,9 +87,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=13><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.6.0" alt="SecretSharingDotNet NuGet"/></a></td>
-          <td rowspan=13><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.6.0"/></a></td>
-          <td rowspan=13><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.6.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.6.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=12><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.6.0" alt="SecretSharingDotNet NuGet"/></a></td>
+          <td rowspan=12><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.6.0"/></a></td>
+          <td rowspan=12><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.6.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.6.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
@@ -106,9 +103,6 @@ An C# implementation of Shamir's Secret Sharing.
       </tr>
       <tr>
           <td>Standard 2.1</td>
-      </tr>
-      <tr>
-          <td>FX 4.5.2</td>
       </tr>
       <tr>
           <td>FX 4.6</td>
@@ -339,25 +333,25 @@ dotnet test -c Debug SecretSharingDotNet5.sln
 dotnet test -c Release SecretSharingDotNet5.sln
 ```
 
-## Using MSBuild to build for .NET FX 4.5.2
+## Using MSBuild to build for .NET FX 4.6.2
 Use one of the following solutions with `msbuild` to build [SecretSharingDotNet](#secretsharingdotnet):
-* `SecretSharingDotNetFx4.5.2.sln`
+* `SecretSharingDotNetFx4.6.2.sln`
 
 Currently unit testing with MSBuild isn't possible.
 
 The syntax is:
 ```dotnetcli
-msbuild /p:RestorePackagesConfig=true;Configuration={Debug|Release} /t:restore;build SecretSharingDotNetFx4.5.2.sln
+msbuild /p:RestorePackagesConfig=true;Configuration={Debug|Release} /t:restore;build SecretSharingDotNetFx4.6.2.sln
 ```
 
 ### Build Debug configuration
 
 ```dotnetcli
-msbuild /p:RestorePackagesConfig=true;Configuration=Debug /t:restore;build SecretSharingDotNetFx4.5.2.sln
+msbuild /p:RestorePackagesConfig=true;Configuration=Debug /t:restore;build SecretSharingDotNetFx4.6.2.sln
 ```
 
 ### Build Release configuration
 
 ```dotnetcli
-msbuild /p:RestorePackagesConfig=true;Configuration=Release /t:restore;build SecretSharingDotNetFx4.5.2.sln
+msbuild /p:RestorePackagesConfig=true;Configuration=Release /t:restore;build SecretSharingDotNetFx4.6.2.sln
 ```

--- a/SecretSharingDotNetFx4.6.2.sln
+++ b/SecretSharingDotNetFx4.6.2.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29102.190
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNetFx4.5.2", "src\SecretSharingDotNetFx4.5.2.csproj", "{1C21B99C-2DE4-4CA5-B4CE-BC95CF89369E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNetFx4.6.2", "src\SecretSharingDotNetFx4.6.2.csproj", "{1C21B99C-2DE4-4CA5-B4CE-BC95CF89369E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNetFx4.5.2Test", "tests\SecretSharingDotNetFx4.5.2Test.csproj", "{70290CC4-75A1-4609-AFCA-F1343D889A0E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecretSharingDotNetFx4.6.2Test", "tests\SecretSharingDotNetFx4.6.2Test.csproj", "{70290CC4-75A1-4609-AFCA-F1343D889A0E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SecretSharingDotNet</AssemblyName>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1;net452;net46;net461;net462;net47;net471;net472;net48;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1;net46;net461;net462;net47;net471;net472;net48;net5.0;net6.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/SecretSharingDotNetFx4.6.2.csproj
+++ b/src/SecretSharingDotNetFx4.6.2.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SecretSharingDotNet</RootNamespace>
     <AssemblyName>SecretSharingDotNetFx</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/tests/SecretSharingDotNetFx4.6.2Test.csproj
+++ b/tests/SecretSharingDotNetFx4.6.2Test.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\packages\xunit.runner.console.2.4.0\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.4.0\build\xunit.runner.console.props')" />
-  <Import Project="..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props" Condition="Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" />
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SecretSharingDotNet</RootNamespace>
     <AssemblyName>SecretSharingDotNetTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
@@ -51,20 +51,17 @@
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.2.0.2\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.4.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.4.0\lib\net452\xunit.core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.execution.2.4.0\lib\net452\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
     <Reference Include="xunit.execution.dotnet, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.extensibility.execution.2.4.0\lib\netstandard1.1\xunit.execution.dotnet.dll</HintPath>
@@ -83,6 +80,7 @@
     <None Include="..\src\SecretSharingDotNet.snk">
       <Link>SecretSharingDotNet.snk</Link>
     </None>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -90,9 +88,9 @@
     <Analyzer Include="..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\src\SecretSharingDotNetFx4.5.2.csproj">
+    <ProjectReference Include="..\src\SecretSharingDotNetFx4.6.2.csproj">
       <Project>{1c21b99c-2de4-4ca5-b4ce-bc95cf89369e}</Project>
-      <Name>SecretSharingDotNetFx4.5.2</Name>
+      <Name>SecretSharingDotNetFx4.6.2</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -100,10 +98,10 @@
     <PropertyGroup>
       <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.console.2.4.0\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.4.0\build\xunit.runner.console.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.console.2.4.1\build\xunit.runner.console.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props'))" />
   </Target>
-  <Import Project="..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
 </Project>

--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\src\SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <IsPackable>false</IsPackable>

--- a/tests/app.config
+++ b/tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.2" targetFramework="net452" />
+  <package id="xunit" version="2.4.1" targetFramework="net462" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.runner.console" version="2.4.0" targetFramework="net452" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net452" developmentDependency="true" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net462" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net462" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net462" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net462" />
+  <package id="xunit.runner.console" version="2.4.1" targetFramework="net462" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.3" targetFramework="net462" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
.NET Framework 4.5.2 will reach End of Support on April 26, 2022.

For further details see:
- [Microsoft .NET Framework](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
- [.NET Framework 4.5.2, 4.6, 4.6.1 will reach End of Support on April 26, 2022](https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/)