### PR TITLE
Fix - Issue #60 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added implicit casts for byte arrays in Secret class.
+- Added legacy mode. See README.md, section "Usage" for more details.
 
 ### Changed
+- Changed behavior of Secret class for negative secret values. See README.md, section "Usage" and bug report [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) for more details.
+- Changed calculation of maximum security level in Reconstruction method.
 
 ### Fixed
+- Fixed reopened bug [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) "Reconstruction fails at random".
 
 ### Removed
-- Removed .NET FX 4.5.2 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy.](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
-- Removed .NET FX 4.6 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy.](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
-- Removed .NET FX 4.6.1 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy.](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
+- Removed .NET FX 4.5.2 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).
+- Removed .NET FX 4.6 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).
+- Removed .NET FX 4.6.1 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).
 
 ## [0.6.0] - 2021-11-25
 ### Added

--- a/src/Cryptography/FinitePoint.cs
+++ b/src/Cryptography/FinitePoint.cs
@@ -165,7 +165,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <returns></returns>
         public int CompareTo(FinitePoint<TNumber> other)
         {
-            return ((this.X * this.X + this.Y * this.Y).Sqrt - (other.X * other.X + other.Y * other.Y).Sqrt).Sign;
+            return ((this.X.Pow(2) + this.Y.Pow(2)).Sqrt - (other.X.Pow(2) + other.Y.Pow(2)).Sqrt).Sign;
         }
 
         /// <summary>

--- a/src/Cryptography/Secret.cs
+++ b/src/Cryptography/Secret.cs
@@ -1,6 +1,6 @@
 // ----------------------------------------------------------------------------
 // <copyright file="Secret.cs" company="Private">
-// Copyright (c) 2019 All Rights Reserved
+// Copyright (c) 2022 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
 // <date>04/20/2019 10:52:28 PM</date>
@@ -8,7 +8,7 @@
 
 #region License
 // ----------------------------------------------------------------------------
-// Copyright 2019 Sebastian Walther
+// Copyright 2022 Sebastian Walther
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -32,74 +32,215 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("SecretSharingDotNetTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100257917fef6a3508bdfc3db4dd65b0b485261c2f5bff7380b7737b0d59f741d41b6086743a7957cab387fb7da8a17491dea1239b496cef97ef61cd76bc3b5f0f983d5e693083c8a0c283bb55edd6fe389abda1565c534a3537e9e087ddef8b1525520ebd5ff6f36e74baaa97522816f3a7998bbdd9392f99c0777c421634abaaa")]
 namespace SecretSharingDotNet.Cryptography
 {
+    using Helper;
     using Math;
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Security.Cryptography;
     using System.Text;
+    using System.Threading;
+
+    /// <summary>
+    /// This class represents the secret including members to parse or convert it.
+    /// </summary>
+    public class Secret
+    {
+        /// <summary>
+        /// Gets or sets the legacy mode on (<see langword="true"/>) or <see langword="off"/> to be compatible with
+        /// v0.6.0 or older.
+        /// </summary>
+        public static ThreadLocal<bool> LegacyMode = new ThreadLocal<bool> { Value = false };
+
+        /// <summary>
+        /// Maximum mark byte to terminate the secret array and to avoid negative secret values.
+        /// </summary>
+        /// <remarks>prime number greater than 2^13-1</remarks>
+        protected const byte MaxMarkByte = 0x7F;
+
+        /// <summary>
+        /// Minimum mark byte to terminate the secret array and to avoid negative secret values.
+        /// </summary>
+        /// <remarks>prime number equal to 2^13-1</remarks>
+        protected const byte MinMarkByte = 0x1F;
+
+        /// <summary>
+        /// Create <see cref="Secret{TNumber}"/> from a0 coefficient
+        /// </summary>
+        /// <typeparam name="TNumber"></typeparam>
+        /// <param name="coefficient">a0 coefficient</param>
+        /// <returns>A <see cref="Secret{TNumber}"/></returns>
+        internal static Secret<TNumber> FromCoefficient<TNumber>(Calculator<TNumber> coefficient) =>
+            new Secret<TNumber>(coefficient.ByteRepresentation.Take(coefficient.ByteCount - MarkByteCount).ToArray());
+
+        /// <summary>
+        /// Creates a random secret
+        /// </summary>
+        /// <param name="prime">mersenne prime number</param>
+        /// <remarks>Use this ctor to create a random secret</remarks>
+        internal static Secret<TNumber> CreateRandom<TNumber>(Calculator<TNumber> prime)
+        {
+            var randomSecretBytes = new byte[prime.ByteCount];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(randomSecretBytes);
+            }
+
+            if (LegacyMode.Value)
+            {
+                return (Calculator.Create(randomSecretBytes, typeof(TNumber)) as Calculator<TNumber>)?.Abs() % prime;
+            }
+
+            int i = randomSecretBytes.Length - 1;
+            while (i > 0)
+            {
+                randomSecretBytes[i] = i == 1 ? MinMarkByte : MaxMarkByte;
+                var randomSecretNumber = Calculator.Create(randomSecretBytes, typeof(TNumber)) as Calculator<TNumber>;
+                var a0 = randomSecretNumber?.Abs() % prime;
+                if (a0 == randomSecretNumber)
+                {
+                    break;
+                }
+
+                if (a0.IsZero)
+                {
+                    return new Secret<TNumber>(new byte[] { 0x00 });
+                }
+
+                randomSecretBytes[i--] = 0x00;
+            }
+
+            return new Secret<TNumber>(randomSecretBytes.Subset(0, randomSecretBytes.Length - (randomSecretBytes.Length - i)));
+        }
+
+        /// <summary>
+        /// Gets the MarkByte count in dependency of the <see cref="LegacyMode"/>.
+        /// </summary>
+        protected static int MarkByteCount => LegacyMode.Value ? 0 : 1;
+
+        /// <summary>
+        /// Creates an array from a base64 string as in version 0.6.0 or older
+        /// </summary>
+        protected static readonly Func<string, byte[]> FromBase64Legacy = base64 =>
+        {
+            var bytes = Convert.FromBase64String(base64).ToList();
+            bytes.Insert(0, 0x00);
+            bytes.Add(0x78);
+            return bytes.ToArray();
+        };
+    }
 
     /// <summary>
     /// This class represents the secret including members to parse or convert it.
     /// </summary>
     /// <typeparam name="TNumber">Numeric data type (An integer data type)</typeparam>
