### PR TITLE
Remove Microsoft .NET Framework 4.6.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed .NET Core 2.1 (LTS) support
-- Removed .NET FX 4.5.2 support
 
 ## [0.5.0] - 2021-10-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed .NET Core 2.1 (LTS) support
+- Removed .NET FX 4.5.2 support
 
 ## [0.5.0] - 2021-10-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Removed .NET FX 4.5.2 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy.](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
 - Removed .NET FX 4.6 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy.](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
-
+- Removed .NET FX 4.6.1 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy.](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
 
 ## [0.6.0] - 2021-11-25
 ### Added
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed .NET Core 2.1 (LTS) support
-- Removed .NET FX 4.5.2 support
 
 ## [0.5.0] - 2021-10-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=11><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
-          <td rowspan=11><code>SecretSharingDotNet.sln</code></td>
-          <td rowspan=11>Core</td>
+          <td rowspan=10><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
+          <td rowspan=10><code>SecretSharingDotNet.sln</code></td>
+          <td rowspan=10>Core</td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
@@ -23,9 +23,6 @@ An C# implementation of Shamir's Secret Sharing.
       </tr>
       <tr>
           <td>Standard 2.1</td>
-      </tr>
-      <tr>
-          <td>FX 4.6.1</td>
       </tr>
       <tr>
           <td>FX 4.6.2</td>
@@ -84,9 +81,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=11><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.6.0" alt="SecretSharingDotNet NuGet"/></a></td>
-          <td rowspan=11><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.6.0"/></a></td>
-          <td rowspan=11><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.6.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.6.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=10><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.6.0" alt="SecretSharingDotNet NuGet"/></a></td>
+          <td rowspan=10><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.6.0"/></a></td>
+          <td rowspan=10><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.6.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.6.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
@@ -100,9 +97,6 @@ An C# implementation of Shamir's Secret Sharing.
       </tr>
       <tr>
           <td>Standard 2.1</td>
-      </tr>
-      <tr>
-          <td>FX 4.6.1</td>
       </tr>
       <tr>
           <td>FX 4.6.2</td>

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SecretSharingDotNet</AssemblyName>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1;net461;net462;net47;net471;net472;net48;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1;net462;net47;net471;net472;net48;net5.0;net6.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net462;net47;net471;net472;net48</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\src\SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
.NET Framework 4.6.1 will reach End of Support on April 26, 2022.

For further details see:
- [Microsoft .NET Framework](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
- [.NET Framework 4.5.2, 4.6, 4.6.1 will reach End of Support on April 26, 2022](https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/)