### PR TITLE
Fix - Issue #72: Bug with different numbers in secureLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added more examples in the section *Usage* of the `README.md` file to explain the use of shares and the use of the new type casting from byte array to secret and vice versa.
+- Added method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel)`
+- Added method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret, int securityLevel)`
 
 ### Changed
 - Changed existing examples in the section *Usage* of the `README.md` file to explain the use and the type casting of recovered secrets.
+- Changed ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd)`. This ctor sets the SecurityLevel to 13.
+
+### Deprecated
+- Ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd, int securityLevel)` is deprecated.
+- Method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares)` is deprecated.
 
 ## [0.7.0] - 2022-02-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -243,12 +243,12 @@ namespace Example1
       var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
 
       //// Create Shamir's Secret Sharing instance with BigInteger
-      //// and security level 127 (Mersenne prime exponent)
-      var split = new ShamirsSecretSharing<BigInteger>(gcd, 127);
+      var split = new ShamirsSecretSharing<BigInteger>(gcd);
 
       //// Minimum number of shared secrets for reconstruction: 3
       //// Maximum number of shared secrets: 7
-      var shares = split.MakeShares(3, 7);
+      //// Security level: 127 (Mersenne prime exponent)
+      var shares = split.MakeShares(3, 7, 127);
 
       //// The property 'shares.OriginalSecret' represents the random secret
       var secret = shares.OriginalSecret;
@@ -310,7 +310,8 @@ namespace Example2
       string password = "Hello World!!";
       //// Minimum number of shared secrets for reconstruction: 3
       //// Maximum number of shared secrets: 7
-      //// Attention: The password length changes the security level set by the ctor
+      //// Attention: The password length can change the security level set by the ctor
+      //// or SecurityLevel property.
       var shares = split.MakeShares(3, 7, password);
 
       //// The property 'shares.OriginalSecret' represents the original password
@@ -357,14 +358,16 @@ namespace Example3
       var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
 
       //// Create Shamir's Secret Sharing instance with BigInteger
-      //// and security level 521 (Mersenne prime exponent)
-      var split = new ShamirsSecretSharing<BigInteger>(gcd, 521);
+      //// and 
+      var split = new ShamirsSecretSharing<BigInteger>(gcd);
 
       BigInteger number = 20000;
       //// Minimum number of shared secrets for reconstruction: 3
       //// Maximum number of shared secrets: 7
-      //// Attention: The number size changes the security level set by the ctor
-      var shares = split.MakeShares (3, 7, number);
+      //// Security level: 521 (Mersenne prime exponent)
+      //// Attention: The size of the number can change the security level set by the ctor
+      //// or SecurityLevel property.
+      var shares = split.MakeShares (3, 7, number, 521);
 
       //// The property 'shares.OriginalSecret' represents the number (original secret)
       var secret = shares.OriginalSecret;

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -104,6 +104,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <summary>
         /// Gets or sets the security level
         /// </summary>
+        /// <remarks>Value is lower than 5 or greater than 43112609.</remarks>
         /// <exception cref="T:System.ArgumentOutOfRangeException" accessor="set">Value is lower than 5 or greater than 43112609.</exception>
         public int SecurityLevel
         {
@@ -144,6 +145,7 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
         /// <param name="numberOfShares">Maximum number of shared secrets</param>
+        /// <param name="securityLevel">Security level (in number of bits). Minimum is 5 for legacy mode and 13 for normal mode.</param>
         /// <returns></returns>
         /// <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="securityLevel"/> parameter is lower than 5 or greater than 43112609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.</exception>
         public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel)
@@ -205,7 +207,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="secret">secret text as <see cref="Secret{TNumber}"/> or see cref="string"/></param>
         /// <param name="securityLevel">Security level (in number of bits). Minimum is 5 for legacy mode and 13 for normal mode.</param>
         /// <returns></returns>
-        /// <remarks>This method modifies the <see cref="SecurityLevel"/> based on the <paramref name="secret"/> length</remarks>
+        /// <remarks>This method can modify the <see cref="SecurityLevel"/> based on the <paramref name="secret"/> length.</remarks>
         /// <exception cref="T:System.ArgumentNullException">The <paramref name="secret"/> parameter is <see langword="null"/>.</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="securityLevel"/> is lower than 5 or greater than 43112609. OR <paramref name="numberOfMinimumShares"/> is lower than 2 or greater than <paramref name="numberOfShares"/>.</exception>
         public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret, int securityLevel)
@@ -230,7 +232,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="secret">secret text as <see cref="Secret{TNumber}"/> or see cref="string"/></param>
         /// <returns></returns>
         /// <remarks>This method modifies the <see cref="SecurityLevel"/> based on the <paramref name="secret"/> length</remarks>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="secret"/> is <see langword="null"/></exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="secret"/> is <see langword="null"/>.</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="numberOfMinimumShares"/> is lower than 2 or greater than <paramref name="numberOfShares"/>.</exception>
         public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret)
         {

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -56,9 +56,9 @@ namespace SecretSharingDotNet.Cryptography
         });
 
         /// <summary>
-        /// Saves the security level
+        /// Saves the fixed security level
         /// </summary>
-        private int securityLevel;
+        private int fixedSecurityLevel;
 
         /// <summary>
         /// Saves the calculated mersenne prime
@@ -104,7 +104,7 @@ namespace SecretSharingDotNet.Cryptography
         /// <exception cref="T:System.ArgumentOutOfRangeException" accessor="set">Value is lower than 5 or greater than 43112609.</exception>
         public int SecurityLevel
         {
-            get => this.securityLevel;
+            get => this.fixedSecurityLevel;
 
             set
             {
@@ -132,7 +132,7 @@ namespace SecretSharingDotNet.Cryptography
                 }
 
                 this.mersennePrime = Calculator<TNumber>.Two.Pow(value) - Calculator<TNumber>.One;
-                this.securityLevel = value;
+                this.fixedSecurityLevel = value;
             }
         }
 

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -113,7 +113,7 @@ namespace SecretSharingDotNet.Cryptography
             {
                 if (value < 5)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, "Minimum exceeded!");
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "Minimum security level exceeded!");
                 }
 
                 if (!Secret.LegacyMode.Value && value < 13)
@@ -130,7 +130,7 @@ namespace SecretSharingDotNet.Cryptography
                     }
                     catch (ArgumentOutOfRangeException)
                     {
-                        throw new ArgumentOutOfRangeException(nameof(value), value, "Maximum exceeded!");
+                        throw new ArgumentOutOfRangeException(nameof(value), value, "Maximum security level exceeded!");
                     }
                 }
 
@@ -177,12 +177,12 @@ namespace SecretSharingDotNet.Cryptography
             Calculator<TNumber> max = numberOfShares;
             if (min < Calculator<TNumber>.Two)
             {
-                throw new ArgumentOutOfRangeException(nameof(numberOfMinimumShares));
+                throw new ArgumentOutOfRangeException(nameof(numberOfMinimumShares), numberOfMinimumShares, "The minimum number of shares is lower than 2.");
             }
 
             if (min > max)
             {
-                throw new ArgumentOutOfRangeException(nameof(numberOfShares), "The pool secret would be irrecoverable.");
+                throw new ArgumentOutOfRangeException(nameof(numberOfShares), numberOfShares, "The pool secret would be irrecoverable. The number of shares is lower than the minimum number of shares.");
             }
 
             if (this.mersennePrime == null)
@@ -243,12 +243,12 @@ namespace SecretSharingDotNet.Cryptography
             Calculator<TNumber> max = numberOfShares;
             if (min < Calculator<TNumber>.Two)
             {
-                throw new ArgumentOutOfRangeException(nameof(numberOfMinimumShares));
+                throw new ArgumentOutOfRangeException(nameof(numberOfMinimumShares), numberOfMinimumShares, "The minimum number of shares is lower than 2.");
             }
 
             if (min > max)
             {
-                throw new ArgumentOutOfRangeException(nameof(numberOfShares), "The pool secret would be irrecoverable.");
+                throw new ArgumentOutOfRangeException(nameof(numberOfShares), numberOfShares, "The pool secret would be irrecoverable. The number of shares is lower than the minimum number of shares.");
             }
 
             int newSecurityLevel = secret.SecretByteSize * 8;

--- a/tests/FinitePointTest.cs
+++ b/tests/FinitePointTest.cs
@@ -46,8 +46,8 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void FinitePointToString()
         {
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 500);
-            FinitePoint<BigInteger> fp = split.MakeShares(3, 7).First();
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            FinitePoint<BigInteger> fp = split.MakeShares(3, 7, 500).First();
             string s1 = fp.ToString();
             string s2 = new FinitePoint<BigInteger>(s1).ToString();
             Assert.Equal(s1, s2);

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -145,10 +145,9 @@ namespace SecretSharingDotNet.Test
         [MemberData(nameof(TestData.TestPasswordData), MemberType = typeof(TestData))]
         public void TestWithPassword(int splitSecurityLevel, int expectedSecurityLevel, string password)
         {
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(),
-                splitSecurityLevel);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
             var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
-            var shares = split.MakeShares(3, 7, password);
+            var shares = split.MakeShares(3, 7, password, splitSecurityLevel);
             Assert.True(shares.OriginalSecretExists);
             Assert.NotNull(shares.OriginalSecret);
             var secret = shares.OriginalSecret;
@@ -173,10 +172,9 @@ namespace SecretSharingDotNet.Test
         [MemberData(nameof(TestData.TestNumberData), MemberType = typeof(TestData))]
         public void TestWithNumber(int splitSecurityLevel, int expectedSecurityLevel, BigInteger number)
         {
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(),
-                splitSecurityLevel);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
             var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
-            var shares = split.MakeShares(3, 7, number);
+            var shares = split.MakeShares(3, 7, number, splitSecurityLevel);
             Assert.True(shares.OriginalSecretExists);
             Assert.NotNull(shares.OriginalSecret);
             var secret = shares.OriginalSecret;
@@ -194,19 +192,15 @@ namespace SecretSharingDotNet.Test
         /// Tests <see cref="ShamirsSecretSharing{TNumber}"/> with random <see cref="BigInteger"/> value as secret.
         /// </summary>
         /// <param name="splitSecurityLevel">Initial security level for secret split phase</param>
-        /// <param name="combineSecurityLevel">Initial security level for secret combine phase (aka reconstruction phase)</param>
         /// <param name="expectedSecurityLevel">Expected security level after secret reconstruction</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
         [Theory]
         [MemberData(nameof(TestData.TestRandomSecretData), MemberType = typeof(TestData))]
-        public void TestWithRandomSecret(int splitSecurityLevel, int combineSecurityLevel, int expectedSecurityLevel)
+        public void TestWithRandomSecret(int splitSecurityLevel, int expectedSecurityLevel)
         {
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(),
-                splitSecurityLevel);
-            var combine =
-                new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(),
-                    combineSecurityLevel);
-            var shares = split.MakeShares(3, 7);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var shares = split.MakeShares(3, 7, splitSecurityLevel);
             Assert.True(shares.OriginalSecretExists);
             Assert.NotNull(shares.OriginalSecret);
             var secret = shares.OriginalSecret;
@@ -227,8 +221,8 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void TestMinimumSharedSecretsMake()
         {
-            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 5);
-            Assert.Throws<ArgumentOutOfRangeException>(() => sss.MakeShares(1, 7));
+            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            Assert.Throws<ArgumentOutOfRangeException>(() => sss.MakeShares(1, 7, 5));
         }
 
         /// <summary>
@@ -238,8 +232,8 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void TestMinimumSharedSecretsReconstruction()
         {
-            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 13);
-            var shares = sss.MakeShares(2, 7);
+            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var shares = sss.MakeShares(2, 7, 13);
             var subSet = shares.Where(p => p.X == Calculator<BigInteger>.One).ToList();
             Assert.Throws<ArgumentOutOfRangeException>(() => sss.Reconstruction(subSet.ToArray()));
         }
@@ -251,23 +245,11 @@ namespace SecretSharingDotNet.Test
         [Fact]
         public void TestShareThreshold()
         {
-            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 51);
-            var shares = sss.MakeShares(3, 7);
+            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var shares = sss.MakeShares(3, 7, 51);
             var subSet = shares.Take(2).ToList();
             var secret = sss.Reconstruction(subSet.ToArray());
             Assert.NotEqual(shares.OriginalSecret, secret);
-        }
-
-        /// <summary>
-        /// Tests whether or not the <see cref="InvalidOperationException"/> is thrown if the security level
-        /// is not initialized.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-        [Fact]
-        public void TestUninitializedSecurityLevel()
-        {
-            var sss = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
-            Assert.Throws<InvalidOperationException>(() => sss.MakeShares(2, 7));
         }
 
         /// <summary>
@@ -279,9 +261,9 @@ namespace SecretSharingDotNet.Test
         {
             const string longSecret =
                 "-----BEGIN EC PRIVATE KEY-----MIIBUQIBAQQgxq7AWG9L6uleuTB9q5FGqnHjXF+kD4y9154SLYYKMDqggeMwgeACAQEwLAYHKoZIzj0BAQIhAP////////////////////////////////////7///wvMEQEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwRBBHm+Zn753LusVaBilc6HCwcCm/zbLc4o2VnygVsW+BeYSDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj/sQ1LgCIQD////////////////////+uq7c5q9IoDu/0l6M0DZBQQIBAaFEA0IABE0XO6I8lZYzXqRQnHP/knSwLex7q77g4J2AN0cVyrADicGlUr6QjVIlIu9NXCHxD2i++ToWjO1zLVdxgNJbUUc=-----END EC PRIVATE KEY-----";
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 1024);
-            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>(), 5);
-            var shares = split.MakeShares(3, 7, longSecret);
+            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            var shares = split.MakeShares(3, 7, longSecret, 1024);
             var subSet1 = shares.Where(p => p.X.IsEven).ToList();
             var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
             var subSet2 = shares.Where(p => !p.X.IsEven).ToList();

--- a/tests/TestData.cs
+++ b/tests/TestData.cs
@@ -100,16 +100,16 @@ namespace SecretSharingDotNet
         public static IEnumerable<object[]> TestRandomSecretData =>
             new List<object[]>
             {
-                new object[] {5, 32, 13},
-                new object[] {7, 32, 13},
-                new object[] {13, 32, 13},
-                new object[] {17, 521, 17},
-                new object[] {127, 521, 127},
-                new object[] {130, 5, 521},
-                new object[] {500, 5, 521},
-                new object[] {521, 5, 521},
-                new object[] {1024, 5, 1279},
-                new object[] {1279, 5, 1279}
+                new object[] {5, 13},
+                new object[] {7, 13},
+                new object[] {13, 13},
+                new object[] {17, 17},
+                new object[] {127, 127},
+                new object[] {130, 521},
+                new object[] {500, 521},
+                new object[] {521, 521},
+                new object[] {1024, 1279},
+                new object[] {1279, 1279}
             };
 
         /// <summary>


### PR DESCRIPTION
This is a design issue fix, not a funcitonality fix. The following changes were done based on the final security level use case. 

### Added
- Added method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel)`
- Added method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret, int securityLevel)`

### Changed
- Changed ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd)`. This ctor sets the SecurityLevel to 13.

### Deprecated
- Ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd, int securityLevel)` is deprecated.
- Method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares)` is deprecated.


Resolves issue #72