-    public class Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparable<Secret<TNumber>>
+    public sealed class Secret<TNumber> : Secret, IEquatable<Secret<TNumber>>, IComparable<Secret<TNumber>>
     {
         /// <summary>
         /// Saves the secret
         /// </summary>
-        private readonly Calculator<TNumber> secretNumber;
+        private readonly byte[] secretNumber;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Secret{TNumber}"/> class.
         /// </summary>
-        /// <param name="secretNumber">A secret integer number represented by an <see cref="Calculator{TNumber}"/> instance.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="secretNumber"/> is <see langword="null"/></exception>
-        internal Secret(Calculator<TNumber> secretNumber)
+        /// <param name="secretSource">A secret as array of type <see cref="byte"/></param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="secretSource"/> is <see langword="null"/></exception>
+        public Secret(byte[] secretSource)
         {
-            if (secretNumber == null)
+            if (secretSource == null)
             {
-                throw new ArgumentNullException(nameof(secretNumber));
+                throw new ArgumentNullException(nameof(secretSource));
             }
 
-            if (secretNumber.Sign < 0)
+            if (secretSource.Length == 0)
             {
-                throw new ArgumentException($"The secret is represented by a negative {typeof(TNumber).Name}. Please choose secret which is represented by a positive {typeof(TNumber).Name}", nameof(secretNumber));
+                throw new ArgumentException("Value cannot be an empty collection.", nameof(secretSource));
             }
 
-            this.secretNumber = secretNumber;
+            var buffer = new byte[1];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetNonZeroBytes(buffer);
+            }
+
+            byte maxMarkByte = secretSource.Length == 1 ? MinMarkByte : MaxMarkByte;
+            byte markByte = (byte)(new Random(buffer[0]).Next(0x01, maxMarkByte) % maxMarkByte);
+            var bytes = (byte[])secretSource.Clone();
+            this.secretNumber = LegacyMode.Value ? bytes : bytes.Concat(new[] { markByte }).ToArray();
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Secret{TNumber}"/> class.
         /// </summary>
+        /// <param name="secretSource">Secret as <see cref="Calculator"/> or <see cref="Calculator{TNumber}"/> value.</param>
+        public Secret(Calculator secretSource) : this(secretSource.ByteRepresentation.ToArray()) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Secret{TNumber}"/> class. Use this ctor to deserialize a base64 string to
+        /// a <see cref="Secret"/> instance.
+        /// </summary>
         /// <param name="encoded">Secret encoded as base-64</param>
+        /// <remarks>For normal text use the implicit cast from <see cref="string"/> to <see cref="Secret{TNumber}"/></remarks>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="encoded"/> is <see langword="null"/>, empty or consists exclusively of white-space characters</exception>
-        public Secret(string encoded) => this.secretNumber = ParseBase64(encoded);
+        public Secret(string encoded) : this(LegacyMode.Value ? FromBase64Legacy(encoded) : Convert.FromBase64String(encoded)) { }
+
+        /// <summary>
+        /// Gets the <see cref="Secret{TNumber}"/> byte size.
+        /// </summary>
+        internal int SecretByteSize => this.secretNumber.Length;
+
+        /// <summary>
+        /// Gets this <see cref="Secret{TNumber}"/> as an a0 coefficient.
+        /// </summary>
+        internal Calculator<TNumber> ToCoefficient => Calculator.Create(this.secretNumber, typeof(TNumber)) as Calculator<TNumber>;
 
         /// <summary>
         /// Casts the <typeparamref name="TNumber"/> instance to an <see cref="Secret{TNumber}"/> instance
         /// </summary>
-        public static implicit operator Secret<TNumber>(TNumber number) => new Secret<TNumber>(number);
+        public static implicit operator Secret<TNumber>(TNumber number) => new Secret<TNumber>(((Calculator<TNumber>)number).ByteRepresentation.ToArray());
 
         /// <summary>
         /// Casts the <see cref="Secret{TNumber}"/> instance to an <typeparamref name="TNumber"/> instance
         /// </summary>
-        public static implicit operator TNumber(Secret<TNumber> secret) => secret != null && secret.secretNumber != null ? secret.secretNumber.Value : default;
+        public static implicit operator TNumber(Secret<TNumber> secret)
+        {
+            if (secret == null || secret.secretNumber == null || secret.secretNumber.Length == 0)
+            {
+                return default;
+            }
+
+            return ((Calculator<TNumber>)secret).Value;
+        }
 
         /// <summary>
         /// Casts the <see cref="Secret{TNumber}"/> instance to an <see cref="Calculator{TNumber}"/> instance
         /// </summary>
-        public static implicit operator Calculator<TNumber>(Secret<TNumber> secret) => secret?.secretNumber;
+        public static implicit operator Calculator<TNumber>(Secret<TNumber> secret)
+        {
+            var bytes = secret?.secretNumber.Subset(0, secret.secretNumber.Length - MarkByteCount);
+            return Calculator.Create(bytes, typeof(TNumber)) as Calculator<TNumber>;
+        }
 
         /// <summary>
         /// Casts the <see cref="Calculator{TNumber}"/> instance to an <see cref="Secret{TNumber}"/> instance
         /// </summary>
-        public static implicit operator Secret<TNumber>(Calculator<TNumber> calculator) => new Secret<TNumber>(calculator);
+        public static implicit operator Secret<TNumber>(Calculator<TNumber> calculator) => new Secret<TNumber>(calculator.ByteRepresentation.ToArray());
+
+        /// <summary>
+        /// Casts the <see cref="byte"/> array instance to an <see cref="Secret{TNumber}"/> instance
+        /// </summary>
+        public static implicit operator Secret<TNumber>(byte[] array) => new Secret<TNumber>(array);
+
+        /// <summary>
+        /// Casts the <see cref="Secret{TNumber}"/> instance to an <see cref="byte"/> array instance
+        /// </summary>
+        public static implicit operator byte[](Secret<TNumber> secret) => secret.ToByteArray();
 
         /// <summary>
         /// Casts the <see cref="string"/> instance to an <see cref="Secret{TNumber}"/> instance
         /// </summary>
-        public static implicit operator Secret<TNumber>(string secret) => new Secret<TNumber>(Calculator.Create(Encoding.Unicode.GetBytes(secret), typeof(TNumber)) as Calculator<TNumber>);
+        public static implicit operator Secret<TNumber>(string secret) => new Secret<TNumber>(Encoding.Unicode.GetBytes(secret));
 
         /// <summary>
         /// Equality operator
@@ -155,15 +296,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="other">An <see cref="Secret{TNumber}"/> instance to compare with this instance.</param>
         /// <returns>A value that indicates the relative order of the <see cref="Secret{TNumber}"/> instances being compared.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="other"/> is <see langword="null"/></exception>
-        public int CompareTo(Secret<TNumber> other)
-        {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
-
-            return ((this.secretNumber * this.secretNumber).Sqrt - (other.secretNumber * other.secretNumber).Sqrt).Sign;
-        }
+        public int CompareTo(Secret<TNumber> other) => this.secretNumber.CompareTo(other?.secretNumber ?? throw new ArgumentNullException(nameof(other)));
 
         /// <summary>
         /// Determines whether this instance and an<paramref name="other"/> specified <see cref="Secret{TNumber}"/> instance are equal.
@@ -173,7 +306,13 @@ namespace SecretSharingDotNet.Cryptography
         /// If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</returns>
         public bool Equals(Secret<TNumber> other)
         {
-            return !(other is null) && this.secretNumber.Equals(other.secretNumber);
+            if (LegacyMode.Value)
+            {
+                return !(other is null) && Calculator.Create(this.secretNumber, typeof(TNumber)).Equals(Calculator.Create(other.secretNumber, typeof(TNumber)));
+            }
+
+            return !(other is null) && this.secretNumber.Subset(0, this.SecretByteSize - MarkByteCount)
+                .SequenceEqual(other.secretNumber.Subset(0, other.SecretByteSize - MarkByteCount));
         }
 
         /// <summary>
@@ -182,10 +321,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="obj">The object to compare.</param>
         /// <returns><see langword="true"/> if the <paramref name="obj"/> argument is a <see cref="Secret{TNumber}"/> object,
         /// and its value is equal to the value of the current <see cref="Secret{TNumber}"/> instance; otherwise, <see langword="false"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return obj != null && this.Equals((Secret<TNumber>)obj);
-        }
+        public override bool Equals(object obj) => obj != null && this.Equals((Secret<TNumber>)obj);
 
         /// <summary>
         /// Returns the hash code for the current <see cref="Secret{TNumber}"/> structure.
