### PR TITLE
Added/Changed  - Examples in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added more examples in the section *Usage* of the `README.md` file to explain the use of shares and the use of the new type casting from byte array to secret and vice versa.
+
+### Changed
+- Changed existing examples in the section *Usage* of the `README.md` file to explain the use and the type casting of recovered secrets.
+
 ## [0.7.0] - 2022-02-09
 ### Added
 - Added implicit casts for byte arrays in *Secret* class.


### PR DESCRIPTION
### Added
- Added more examples in the section *Usage* of the `README.md` file to explain the use of shares and the use of the new type casting from byte array to secret and vice versa.

### Changed
- Changed existing examples in the section *Usage* of the `README.md` file to explain the use and the type casting of recovered secrets.
