### PR TITLE
Fix - Style guide SharesEnumerator class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `xunit.runner.visualstudio` Nuget package version to 2.4.5.
 - Set `Calculator` fields `ChildTypes` and `ChildBaseCtors` from protected to private.
 
+### Fixed
+- Fixed style guide violations in SharesEnumerator.cs.
+
+### Removed
+- Removed constructor w/ `ReadOnlyCollection` parameter from the `SharesEnumerator{TNumber}` class.
+
 ## [0.8.0] - 2022-07-05
 ### Added
 - Added more examples in the section *Usage* of the `README.md` file to explain the use of shares and the use of the new type casting from byte array to secret and vice versa.

--- a/src/Cryptography/SharesEnumerator.cs
+++ b/src/Cryptography/SharesEnumerator.cs
@@ -58,16 +58,6 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="shares">A collection of <see cref="FinitePoint{TNumber}"/> items representing the shares.</param>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/></exception>
-        public SharesEnumerator(ReadOnlyCollection<FinitePoint<TNumber>> shares)
-        {
-            this.shareList = shares ?? throw new ArgumentNullException(nameof(shares));
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SharesEnumerator{TNumber}"/> class.
-        /// </summary>
-        /// <param name="shares">A collection of <see cref="FinitePoint{TNumber}"/> items representing the shares.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/></exception>
         public SharesEnumerator(Collection<FinitePoint<TNumber>> shares)
         {
             _ = shares ?? throw new ArgumentNullException(nameof(shares));
@@ -82,7 +72,7 @@ namespace SecretSharingDotNet.Cryptography
         public bool MoveNext()
         {
             this.position++;
-            return (this.position < shareList.Count);
+            return this.position < this.shareList.Count;
         }
 
         /// <summary>
@@ -109,7 +99,7 @@ namespace SecretSharingDotNet.Cryptography
             {
                 try
                 {
-                    return this.shareList[position];
+                    return this.shareList[this.position];
                 }
                 catch (IndexOutOfRangeException)
                 {


### PR DESCRIPTION
### Fixed
- Fixed style guide violations in SharesEnumerator.cs.

### Removed
- Removed constructor w/ `ReadOnlyCollection` parameter from the `SharesEnumerator{TNumber}` class.