@@ -200,13 +336,13 @@ namespace SecretSharingDotNet.Cryptography
         /// <returns><see cref="string"/> representation of <see cref="Secret{TNumber}"/></returns>
         public override string ToString()
         {
-            int padCount = this.secretNumber.ByteCount % sizeof(char);
+            int padCount = (this.secretNumber.Length - MarkByteCount) % sizeof(char);
             if (padCount == 0)
             {
-                return Encoding.Unicode.GetString(this.secretNumber.ByteRepresentation.ToArray(), 0, this.secretNumber.ByteCount);
+                return Encoding.Unicode.GetString(this.secretNumber, 0, this.secretNumber.Length - MarkByteCount);
             }
 
-            var padded = new List<byte>(this.secretNumber.ByteRepresentation);
+            var padded = new List<byte>(this.secretNumber.Subset(0, this.secretNumber.Length - MarkByteCount));
             for (int i = 0; i < padCount; i++)
             {
                 padded.Add(0x00);
@@ -216,40 +352,27 @@ namespace SecretSharingDotNet.Cryptography
         }
 
         /// <summary>
+        /// Converts the secret to a byte array
+        /// </summary>
+        /// <returns>Array of type <see cref="byte"/></returns>
+        public byte[] ToByteArray()
+        {
+            return this.secretNumber.Subset(0, this.secretNumber.Length - MarkByteCount).Clone() as byte[];
+        }
+
+        /// <summary>
         /// Converts the value of <see cref="Secret{TNumber}"/> structure to its equivalent <see cref="string"/> representation
         /// that is encoded with base-64 digits.
         /// </summary>
         /// <returns>The <see cref="string"/> representation in base 64</returns>
         public string ToBase64()
         {
-            var bytes = this.secretNumber.ByteRepresentation.ToArray();
-            return Convert.ToBase64String(bytes, 0, bytes.Length);
-        }
-
-        /// <summary>
-        /// Parses a base-64 encoded secret and returns an <see cref="Secret{TNumber}"/> instance.
-        /// </summary>
-        /// <param name="encoded">Secret encoded as base-64</param>
-        /// <exception cref="ArgumentNullException"><paramref name="encoded"/> is <see langword="null"/>, empty or  consists exclusively of white-space characters</exception>
-        /// <returns>An <see cref="Secret{TNumber}"/> instance.</returns>
-        private static Secret<TNumber> ParseBase64(string encoded)
-        {
-            if (string.IsNullOrWhiteSpace(encoded))
+            if (LegacyMode.Value)
             {
-                throw new ArgumentNullException(nameof(encoded));
+                return Convert.ToBase64String(this.secretNumber, 1, this.secretNumber.Length - 2);
             }
 
-            byte[] bytes;
-            try
-            {
-                bytes = Convert.FromBase64String(encoded);
-            }
-            catch (FormatException e)
-            {
-                throw new ArgumentException("", nameof(encoded), e);
-            }
-
-            return Calculator.Create(bytes, typeof(TNumber)) as Calculator<TNumber>;
+            return Convert.ToBase64String(this.secretNumber, 0, this.secretNumber.Length - MarkByteCount);
         }
     }
 }

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -398,9 +398,10 @@ namespace SecretSharingDotNet.Cryptography
                 throw new ArgumentOutOfRangeException(nameof(shares));
             }
 
