### PR TITLE
Obsolete  - Shares to tuple type casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd, int securityLevel)` is deprecated.
 - Method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares)` is deprecated.
+- Shares to tuple type casting is obsolete and will be remove in the next release.
+- Shares.Item1 property is obsolete and will be remove in the next release.
+- Shares.Item2 property is obsolete and will be remove in the next release.
 
 ## [0.7.0] - 2022-02-09
 ### Added

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -90,7 +90,7 @@ namespace SecretSharingDotNet.Cryptography
         /// Gets the original secret
         /// </summary>
         /// <remarks>Legacy property</remarks>
-        [Obsolete("Legacy property. Will be removed in futures versions.", false)]
+        [Obsolete("Legacy property. Will be removed in futures versions. Pleas use OriginalSecret property.", true)]
         public Secret<TNumber> Item1 => this.OriginalSecret;
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace SecretSharingDotNet.Cryptography
         /// Gets the shares.
         /// </summary>
         /// <remarks>Legacy property</remarks>
-        [Obsolete("Legacy property. Will be removed in futures versions.", false)]
+        [Obsolete("Legacy property. Will be removed in futures versions.", true)]
         public ICollection<FinitePoint<TNumber>> Item2 => this.shareList;
 
         /// <summary>
@@ -118,6 +118,7 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="shares">A <see cref="Shares{TNumber}"/> object.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
+        [Obsolete("Legacy property. Will be removed in futures versions.", true)]
         public static implicit operator Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>>(Shares<TNumber> shares) => new Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>>(shares?.OriginalSecret, shares);
 
         /// <summary>

--- a/tests/ShamirsSecretSharingTest.cs
+++ b/tests/ShamirsSecretSharingTest.cs
@@ -67,27 +67,6 @@ namespace SecretSharingDotNet.Test
         }
 
         /// <summary>
-        /// Tests the legacy usage of shares
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-        [Fact]
-        public void LegacyShareUsage()
-        {
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
-            var combine = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
-            var shares = split.MakeShares(3, 7, TestData.DefaultTestPassword);
-            var secret = shares.Item1;
-            var subSet1 = shares.Item2.Where(p => p.X.IsEven).ToList();
-            var recoveredSecret1 = combine.Reconstruction(subSet1.ToArray());
-            var subSet2 = shares.Item2.Where(p => !p.X.IsEven).ToList();
-            var recoveredSecret2 = combine.Reconstruction(subSet2.ToArray());
-            Assert.Equal(TestData.DefaultTestPassword, recoveredSecret1);
-            Assert.Equal(secret, recoveredSecret1);
-            Assert.Equal(secret, recoveredSecret2);
-            Assert.Equal(521, split.SecurityLevel);
-        }
-
-        /// <summary>
         /// Tests the security level auto-detection of <see cref="ShamirsSecretSharing{TNumber}"/>.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]

--- a/tests/SharesTest.cs
+++ b/tests/SharesTest.cs
@@ -46,23 +46,6 @@ namespace SecretSharingDotNet.Test
     public class SharesTest
     {
         /// <summary>
-        /// Tests the implicit cast from <see cref="Shares{TNumber}"/> to <see cref="Tuple"/>.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-        [Fact]
-        public void TestSharesToTupleCast()
-        {
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
-            var shares = split.MakeShares(3, 6, TestData.DefaultTestPassword);
-            Tuple<Secret<BigInteger>, ICollection<FinitePoint<BigInteger>>> tuple = shares;
-            Assert.NotNull(tuple);
-            Assert.NotNull(tuple.Item1);
-            Assert.NotNull(tuple.Item2);
-            Assert.Equal(6, tuple.Item2.Count);
-            Assert.Equal(TestData.DefaultTestPassword, tuple.Item1);
-        }
-
-        /// <summary>
         /// Tests the cast from <see cref="string"/> array to <see cref="Shares{TNumber}"/> and vice versa.
         /// </summary>
         [Fact]


### PR DESCRIPTION
### Deprecated
- Shares to tuple type casting is obsolete and will be remove in the next release.
- Shares.Item1 property is obsolete and will be remove in the next release.
- Shares.Item2 property is obsolete and will be remove in the next release.