### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2022-07-05
 ### Added
 - Added more examples in the section *Usage* of the `README.md` file to explain the use of shares and the use of the new type casting from byte array to secret and vice versa.
 - Added method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel)`
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed existing examples in the section *Usage* of the `README.md` file to explain the use and the type casting of recovered secrets.
+- Minify NuGet package README.md
 - Changed ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd)`. This ctor sets the SecurityLevel to 13.
 
 ### Deprecated
@@ -125,7 +126,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added LICENSE.md
 - Added README.md
 
-[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.7.0" alt="SecretSharingDotNet NuGet"/></a></td>
-          <td rowspan=9><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.7.0"/></a></td>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.7.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.7.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.8.0" alt="SecretSharingDotNet NuGet"/></a></td>
+          <td rowspan=9><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.8.0"/></a></td>
+          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.8.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.8.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
@@ -110,10 +110,10 @@ An C# implementation of Shamir's Secret Sharing.
 
 1. Open a console and switch to the directory, containing your project file.
 
-2. Use the following command to install version 0.7.0 of the SecretSharingDotNet package:
+2. Use the following command to install version 0.8.0 of the SecretSharingDotNet package:
 
     ```dotnetcli
-    dotnet add package SecretSharingDotNet -v 0.7.0 -f <FRAMEWORK>
+    dotnet add package SecretSharingDotNet -v 0.8.0 -f <FRAMEWORK>
     ```
 
 3. After the completition of the command, look at the project file to make sure that the package is successfuly installed.
@@ -122,7 +122,7 @@ An C# implementation of Shamir's Secret Sharing.
 
     ```xml
     <ItemGroup>
-      <PackageReference Include="SecretSharingDotNet" Version="0.7.0" />
+      <PackageReference Include="SecretSharingDotNet" Version="0.8.0" />
     </ItemGroup>
     ```
 ## Remove SecretSharingDotNet package

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("1c21b99c-2de4-4ca5-b4ce-bc95cf89369e")]
 
-[assembly: AssemblyVersion("0.7.0")]
-[assembly: AssemblyFileVersion("0.7.0")]
+[assembly: AssemblyVersion("0.8.0")]
+[assembly: AssemblyFileVersion("0.8.0")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -10,14 +10,14 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>SecretSharingDotNet</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>Fixed reopened bug #60 "Reconstruction fails at random". Added implicit casts for byte arrays in Secret class. Added legacy mode. Changed calculation of maximum security level in Reconstruction method. Remove support for .NET FX 4.5.2, 4.6 and 4.6.2.</PackageReleaseNotes>
+    <PackageReleaseNotes>Removed .NET 5 support. Added localization for exception messages in English and German. Add new overloads for the MakeShares method. Mark some ctors, properties and methods as deprecated.</PackageReleaseNotes>
     <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
     <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>Sebastian Walther</Authors>
     <Company>Private Person</Company>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
### Added
- Added more examples in the section *Usage* of the `README.md` file to explain the use of shares and the use of the new type casting from byte array to secret and vice versa.
- Added method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel)`
- Added method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret, int securityLevel)`
- Added localization for exception messages in English and German languages

### Changed
- Changed existing examples in the section *Usage* of the `README.md` file to explain the use and the type casting of recovered secrets.
- Minify NuGet package README.md
- Changed ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd)`. This ctor sets the SecurityLevel to 13.

### Deprecated
- Ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd, int securityLevel)` is deprecated.
- Method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares)` is deprecated.
- Shares to tuple type casting is obsolete and will be remove in the next release.
- Shares.Item1 property is obsolete and will be remove in the next release.
- Shares.Item2 property is obsolete and will be remove in the next release.

### Removed
- Removed .NET 5 support, because it retires on May 10, 2022. See [Microsoft .NET and .NET Core - Support Dates](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core).