-            this.SecurityLevel = shares.Max().Y.ByteCount * 8;
-            int index = this.securityLevels.IndexOf(this.SecurityLevel);
-            while ((shares.Max().Y % this.mersennePrime + this.mersennePrime) % this.mersennePrime == shares.Max().Y && index > 0 && this.SecurityLevel > 5)
+            var maximumY = shares.Select(point => point.Y).Max();
+            this.SecurityLevel = maximumY.ByteCount * 8;
+            var index = this.securityLevels.IndexOf(this.SecurityLevel);
+            while ((maximumY % this.mersennePrime + this.mersennePrime) % this.mersennePrime == maximumY && index > 0 && this.SecurityLevel > 5)
             {
                 this.SecurityLevel = this.securityLevels[--index];
             }

--- a/src/Helper/Extensions.cs
+++ b/src/Helper/Extensions.cs
@@ -1,0 +1,88 @@
+﻿// ----------------------------------------------------------------------------
+// <copyright file="Extensions.cs" company="Private">
+// Copyright (c) 2022 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>02/02/2022 06:54:22 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2022 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Helper
+{
+    using System;
+    using System.Collections;
+
+    /// <summary>
+    /// Helper class which contains extension methods
+    /// </summary>
+    internal static class Extensions
+    {
+        /// <summary>
+        ///  Compares instance <paramref name="a"/> with instance <paramref name="b"/> and returns an indication of their relative values.
+        /// </summary>
+        /// <typeparam name="TStructural">A data type which implements <see cref="IStructuralComparable"/></typeparam>
+        /// <param name="a">The current object to compare with the <paramref name="b"/> instance</param>
+        /// <param name="b">The object to compare with the current instance</param>
+        /// <returns>-1 if the <paramref name="a"/> instance (current) precedes <paramref name="b"/>, 0 the <paramref name="a"/> instance
+        /// and <paramref name="b"/> instance are equal and 1 if the <paramref name="a"/> instance follows <paramref name="b"/>.</returns>
+        public static int CompareTo<TStructural>(this TStructural a, TStructural b)
+            where TStructural : IStructuralComparable => a.CompareTo(b, StructuralComparisons.StructuralComparer);
+
+        /// <summary>
+        /// Creates a new array (destination array) which is a subset of the original array (source array).
+        /// </summary>
+        /// <typeparam name="TArray">Data type of the array</typeparam>
+        /// <param name="array">source array</param>
+        /// <param name="index">start index</param>
+        /// <param name="count">number of elements to copy to new subset array</param>
+        /// <returns>An array that contains the specified number of elements from the <paramref name="index"/> of the <paramref name="array"/>.</returns>
+        public static TArray[] Subset<TArray>(this TArray[] array, int index, int count)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            if (array.Length == 0)
+            {
+                throw new ArgumentException("Value cannot be an empty collection.", nameof(array));
+            }
+
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), index, "Value cannot be lower than 0.");
+            }
+
+            if (count < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count), count, "Value cannot be lower than 1.");
+            }
+
+            var subset = new TArray[count];
+            Array.Copy(array,index, subset, 0, count);
+            return subset;
+        }
+    }
+}

--- a/src/Math/BigIntCalculator.cs
+++ b/src/Math/BigIntCalculator.cs
@@ -58,6 +58,17 @@ namespace SecretSharingDotNet.Math
         public override bool EqualOrLowerThan(BigInteger right) => this.Value <= right;
 
         /// <summary>
+        /// Compares this instance to a second <see cref="Calculator{BigInteger}"/> and returns an integer that
+        /// indicates whether the value of this instance is less than, equal to, or greater than the value of the specified object.
+        /// </summary>
+        /// <param name="other">The object to compare</param>
+        /// <returns>A signed integer value that indicates the relationship of this instance to <paramref name="other"/>parameter</returns>
+        public override int CompareTo(Calculator<BigInteger> other)
+        {
+            return this.Value.CompareTo(other?.Value ?? throw new ArgumentNullException(nameof(other)));
+        }
+
+        /// <summary>
         /// Adds the current <see cref="BigIntCalculator"/> instance with the <paramref name="right"/>
         /// <see cref="BigIntCalculator"/> instance.
         /// </summary>

--- a/src/Math/Calculator.cs
+++ b/src/Math/Calculator.cs
@@ -12,6 +12,7 @@ namespace SecretSharingDotNet.Math
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Linq.Expressions;
     using System.Reflection;
 
     /// <summary>
@@ -30,6 +31,11 @@ namespace SecretSharingDotNet.Math
         /// Gets the number of elements of the byte representation of the <see cref="Calculator"/> object.
         /// </summary>
         public abstract int ByteCount { get; }
+
+        /// <summary>
+        /// Saves a dictionary of constructors of number data types derived from the <see cref="Calculator{TNumber}"/> class.
+        /// </summary>
+        protected static readonly ReadOnlyDictionary<Type, Func<byte[], Calculator>> ChildBaseCtors = new ReadOnlyDictionary<Type, Func<byte[], Calculator>>(GetDerivedCtors<byte[], Calculator>());
 
         /// <summary>
         /// Gets the byte representation of the <see cref="Calculator"/> object.
@@ -62,9 +68,26 @@ namespace SecretSharingDotNet.Math
         /// <param name="data">byte array representation of the <paramref name="numberType"/></param>
         /// <param name="numberType">Type of number</param>
         /// <returns></returns>
-        public static Calculator Create(byte[] data, Type numberType)
+        public static Calculator Create(byte[] data, Type numberType) => ChildBaseCtors[numberType](data);
+
+        /// <summary>
+        /// Returns a dictionary of constructors of number data types derived from the <see cref="Calculator"/> class.
+        /// </summary>
+        /// <returns></returns>
+        protected static Dictionary<Type, Func<TParameter, TCalculator>> GetDerivedCtors<TParameter, TCalculator>() where TCalculator : Calculator
         {
-            return Activator.CreateInstance(ChildTypes[numberType], data) as Calculator;
+            var res = new Dictionary<Type, Func<TParameter, TCalculator>>(ChildTypes.Count);
+            var paramType = typeof(TParameter);
+            var parameterExpression = Expression.Parameter(paramType);
+            foreach (var childType in ChildTypes)
+            {
+                var ctorInfo = childType.Value.GetConstructor(new[] { paramType });
+                var ctor = Expression.Lambda<Func<TParameter, TCalculator>>(Expression.New(ctorInfo, parameterExpression), parameterExpression)
+                    .Compile();
+                res.Add(childType.Key, ctor);
+            }
+
+            return res;
         }
 
         /// <summary>
