### PR TITLE
Release v0.9.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop, main, master ]
+    branches: [ develop, main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ develop ]
+    branches: [ develop, main ]
   schedule:
     - cron: '18 17 * * 4'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2022-10-09
 ### Added
 - Add `ToInt32()` method to `BigIntCalculator` and `Calculator` class.
 - Introduce the `IExtendedGcdResult` interface to decouple GCD result implementations.
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Performance improvements for `ShamirsSecretSharing` classes.
 - Performance improvements for `FinitePoint` class.
 - Performance improvements for generic `Calculator` class.
+
+### Deprecated
+- Ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd, int securityLevel)` is deprecated.
+- Method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares)` is deprecated.
 
 ### Fixed
 - Fixed style guide violations in `CHANGELOG.md`.
@@ -162,7 +166,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LICENSE.md`
 - Added `README.md`
 
-[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.8.0" alt="SecretSharingDotNet NuGet"/></a></td>
-          <td rowspan=9><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.8.0"/></a></td>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.8.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.8.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.9.0" alt="SecretSharingDotNet NuGet"/></a></td>
+          <td rowspan=9><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.9.0"/></a></td>
+          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.9.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.9.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Core 3.1 (LTS)</td>
       </tr>
       <tr>
@@ -110,10 +110,10 @@ An C# implementation of Shamir's Secret Sharing.
 
 1. Open a console and switch to the directory, containing your project file.
 
-2. Use the following command to install version 0.8.0 of the SecretSharingDotNet package:
+2. Use the following command to install version 0.9.0 of the SecretSharingDotNet package:
 
     ```dotnetcli
-    dotnet add package SecretSharingDotNet -v 0.8.0 -f <FRAMEWORK>
+    dotnet add package SecretSharingDotNet -v 0.9.0 -f <FRAMEWORK>
     ```
 
 3. After the completition of the command, look at the project file to make sure that the package is successfuly installed.
@@ -122,7 +122,7 @@ An C# implementation of Shamir's Secret Sharing.
 
     ```xml
     <ItemGroup>
