### PR TITLE
Fix - GitHub Workflow: Switch back from windows-2022  to windows-2019 workflow

### DIFF
--- a/.github/workflows/dotnetfx.yml
+++ b/.github/workflows/dotnetfx.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
     
     steps:
       - name: checkout


### PR DESCRIPTION
The *windows-2022* workflow doesn't support .NET FX and CodeQL.

