### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0] - 2022-12-24
 ### Added
 - Added .NET 7 support
 
@@ -178,7 +178,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LICENSE.md`
 - Added `README.md`
 
-[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.9.0...HEAD
+[0.10.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.9.0...0.10.0
 [0.9.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.6.0...v0.7.0

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("1c21b99c-2de4-4ca5-b4ce-bc95cf89369e")]
 
-[assembly: AssemblyVersion("0.9.0")]
-[assembly: AssemblyFileVersion("0.9.0")]
+[assembly: AssemblyVersion("0.10.0")]
+[assembly: AssemblyFileVersion("0.10.0")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -10,14 +10,14 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>SecretSharingDotNet</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v0.9.0/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/0.10.0/CHANGELOG.md</PackageReleaseNotes>
     <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
     <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
     <Authors>Sebastian Walther</Authors>
     <Company>Private Person</Company>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
### Added
- Added .NET 7 support

### Changed
- Update `Microsoft.NETFramework.ReferenceAssemblies` to v1.0.3

### Removed
- Removed .NET Core 3.1 (LTS) support
- Removed ctor `ShamirsSecretSharing(IExtendedGcdAlgorithm<TNumber> extendedGcd, int securityLevel)`.
- Removed method `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares)`.