-      <PackageReference Include="SecretSharingDotNet" Version="0.8.0" />
+      <PackageReference Include="SecretSharingDotNet" Version="0.9.0" />
     </ItemGroup>
     ```
 ## Remove SecretSharingDotNet package

--- a/src/Cryptography/FinitePoint.cs
+++ b/src/Cryptography/FinitePoint.cs
@@ -273,10 +273,10 @@ namespace SecretSharingDotNet.Cryptography
                 0x0F
             });
 
-            for (int x = 0, i = 0; i < hexString.Length; i += 2, x += 1)
+            for (int i = 0, j = 0; j < hexString.Length; j += 2, i += 1)
             {
                 const char zeroDigit = '0';
-                bytes[x] = (byte)(hexValues[char.ToUpper(hexString[i + 0], CultureInfo.InvariantCulture) - zeroDigit] << 4 | hexValues[char.ToUpper(hexString[i + 1], CultureInfo.InvariantCulture) - zeroDigit]);
+                bytes[i] = (byte)(hexValues[char.ToUpper(hexString[j + 0], CultureInfo.InvariantCulture) - zeroDigit] << 4 | hexValues[char.ToUpper(hexString[j + 1], CultureInfo.InvariantCulture) - zeroDigit]);
             }
 
             return bytes;

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -254,14 +254,14 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="array">The one-dimensional <see cref="Array"/> that is the destination of the items copied from <see cref="Shares{TNumber}"/> collection.
         /// The  <see cref="Array"/> must have zero-based indexing.</param>
-        /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
-        void ICollection.CopyTo(Array array, int arrayIndex)
+        /// <param name="index">The zero-based index in <paramref name="array"/> at which copying begins.</param>
+        void ICollection.CopyTo(Array array, int index)
         {
             _ = array ?? throw new ArgumentNullException(nameof(array));
             switch (array)
             {
                 case FinitePoint<TNumber>[] x:
-                    this.CopyTo(x, arrayIndex);
+                    this.CopyTo(x, index);
                     break;
                 default:
                     throw new InvalidCastException(string.Format(ErrorMessages.InvalidArrayTypeCast, nameof(array), array.GetType().GetElementType(), typeof(FinitePoint<TNumber>)));
@@ -275,23 +275,23 @@ namespace SecretSharingDotNet.Cryptography
         /// <param name="array">The one-dimensional array of <see cref="FinitePoint{TNumber}"/> items that is the destination of the
         /// items copied from <see cref="Shares{TNumber}"/> collection.
         /// The array must have zero-based indexing.</param>
-        /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
-        public void CopyTo(FinitePoint<TNumber>[] array, int arrayIndex)
+        /// <param name="index">The zero-based index in <paramref name="array"/> at which copying begins.</param>
+        public void CopyTo(FinitePoint<TNumber>[] array, int index)
         {
             _ = array ?? throw new ArgumentNullException(nameof(array));
-            if (arrayIndex < 0)
+            if (index < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(arrayIndex), ErrorMessages.StartArrayIndexNegative);
+                throw new ArgumentOutOfRangeException(nameof(index), ErrorMessages.StartArrayIndexNegative);
             }
 
-            if (this.Count > array.Length - arrayIndex + 1)
+            if (this.Count > array.Length - index + 1)
             {
                 throw new ArgumentException(ErrorMessages.DestinationArrayHasFewerElements, nameof(array));
             }
 
             for (int i = 0; i < this.shareList.Count; i++)
             {
-                array[i + arrayIndex] = this.shareList[i];
+                array[i + index] = this.shareList[i];
             }
         }
 

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("1c21b99c-2de4-4ca5-b4ce-bc95cf89369e")]
 
-[assembly: AssemblyVersion("0.8.0")]
-[assembly: AssemblyFileVersion("0.8.0")]
+[assembly: AssemblyVersion("0.9.0")]
+[assembly: AssemblyFileVersion("0.9.0")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -10,14 +10,14 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>SecretSharingDotNet</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>Removed .NET 5 support. Added localization for exception messages in English and German. Add new overloads for the MakeShares method. Mark some ctors, properties and methods as deprecated.</PackageReleaseNotes>
+    <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v0.9.0/CHANGELOG.md</PackageReleaseNotes>
     <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
     <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.8.0</Version>
+    <Version>0.9.0</Version>
     <Authors>Sebastian Walther</Authors>
     <Company>Private Person</Company>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
### Added
- Add `ToInt32()` method to `BigIntCalculator` and `Calculator` class.
- Introduce the `IExtendedGcdResult` interface to decouple GCD result implementations.

### Changed
- Moved generic version of the `Calculator` class from the `Calculator.cs` file to the ``Calculator`1.cs`` file.
- Updated `Microsoft.NET.Test.Sdk` Nuget package version to 17.2.0.
- Updated `xunit.runner.visualstudio` Nuget package version to 2.4.5.
- Set `Calculator` fields `ChildTypes` and `ChildBaseCtors` from protected to private.
- Performance improvements for `ShamirsSecretSharing` classes.
- Performance improvements for `FinitePoint` class.
- Performance improvements for generic `Calculator` class.

### Deprecated
- Ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd, int securityLevel)` is deprecated.
- Method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares)` is deprecated.

### Fixed
- Fixed style guide violations in `CHANGELOG.md`.
- Fixed style guide violations in `FinitePoint.cs`.
- Fixed style guide violations in `Shares.cs`.
- Fixed style guide violations in `SharesEnumerator.cs`.
- Fixed style guide violations in ``IExtendedGcdAlgorithm`2.cs``.
- Fixed style guide violations in `ExtendedEuclideanAlgorithm.cs`.
- Fixed style guide violations in `Calculator.cs`.
- Fixed style guide violations in ``Calculator`1.cs``.
- Fixed style guide violations in `BigIntCalculator.cs`.
- Fixed style guide violations in `Secret.cs`. Split file into `Secret.cs` and ``Secret`1.cs``.
- Fixed possible null reference exception in `Calculator` class.
- Fixed possible null reference exception in `Shares` class.
- Fixed possible null reference exception in `ShamirsSecretSharing` class.
- Fixed unnecessary boxing/unboxing in the `ToString()` methods in `Calculator` classes.

### Removed
- Removed constructor w/ `ReadOnlyCollection` parameter from the `SharesEnumerator{TNumber}` class.
- Removed tuple type casting from the `Shares` class.
- Removed `Shares.Item1` property.
- Removed `Shares.Item2` property.
