### PR TITLE
Remove - Shares class Item1 and Item2 properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed constructor w/ `ReadOnlyCollection` parameter from the `SharesEnumerator{TNumber}` class.
+- Removed tuple type casting from the `Shares` class.
+- Removed `Shares.Item1` property.
+- Removed `Shares.Item2` property.
 
 ## [0.8.0] - 2022-07-05
 ### Added

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -87,26 +87,12 @@ namespace SecretSharingDotNet.Cryptography
         public Secret<TNumber> OriginalSecret { get; }
 
         /// <summary>
-        /// Gets the original secret
-        /// </summary>
-        /// <remarks>Legacy property</remarks>
-        [Obsolete("Legacy property. Will be removed in futures versions. Pleas use OriginalSecret property.", true)]
-        public Secret<TNumber> Item1 => this.OriginalSecret;
-
-        /// <summary>
         /// Gets or sets the <see cref="FinitePoint{TNumber}"/> associated with the specified index.
         /// </summary>
         /// <param name="i">The index of the <see cref="FinitePoint{TNumber}"/> to get or set.</param>
         /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "i")]
         public FinitePoint<TNumber> this[int i] => this.shareList[i];
-
-        /// <summary>
-        /// Gets the shares.
-        /// </summary>
-        /// <remarks>Legacy property</remarks>
-        [Obsolete("Legacy property. Will be removed in futures versions.", true)]
-        public ICollection<FinitePoint<TNumber>> Item2 => this.shareList;
 
         /// <summary>
         /// Gets a value indicating whether or not the original secret is available.

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -100,14 +100,6 @@ namespace SecretSharingDotNet.Cryptography
         public bool OriginalSecretExists => this.OriginalSecret != null;
 
         /// <summary>
-        /// Casts a <see cref="Shares{TNumber}"/> object to a <see cref="Tuple"/> object.
-        /// </summary>
-        /// <param name="shares">A <see cref="Shares{TNumber}"/> object.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
-        [Obsolete("Legacy property. Will be removed in futures versions.", true)]
-        public static implicit operator Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>>(Shares<TNumber> shares) => new Tuple<Secret<TNumber>, ICollection<FinitePoint<TNumber>>>(shares?.OriginalSecret, shares);
-
-        /// <summary>
         /// Casts a <see cref="Shares{TNumber}"/> object to a array of <see cref="string"/>s.
         /// </summary>
         /// <param name="shares">A <see cref="Shares{TNumber}"/> object.</param>


### PR DESCRIPTION
### Removed
- Removed tuple type casting from the `Shares` class.
- Removed `Shares.Item1` property.
- Removed `Shares.Item2` property.