### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2022-02-09
 ### Added
-- Added implicit casts for byte arrays in Secret class.
+- Added implicit casts for byte arrays in *Secret* class.
 - Added legacy mode. See README.md, section "Usage" for more details.
 
 ### Changed
-- Changed behavior of Secret class for negative secret values. See README.md, section "Usage" and bug report [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) for more details.
+- Changed behavior of *Secret* class for negative secret values. See README.md, section "Usage" and bug report [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) for more details.
 - Changed calculation of maximum security level in Reconstruction method.
 
 ### Fixed
 - Fixed reopened bug [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) "Reconstruction fails at random".
-- Fixed assembly output path `in SecretSharingDotNetFx4.6.2.csproj`
+- Fixed assembly output path in `SecretSharingDotNetFx4.6.2.csproj`
 
 ### Removed
 - Removed .NET FX 4.5.2 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=10><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.6.0" alt="SecretSharingDotNet NuGet"/></a></td>
-          <td rowspan=10><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.6.0"/></a></td>
-          <td rowspan=10><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.6.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.6.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=10><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.7.0" alt="SecretSharingDotNet NuGet"/></a></td>
+          <td rowspan=10><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.7.0"/></a></td>
+          <td rowspan=10><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.7.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.7.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
@@ -120,10 +120,10 @@ An C# implementation of Shamir's Secret Sharing.
 
 1. Open a console and switch to the directory, containing your project file.
 
-2. Use the following command to install version 0.6.0 of the SecretSharingDotNet package:
+2. Use the following command to install version 0.7.0 of the SecretSharingDotNet package:
 
     ```dotnetcli
-    dotnet add package SecretSharingDotNet -v 0.6.0 -f <FRAMEWORK>
+    dotnet add package SecretSharingDotNet -v 0.7.0 -f <FRAMEWORK>
     ```
 
 3. After the completition of the command, look at the project file to make sure that the package is successfuly installed.
@@ -132,7 +132,7 @@ An C# implementation of Shamir's Secret Sharing.
 
     ```xml
     <ItemGroup>
-      <PackageReference Include="SecretSharingDotNet" Version="0.6.0" />
+      <PackageReference Include="SecretSharingDotNet" Version="0.7.0" />
     </ItemGroup>
     ```
 ## Remove SecretSharingDotNet package

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("1c21b99c-2de4-4ca5-b4ce-bc95cf89369e")]
 
-[assembly: AssemblyVersion("0.6.0")]
-[assembly: AssemblyFileVersion("0.6.0")]
+[assembly: AssemblyVersion("0.7.0")]
+[assembly: AssemblyFileVersion("0.7.0")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -9,14 +9,14 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>SecretSharingDotNet</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>Added support for .NET 6. Removed .NET Core 2.1 (LTS) support. Uses RandomNumberGenerator class instead RNGCryptoServiceProvider class to create the polynomial. Fixed bug #60 "Reconstruction fails at random" (base64 only).</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed reopened bug #60 "Reconstruction fails at random". Added implicit casts for byte arrays in Secret class. Added legacy mode. Changed calculation of maximum security level in Reconstruction method. Remove support for .NET FX 4.5.2, 4.6 and 4.6.2.</PackageReleaseNotes>
     <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
     <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>Sebastian Walther</Authors>
     <Company>Private Person</Company>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -11,6 +11,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>Added support for .NET 6. Removed .NET Core 2.1 (LTS) support. Uses RandomNumberGenerator class instead RNGCryptoServiceProvider class to create the polynomial. Fixed bug #60 "Reconstruction fails at random" (base64 only).</PackageReleaseNotes>
     <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
     <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
@@ -20,6 +21,10 @@
     <Company>Private Person</Company>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">


### PR DESCRIPTION
### Added
- Added implicit casts for byte arrays in *Secret* class.
- Added legacy mode. See README.md, section "Usage" for more details.

### Changed
- Changed behavior of *Secret* class for negative secret values. See README.md, section "Usage" and bug report [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) for more details.
- Changed calculation of maximum security level in Reconstruction method.

### Fixed
- Fixed reopened bug [#60](https://github.com/shinji-san/SecretSharingDotNet/issues/60) "Reconstruction fails at random".
- Fixed assembly output path in `SecretSharingDotNetFx4.6.2.csproj`

### Removed
- Removed .NET FX 4.5.2 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).
- Removed .NET FX 4.6 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).
- Removed .NET FX 4.6.1 support, because it retires on April 26, 2022. See [.NET FX Lifecycle Policy](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).