@@ -74,7 +97,7 @@ namespace SecretSharingDotNet.Math
         /// <remarks>The key represents the integer data type of the derived calculator. The value represents the type of derived calculator.</remarks>
         private static Dictionary<Type, Type> GetDerivedNumberTypes()
         {
-            Assembly asm = Assembly.GetAssembly(typeof(Calculator));
+            var asm = Assembly.GetAssembly(typeof(Calculator));
             var listOfClasses = asm.GetTypes().Where(x => x.IsSubclassOf(typeof(Calculator)) && !x.IsGenericType);
             return listOfClasses.ToDictionary(x => x.BaseType?.GetGenericArguments()[0]);
         }
@@ -87,6 +110,11 @@ namespace SecretSharingDotNet.Math
     /// <typeparam name="TNumber">Numeric data type</typeparam>
     public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TNumber>>, IComparable, IComparable<Calculator<TNumber>>
     {
+        /// <summary>
+        /// Saves a dictionary of constructors of number data types derived from the <see cref="Calculator{TNumber}"/> class.
+        /// </summary>
+        protected static readonly ReadOnlyDictionary<Type, Func<TNumber, Calculator<TNumber>>> ChildCtors = new ReadOnlyDictionary<Type, Func<TNumber, Calculator<TNumber>>>(GetDerivedCtors<TNumber, Calculator<TNumber>>());
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Calculator{TNumber}"/> class.
         /// </summary>
@@ -326,7 +354,7 @@ namespace SecretSharingDotNet.Math
         {
             try
             {
-                return Activator.CreateInstance(ChildTypes[typeof(TNumber)], number) as Calculator<TNumber>;
+                return ChildCtors[typeof(TNumber)](number);
             }
             catch (KeyNotFoundException)
             {

--- a/src/Math/Calculator.cs
+++ b/src/Math/Calculator.cs
@@ -85,7 +85,7 @@ namespace SecretSharingDotNet.Math
     /// implementation from the concrete numeric data type like BigInteger.
     /// </summary>
     /// <typeparam name="TNumber">Numeric data type</typeparam>
-    public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TNumber>>
+    public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TNumber>>, IComparable, IComparable<Calculator<TNumber>>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Calculator{TNumber}"/> class.
@@ -369,6 +369,25 @@ namespace SecretSharingDotNet.Math
         public override int GetHashCode() => this.Value.GetHashCode();
 
         /// <summary>
+        /// Compares this instance to a specified object and returns an integer that
+        /// indicates whether the value of this instance is less than, equal to, or greater than the value of the specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare</param>
+        /// <returns>A signed integer that indicates the relationship of the current instance to the <paramref name="obj"/> parameter</returns>
+        public virtual int CompareTo(object obj)
+        {
+            switch (obj)
+            {
+                case null:
+                    return 1;
+                case TNumber number:
+                    return this.CompareTo(number);
+                default:
+                    throw new ArgumentException();
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the numeric value
         /// </summary>
         public TNumber Value { get; set; }
@@ -394,6 +413,13 @@ namespace SecretSharingDotNet.Math
         /// </summary>
         /// <returns></returns>
         public Calculator<TNumber> Clone() => this.MemberwiseClone() as Calculator<TNumber>;
+
+        /// <summary>
+        /// Compares this instance to a second <see cref="Calculator{TNumber}"/> and returns an integer that indicates whether the value of this instance is less than, equal to, or greater than the value of the specified object.
+        /// </summary>
+        /// <param name="other">The object to compare.</param>
+        /// <returns>A signed integer that indicates the relationship of the current instance to the <paramref name="other"/> parameter</returns>
+        public abstract int CompareTo(Calculator<TNumber> other);
 
         /// <summary>
         /// Converts the numeric value of the current <see cref="Calculator{TNumber}"/> object to its equivalent string representation.

--- a/src/SecretSharingDotNetFx4.6.2.csproj
+++ b/src/SecretSharingDotNetFx4.6.2.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Cryptography\ShamirsSecretSharing.cs" />
     <Compile Include="Cryptography\SharesEnumerator.cs" />
     <Compile Include="Cryptography\Shares.cs" />
+    <Compile Include="Helper\Extensions.cs" />
     <Compile Include="Math\BigIntCalculator.cs" />
     <Compile Include="Math\Calculator.cs" />
     <Compile Include="Math\ExtendedEuclideanAlgorithm.cs" />
@@ -59,5 +60,6 @@
   <ItemGroup>
     <None Include="SecretSharingDotNet.snk" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/SecretTest.cs
+++ b/tests/SecretTest.cs
@@ -1,6 +1,6 @@
 // ----------------------------------------------------------------------------
 // <copyright file="SecretTest.cs" company="Private">
-// Copyright (c) 2019 All Rights Reserved
+// Copyright (c) 2022 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
 // <date>04/20/2019 10:52:28 PM</date>
@@ -8,7 +8,7 @@
 
 #region License
 // ----------------------------------------------------------------------------
-// Copyright 2019 Sebastian Walther
+// Copyright 2022 Sebastian Walther
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -31,9 +31,10 @@
 
 namespace SecretSharingDotNet.Test
 {
-    using System.Numerics;
     using Cryptography;
     using Math;
+    using System.Linq;
+    using System.Numerics;
     using Xunit;
 
     public class SecretTest
@@ -185,21 +186,35 @@ namespace SecretSharingDotNet.Test
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-        [Fact]
-        public void TestSecretNumber()
+        [Theory]
+        [MemberData(nameof(TestData.MixedSecrets), MemberType = typeof(TestData))]
+        public void TestSecretSourceConversion(object secretSource)
         {
-            BigInteger number = 2007671;
-            Secret<BigInteger> secret = number;
-            Assert.Equal(number, (BigInteger)secret);
-        }
+            Secret<BigInteger> secret1 = null;
+            switch (secretSource)
+            {
+                case string password:
+                    secret1 = password;
+                    Assert.Equal(password, secret1);
+                    break;
+                case BigInteger bigNumber:
+                    secret1 = bigNumber;
+                    Assert.Equal(bigNumber, (BigInteger)secret1);
+                    break;
+                case int number:
+                    secret1 = (BigInteger)number;
+                    Assert.Equal(number, (BigInteger)secret1);
+                    break;
+                case byte[] bytes1:
+                    secret1 = new Secret<BigInteger>(bytes1);
+                    byte[] bytes2 = secret1;
+                    Assert.True(bytes1.SequenceEqual(bytes2));
+                    break;
+                case null:
+                    return;
+            }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-        [Fact]
-        public void TestSecretBase64()
-        {
-            BigInteger number = 333331;
-            Secret<BigInteger> secret1 = number;
-            string base64 = secret1.ToBase64();
+            string base64 = secret1?.ToBase64();
             Secret<BigInteger> secret2 = new Secret<BigInteger>(base64);
             Assert.Equal(base64, secret2.ToBase64());
         }

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -1,6 +1,6 @@
 // ----------------------------------------------------------------------------
 // <copyright file="ShamirsSecretSharingTest.cs" company="Private">
-// Copyright (c) 2019 All Rights Reserved
+// Copyright (c) 2022 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
 // <date>04/20/2019 10:52:28 PM</date>
@@ -8,7 +8,7 @@
 
 #region License
 // ----------------------------------------------------------------------------
-// Copyright 2019 Sebastian Walther
+// Copyright 2022 Sebastian Walther
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -52,7 +52,8 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void TestDivMod()
         {
-            Calculator<BigInteger> DivMod(Calculator<BigInteger> denominator, Calculator<BigInteger> numerator, Calculator<BigInteger> prime)
+            Calculator<BigInteger> DivMod(Calculator<BigInteger> denominator, Calculator<BigInteger> numerator,
+                Calculator<BigInteger> prime)
             {
                 var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
                 var result = gcd.Compute(denominator, prime);
@@ -144,7 +145,8 @@ namespace SecretSharingDotNet.Test
         [MemberData(nameof(TestData.TestPasswordData), MemberType = typeof(TestData))]
         public void TestWithPassword(int splitSecurityLevel, int expectedSecurityLevel, string password)
         {
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), splitSecurityLevel);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(),
+                splitSecurityLevel);
             var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
             var shares = split.MakeShares(3, 7, password);
             Assert.True(shares.OriginalSecretExists);
@@ -171,7 +173,8 @@ namespace SecretSharingDotNet.Test
         [MemberData(nameof(TestData.TestNumberData), MemberType = typeof(TestData))]
         public void TestWithNumber(int splitSecurityLevel, int expectedSecurityLevel, BigInteger number)
         {
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), splitSecurityLevel);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(),
+                splitSecurityLevel);
             var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
             var shares = split.MakeShares(3, 7, number);
             Assert.True(shares.OriginalSecretExists);
@@ -198,8 +201,11 @@ namespace SecretSharingDotNet.Test
         [MemberData(nameof(TestData.TestRandomSecretData), MemberType = typeof(TestData))]
         public void TestWithRandomSecret(int splitSecurityLevel, int combineSecurityLevel, int expectedSecurityLevel)
         {
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), splitSecurityLevel);
-            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), combineSecurityLevel);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(),
+                splitSecurityLevel);
+            var combine =
+                new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(),
+                    combineSecurityLevel);
             var shares = split.MakeShares(3, 7);
             Assert.True(shares.OriginalSecretExists);
             Assert.NotNull(shares.OriginalSecret);
