### PR TITLE
Feature -  Implement ToInt32() method in Calculator class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `ToInt32()` method to `BigInteger` and `Calculator` class.
+
 ### Changed
 - Moved generic version of the `Calculator` class from the `Calculator.cs` file to the ``Calculator`1.cs`` file.
 - Updated `Microsoft.NET.Test.Sdk` Nuget package version to 17.2.0.

--- a/src/Math/BigIntCalculator.cs
+++ b/src/Math/BigIntCalculator.cs
@@ -57,6 +57,10 @@ namespace SecretSharingDotNet.Math
         /// <returns>This method returns <see langword="true"/> if this instance is less than or equal to the <paramref name="right"/> instance, <see langword="false"/> otherwise.</returns>
         public override bool EqualOrLowerThan(BigInteger right) => this.Value <= right;
 
+        /// <inheritdoc />
+        /// <exception cref="T:System.OverflowException">Unable to convert the current instance of <see cref="BigIntCalculator"/> class to <see cref="Int32"/>.</exception>
+        public override int ToInt32() => (int)this.Value;
+
         /// <summary>
         /// Compares this instance to a second <see cref="Calculator{BigInteger}"/> and returns an integer that
         /// indicates whether the value of this instance is less than, equal to, or greater than the value of the specified object.

--- a/src/Math/BigIntCalculator.cs
+++ b/src/Math/BigIntCalculator.cs
@@ -6,6 +6,29 @@
 // <date>04/20/2019 10:52:28 PM</date>
 // ----------------------------------------------------------------------------
 
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2022 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
 namespace SecretSharingDotNet.Math
 {
     using System;

--- a/src/Math/Calculator.cs
+++ b/src/Math/Calculator.cs
@@ -86,6 +86,13 @@ namespace SecretSharingDotNet.Math
         public abstract int Sign { get; }
 
         /// <summary>
+        /// Converts the current <see cref="Calculator{TNumber}"/> instance to a <see cref="Int32"/>.
+        /// </summary>
+        /// <returns>A value of the <see cref="Int32"/> type.</returns>
+        /// <exception cref="T:System.OverflowException">Unable to convert the current instance of <see cref="Calculator{TNumber}"/> class to <see cref="Int32"/>.</exception>
+        public abstract int ToInt32();
+
+        /// <summary>
         /// Creates a new instance derived from the <see cref="Calculator"/> class.
         /// </summary>
         /// <param name="data">byte array representation of the <paramref name="numberType"/></param>


### PR DESCRIPTION
### Added
The `ToInt32()` method can be used in context of loops and indexer.

Keep an eye on the OverflowException, because the main purpose of
the Calculator class is the implementation of big number types like
BigInteger.
