### PR TITLE
Fix - Avoid boxing/unboxing in ToString method in calculator classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed style guide violations in SharesEnumerator.cs.
+- Fixed unnecessary boxing/unboxing in the `ToString()` methods in `Calculator` classes.
 
 ### Removed
 - Removed constructor w/ `ReadOnlyCollection` parameter from the `SharesEnumerator{TNumber}` class.

--- a/src/Math/BigIntCalculator.cs
+++ b/src/Math/BigIntCalculator.cs
@@ -1,9 +1,9 @@
 // ----------------------------------------------------------------------------
 // <copyright file="BigIntCalculator.cs" company="Private">
-// Copyright (c) 2019 All Rights Reserved
+// Copyright (c) 2022 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
-// <date>04/20/2019 10:52:28 PM</date>
+// <date>08/20/2022 02:34:00 PM</date>
 // ----------------------------------------------------------------------------
 
 #region License
@@ -225,5 +225,11 @@ namespace SecretSharingDotNet.Math
                 return root;
             }
         }
+
+        /// <summary>
+        /// Converts the numeric value of the current <see cref="BigIntCalculator"/> object to its equivalent string representation.
+        /// </summary>
+        /// <returns>The <see cref="System.String"/> representation of the current <see cref="BigIntCalculator"/> value.</returns>
+        public override string ToString() => this.Value.ToString();
     }
 }

--- a/src/Math/Calculator.cs
+++ b/src/Math/Calculator.cs
@@ -101,6 +101,12 @@ namespace SecretSharingDotNet.Math
         public static Calculator Create(byte[] data, Type numberType) => ChildBaseCtors[numberType](data);
 
         /// <summary>
+        /// Returns a <see cref="System.String"/> that represents the current <see cref="Calculator"/>.
+        /// </summary>
+        /// <returns>The <see cref="System.String"/> representation of this <see cref="Calculator"/> object</returns>
+        public abstract override string ToString();
+
+        /// <summary>
         /// Returns a dictionary of constructors of number data types derived from the <see cref="Calculator"/> class.
         /// </summary>
         /// <returns></returns>

--- a/src/Math/Calculator`1.cs
+++ b/src/Math/Calculator`1.cs
@@ -383,7 +383,7 @@ namespace SecretSharingDotNet.Math
         /// <summary>
         /// Converts the numeric value of the current <see cref="Calculator{TNumber}"/> object to its equivalent string representation.
         /// </summary>
-        /// <returns>The string representation of the current <see cref="Calculator{TNumber}"/> value.</returns>
-        public override string ToString() => this.Value.ToString();
+        /// <returns>The <see cref="System.String"/> representation of the current <see cref="Calculator{TNumber}"/> value.</returns>
+        public abstract override string ToString();
     }
 }


### PR DESCRIPTION
### Fixed
- Fixed unnecessary boxing/unboxing in the ToString() methods in Calculator classes.