@@ -232,10 +238,24 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void TestMinimumSharedSecretsReconstruction()
         {
-            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 5);
+            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 13);
             var shares = sss.MakeShares(2, 7);
-            var subSet1 = shares.Where(p => p.X == Calculator<BigInteger>.One).ToList();
-            Assert.Throws<ArgumentOutOfRangeException>(() => sss.Reconstruction(subSet1.ToArray()));
+            var subSet = shares.Where(p => p.X == Calculator<BigInteger>.One).ToList();
+            Assert.Throws<ArgumentOutOfRangeException>(() => sss.Reconstruction(subSet.ToArray()));
+        }
+
+        /// <summary>
+        /// Tests
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
+        [Fact]
+        public void TestShareThreshold()
+        {
+            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 51);
+            var shares = sss.MakeShares(3, 7);
+            var subSet = shares.Take(2).ToList();
+            var secret = sss.Reconstruction(subSet.ToArray());
+            Assert.NotEqual(shares.OriginalSecret, secret);
         }
 
         /// <summary>
@@ -257,7 +277,8 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void MaximumExceeded()
         {
-            const string longSecret = "-----BEGIN EC PRIVATE KEY-----MIIBUQIBAQQgxq7AWG9L6uleuTB9q5FGqnHjXF+kD4y9154SLYYKMDqggeMwgeACAQEwLAYHKoZIzj0BAQIhAP////////////////////////////////////7///wvMEQEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwRBBHm+Zn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW+BeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////+uq7c5q9IoDu/0l6M0DZBQQIBAaFEA0IABE0XO6I8lZYzXqRQnHP/knSwLex7q77g4J2AN0cVyrADicGlUr6QjVIlIu9NXCHxD2i++ToWjO1zLVdxgNJbUUc=-----END EC PRIVATE KEY-----";
+            const string longSecret =
+                "-----BEGIN EC PRIVATE KEY-----MIIBUQIBAQQgxq7AWG9L6uleuTB9q5FGqnHjXF+kD4y9154SLYYKMDqggeMwgeACAQEwLAYHKoZIzj0BAQIhAP////////////////////////////////////7///wvMEQEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwRBBHm+Zn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW+BeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////+uq7c5q9IoDu/0l6M0DZBQQIBAaFEA0IABE0XO6I8lZYzXqRQnHP/knSwLex7q77g4J2AN0cVyrADicGlUr6QjVIlIu9NXCHxD2i++ToWjO1zLVdxgNJbUUc=-----END EC PRIVATE KEY-----";
             var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 1024);
             var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 5);
             var shares = split.MakeShares(3, 7, longSecret);
