### PR TITLE
Fix assembly output path for .NET FX 4.6.2 version in project file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed reopened bug [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) "Reconstruction fails at random".
+- Fixed assembly output path `in SecretSharingDotNetFx4.6.2.csproj`
 
 ### Removed
 - Removed .NET FX 4.5.2 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).

--- a/src/SecretSharingDotNetFx4.6.2.csproj
+++ b/src/SecretSharingDotNetFx4.6.2.csproj
@@ -18,7 +18,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\NetFx4.5.2</OutputPath>
+    <OutputPath>bin\Debug\NetFx4.6.2</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\NetFx4.5.2</OutputPath>
+    <OutputPath>bin\Release\NetFx4.6.2</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
The output path of the SecretSharingDotNet assembly for .NET FX 4.6.2 was wrong. The assembly was stored in the directory for the SecretSharingDotNet .NET FX 4.5.2 assembly.

Now the path is updated to correct directory.
