### PR TITLE
Fix - Style guide violations in calculator classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed style guide violations in SharesEnumerator.cs.
 - Fixed style guide violations in IExtendedGcdAlgorithm`2.cs.
 - Fixed style guide violations in ExtendedEuclideanAlgorithm.cs.
+- Fixed style guide violations in Calculator.cs.
+- Fixed style guide violations in Calculator`1.cs.
+- Fixed style guide violations in BigIntCalculator.cs.
 - Fixed possible null reference exception in `Calculator` class.
 - Fixed possible null reference exception in `Shares` class.
 - Fixed possible null reference exception in `ShamirsSecretSharing` class.

--- a/src/Cryptography/FinitePoint.cs
+++ b/src/Cryptography/FinitePoint.cs
@@ -228,13 +228,14 @@ namespace SecretSharingDotNet.Cryptography
         /// <remarks>
         /// Based on discussion on <see href="https://stackoverflow.com/questions/623104/byte-to-hex-string/5919521#5919521">stackoverflow</see>
         /// </remarks>
-        private static string ToHexString(IReadOnlyCollection<byte> bytes)
+        private static string ToHexString(IEnumerable<byte> bytes)
         {
-            StringBuilder hexRepresentation = new StringBuilder(bytes.Count * 2);
-            foreach (byte b in bytes)
+            byte[] byteArray = bytes as byte[] ?? bytes.ToArray();
+            var hexRepresentation = new StringBuilder(byteArray.Length * 2);
+            foreach (byte b in byteArray)
             {
                 const string hexAlphabet = "0123456789ABCDEF";
-                hexRepresentation.Append(new[] { hexAlphabet[b >> 4], hexAlphabet[b & 0xF] });
+                hexRepresentation.Append(hexAlphabet[b >> 4]).Append(hexAlphabet[b & 0xF]);
             }
 
             return hexRepresentation.ToString();

--- a/src/Math/BigIntCalculator.cs
+++ b/src/Math/BigIntCalculator.cs
@@ -32,6 +32,7 @@
 namespace SecretSharingDotNet.Math
 {
     using System;
+    using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Numerics;
 
@@ -174,7 +175,7 @@ namespace SecretSharingDotNet.Math
         /// <summary>
         /// Gets the byte representation of the <see cref="BigIntCalculator"/> object.
         /// </summary>
-        public override ReadOnlyCollection<byte> ByteRepresentation => new ReadOnlyCollection<byte>(this.Value.ToByteArray());
+        public override IEnumerable<byte> ByteRepresentation => new ReadOnlyCollection<byte>(this.Value.ToByteArray());
 
         /// <summary>
         /// Gets a value indicating whether or not the current <see cref="BigIntCalculator"/> object is zero (0).
@@ -200,9 +201,9 @@ namespace SecretSharingDotNet.Math
         /// Returns the square root of the current <see cref="BigIntCalculator"/> object.
         /// </summary>
         /// <exception cref="T:System.ArithmeticException" accessor="get">NaN (value is lower than zero)</exception>
-        public override Calculator<BigInteger> Sqrt 
+        public override Calculator<BigInteger> Sqrt
         {
-            get 
+            get
             {
                 if (this.Value == BigInteger.Zero)
                 {
@@ -215,11 +216,11 @@ namespace SecretSharingDotNet.Math
                 }
 
                 int bitLength = Convert.ToInt32(Math.Ceiling(BigInteger.Log(this.Value, 2)));
-                BigInteger root = BigInteger.One << (bitLength >> 1);
+                var root = BigInteger.One << (bitLength >> 1);
                 bool IsSqrt(BigInteger n, BigInteger r) => n >= r * r && n < (r + 1) * (r + 1);
                 while (!IsSqrt(this.Value, root))
                 {
-                    root = (root + this.Value / root) >> 1;
+                    root = root + this.Value / root >> 1;
                 }
 
                 return root;

--- a/src/Math/Calculator.cs
+++ b/src/Math/Calculator.cs
@@ -63,7 +63,7 @@ namespace SecretSharingDotNet.Math
         /// <summary>
         /// Gets the byte representation of the <see cref="Calculator"/> object.
         /// </summary>
-        public abstract ReadOnlyCollection<byte> ByteRepresentation { get; }
+        public abstract IEnumerable<byte> ByteRepresentation { get; }
 
         /// <summary>
         /// Gets a value indicating whether or not the current <see cref="Calculator"/> object is zero.
@@ -118,12 +118,14 @@ namespace SecretSharingDotNet.Math
             foreach (var childType in ChildTypes)
             {
                 var ctorInfo = childType.Value.GetConstructor(new[] {paramType});
-                if (ctorInfo != null)
+                if (ctorInfo == null)
                 {
-                    var ctor = Expression.Lambda<Func<TParameter, TCalculator>>(Expression.New(ctorInfo, parameterExpression), parameterExpression)
-                        .Compile();
-                    res.Add(childType.Key, ctor);
+                    continue;
                 }
+
+                var ctor = Expression.Lambda<Func<TParameter, TCalculator>>(Expression.New(ctorInfo, parameterExpression), parameterExpression)
+                    .Compile();
+                res.Add(childType.Key, ctor);
             }
 
             return res;

--- a/src/Math/Calculator`1.cs
+++ b/src/Math/Calculator`1.cs
@@ -332,6 +332,7 @@ namespace SecretSharingDotNet.Math
         /// indicates whether the value of this instance is less than, equal to, or greater than the value of the specified object.
         /// </summary>
         /// <param name="obj">The object to compare</param>
+        /// <exception cref="ArgumentException"><paramref name="obj"/> has a unknown data type</exception>
         /// <returns>A signed integer that indicates the relationship of the current instance to the <paramref name="obj"/> parameter</returns>
         public virtual int CompareTo(object obj)
         {
@@ -364,7 +365,6 @@ namespace SecretSharingDotNet.Math
         /// <summary>
         /// Gets a value that represents the number two (2).
         /// </summary>
-        /// <returns></returns>
         public static Calculator<TNumber> Two { get; } = One.Increment();
 
         /// <summary>


### PR DESCRIPTION
### Fixed
- Fixed style guide violations in Calculator.cs.
- Fixed style guide violations in Calculator`1.cs.
- Fixed style guide violations in BigIntCalculator.cs.