@@ -279,6 +300,26 @@ namespace SecretSharingDotNet.Test
             var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
             var secret = combine.Reconstruction(TestData.GetPredefinedShares());
             Assert.Equal(TestData.DefaultTestPassword, secret);
+        }
+
+        /// <summary>
+        /// Tests the secret reconstruction from array of shares represented by strings (legacy mode to compatible to v0.6.0 or older)
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
+        [Fact]
+        public void TestReconstructFromStringArrayLegacy()
+        {
+            Secret.LegacyMode.Value = true;
+            try
+            {
+                var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+                var secret = combine.Reconstruction(TestData.GetPredefinedSharesLegacy());
+                Assert.Equal(TestData.DefaultTestPassword, secret);
+            }
+            finally
+            {
+                Secret.LegacyMode.Value = false;
+            }
         }
 
         /// <summary>
@@ -326,6 +367,24 @@ namespace SecretSharingDotNet.Test
             }
 
             Assert.Equal(1.0, (double)ok / total);
+        }
+
+        /// <summary>
+        /// Tests whether or not bug #60 occurs [Reconstruction fails at random].
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(TestData.ByteArraySize), MemberType = typeof(TestData))]
+        public void ReconstructionFailsAtRndLegacy(int byteArraySize)
+        {
+            Secret.LegacyMode.Value = true;
+            try
+            {
+                ReconstructionFailsAtRnd(byteArraySize);
+            }
+            finally
+            {
+                Secret.LegacyMode.Value = false;
+            }
         }
     }
 }

--- a/tests/TestData.cs
+++ b/tests/TestData.cs
@@ -1,6 +1,6 @@
 ﻿// ----------------------------------------------------------------------------
 // <copyright file="SharesTest.cs" company="Private">
-// Copyright (c) 2021 All Rights Reserved
+// Copyright (c) 2022 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
 // <date>05/12/2021 5:54:09 PM</date>
@@ -8,7 +8,7 @@
 
 #region License
 // ----------------------------------------------------------------------------
-// Copyright 2019 Sebastian Walther
+// Copyright 2022 Sebastian Walther
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -42,30 +42,49 @@ namespace SecretSharingDotNet
         public const string DefaultTestPassword = "Hello World!!";
 
         /// <summary>
-        /// A test number as secret (value is 2000).
+        /// A positive test number as secret (value is 2000).
         /// </summary>
-        public static BigInteger TestNumber => 20000;
+        public static BigInteger DefaultPosTestNumber => 20000;
 
         /// <summary>
-        /// Gets a list of data for tests with number as secret
+        /// A negative test number as secret (value is 2000).
+        /// </summary>
+        public static BigInteger DefaultNegTestNumber => -20000;
+
+        /// <summary>
+        /// Gets a list of data for tests with number as secret.
+        /// Provides also split security level followed by expected split security level.
         /// </summary>
         public static IEnumerable<object[]> TestNumberData =>
             new List<object[]>
             {
-                new object[] {5, 17, TestNumber},
-                new object[] {17, 17, TestNumber},
-                new object[] {127, 127, TestNumber},
-                new object[] {130, 521, TestNumber},
-                new object[] {500, 521, TestNumber},
-                new object[] {1279, 1279, TestNumber}
+                new object[] {5, 31, DefaultPosTestNumber},
+                new object[] {17, 31, DefaultPosTestNumber},
+                new object[] {127, 127, DefaultPosTestNumber},
+                new object[] {130, 521, DefaultPosTestNumber},
+                new object[] {500, 521, DefaultPosTestNumber},
+                new object[] {1279, 1279, DefaultPosTestNumber},
+
+                new object[] {5, 31, DefaultNegTestNumber},
+                new object[] {17, 31, DefaultNegTestNumber},
+                new object[] {127, 127, DefaultNegTestNumber},
+                new object[] {130, 521, DefaultNegTestNumber},
+                new object[] {500, 521, DefaultNegTestNumber},
+                new object[] {1279, 1279, DefaultNegTestNumber }
             };
 
         /// <summary>
-        /// Gets a list of data for tests with string as secret
+        /// Gets a list of data for tests with strings as secret
+        /// Provides also split security level followed by expected split security level.
         /// </summary>
         public static IEnumerable<object[]> TestPasswordData =>
             new List<object[]>
             {
+                new object[] {5, 31, " "},
+                new object[] {5, 31, "0"},
+                new object[] {5, 31, "A"},
+                new object[] {5, 31, "Z"},
+                new object[] {5, 31, "ÿ"},
                 new object[] {5, 521, DefaultTestPassword},
                 new object[] {17, 521, DefaultTestPassword},
                 new object[] {127, 521, DefaultTestPassword},
@@ -76,11 +95,14 @@ namespace SecretSharingDotNet
 
         /// <summary>
         /// Gets a list of data for tests with random secret
+        /// Provides also split security level, combine security level followed by expected security level.
         /// </summary>
         public static IEnumerable<object[]> TestRandomSecretData =>
             new List<object[]>
             {
-                new object[] {5, 32, 5},
+                new object[] {5, 32, 13},
+                new object[] {7, 32, 13},
+                new object[] {13, 32, 13},
                 new object[] {17, 521, 17},
                 new object[] {127, 521, 127},
                 new object[] {130, 5, 521},
@@ -96,7 +118,7 @@ namespace SecretSharingDotNet
         public static IEnumerable<object[]> SecurityLevelAutoDetectionData =>
             new List<object[]>
             {
-                new object[] {TestNumber, 17},
+                new object[] {DefaultPosTestNumber, 31},
                 new object[] {DefaultTestPassword, 521},
             };
 
@@ -104,6 +126,21 @@ namespace SecretSharingDotNet
         /// A set of pre-defined shares for reconstruction tests
         /// </summary>
         public static string[] GetPredefinedShares() => new[]
+        {
+            "01-0131621CFFE838F31347293CC1093C91C7BF50F64AD0F3F09AAF1844F26EECC7F84A23376E5786E8B34DDDFAC957F025201A42114D4C114B42DBC70B96453A19D600",
+            "02-520CE6164D5030CC3670DE39F29EE241A5CC70B5FE5001C1C33A6551C5DE34065B486FAAEA4B51C738352496E78F36096915FF7FE6870E741B859AE72C8D0EF1BC01",
+            "03-3C92F0EF5536528BD77B3FF9E9BF62120B27CC3D7F8249709BA15D28794FD9BA26F8E35975DD609C8EB6D4D158A8D2A9DAF1364CCCB2F77A8BFD7793C4D67C87B400",
+            "04-BDC281A7199B9E30F6694C7AA86CBC02F9CE628FCC64CCFE21E401C90DC1D9E55B5A81450E0CB567B5D1EEAD1DA1C40775AFE975FECCCC5F9244600F5D2285DCBC01",
+            "05-D79D993D987E15BC923A05BD2DA5EF126FC434AAE6F7896C5702523383333687FA6E476DB5D74D29AD86722A367A0C23384E17FD7CD68D22305A535BF66F27F0D500",
+            "06-882338B2D1E0B62DADED69C17969FC426D07428ECD3B82B93BFC4D67D9A6EE9E023636D16A402BE175D55F47A233AAFB23CEBFE147CF3AC3643E517790BF63C2FF01",
+            "07-D2535D05C6C1828545837A878CB9E292F3978A3B8130B5E5CED1F564101B032D74AF4D712E464D8F0FBEB60462CD9D91382FE3235FB7D34130F159632B113A533A01"
+
+        };
+
+        /// <summary>
+        /// A set of pre-defined shares for reconstruction tests (Legacy mode for v0.6.0 or older)
+        /// </summary>
+        public static string[] GetPredefinedSharesLegacy() => new[]
         {
             "01-A096198683E02AA999D66B4710E69E0118EB81511E5971B3DFA1916DBC00A1B2B12F21802A4B350A562DFDD0376A2D930FCD5AFFEFA553FEB0F739F063B452E962",
             "02-D71CFE40BF6AB68BF92C24E9D5C8C5C3AB02714E9C001761B0F71D2C627995E65932DB4EE3F85827C14CD756B6D1D4731F4E5E442E97717C21975A062C6EB9910201",
@@ -127,6 +164,24 @@ namespace SecretSharingDotNet
                 new object[] { 64},
                 new object[] { 77},
                 new object[] { 128}
+            };
+
+        /// <summary>
+        /// Gets a list of secrets of different data types
+        /// </summary>
+        public static IEnumerable<object[]> MixedSecrets =>
+            new List<object[]>
+            {
+                new object[] { 333331},
+                new object[] { -333331},
+                new object[] { 2007671},
+                new object[] { new BigInteger(2007671)},
+                new object[] { new BigInteger(-2007671)},
+                new object[] { DefaultPosTestNumber},
+                new object[] { DefaultNegTestNumber},
+                new object[] { DefaultTestPassword},
+                new object[] { new byte[] {0x00}},
+                new object[] { new byte[] {0xFF, 0XFF}},
             };
     }
 }


### PR DESCRIPTION
### Added
- Added implicit casts for byte arrays in Secret class.
- Added legacy mode. See section [Attention](#attention) below.

### Changed
- Changed behavior of Secret class for negative secret values. See section [Attention](#attention) below and bug report [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) for more details.
- Changed calculation of maximum security level in Reconstruction method.

### Fixed
- Fixed reopened bug [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) "Reconstruction fails at random".


<hr/>

### Attention

Library version 0.7.0 introduces a normal mode and a legacy mode for secrets. The normal mode is the new and default mode. The legacy mode is for backward compatibility.

*Why was the normal mode introduced?*

The normal mode supports positive secret values and also negative secret values like negative integer numbers or byte arrays with most significant byte greater than 0x7F. The legacy mode generates shares that can't be used to reconstruct negative secret values. So the original secret and the reconstructed secret aren't identical for negative secret values (e.g. `BigInetger secret = -2000`). The legacy mode only returns correct results for positive secret values.

*Mode overview*

* **Normal mode** (`Secret.LegacyMode.Value = false`):
  * Shares generated with v0.7.0 or later *cannot* be used with v0.6.0 or earlier to reconstruct the secret.
  * Shares generated with v0.6.0 or earlier *cannot* be used with v0.7.0 or later to reconstruct the secret.
  * This mode supports security level 13 as minimum.
* **Legacy mode:** (`Secret.LegacyMode.Value = true`):
  * Shares generated with v0.7.0 or later *can* be used with v0.6.0 or earlier to reconstruct the secret.
  * Shares generated with v0.6.0 or earlier *can* be used with v0.7.0 or later to reconstruct the secret.
  * This mode supports security level 5 as minimum.

A mixed mode is not possible. It is recommended to reconstruct the secret with the old procedure and to split again with the new procedure.

The legacy mode is thread-safe, but not task-safe.

For further details see the example below:

```csharp
using System;
using System.Collections.Generic;
using System.Linq;
using System.Numerics;

using SecretSharingDotNet.Cryptography;
using SecretSharingDotNet.Math;

namespace LegacyModeExample
{
  public class Program
  {
    public static void Main(string[] args)
    {
      //// Legacy mode on / normal mode off
      Secret.LegacyMode.Value = true
      try
      {
        var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();

        var split = new ShamirsSecretSharing<BigInteger>(gcd);

        string password = "Hello World!!";
        
        var shares = split.MakeShares(3, 7, password);

        var combine = new ShamirsSecretSharing<BigInteger>(gcd);
        var subSet = shares.Where(p => p.X.IsEven).ToList();
        var recoveredSecret = combine.Reconstruction(subSet.ToArray());

      }
      finally
      {
        //// Legacy mode off / normal mode on
        Secret.LegacyMode.Value = false
      }
    }
  }
}
```