### PR TITLE
Feature - Slow Equal Implementation for BigIntCalculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed BigIntCalculator's Equals method to avoid timing attacks. The slow equal implementation is used now.
+
 ## [0.10.0] - 2022-12-24
 ### Added
 - Added .NET 7 support

--- a/src/Math/BigIntCalculator.cs
+++ b/src/Math/BigIntCalculator.cs
@@ -35,6 +35,7 @@ namespace SecretSharingDotNet.Math
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Numerics;
+    using System.Runtime.CompilerServices;
 
     /// <summary>
     /// <see cref="Calculator"/> implementation of <see cref="System.Numerics.BigInteger"/>
@@ -52,6 +53,29 @@ namespace SecretSharingDotNet.Math
         /// </summary>
         /// <param name="data">byte stream representation of numeric value</param>
         public BigIntCalculator(byte[] data) : base(new BigInteger(data)) { }
+
+        /// <summary>
+        /// Determines whether this instance and an <paramref name="other"/> specified <see cref="Calculator{BigInteger}"/> instance are equal.
+        /// </summary>
+        /// <param name="other">The <see cref="Calculator{BigInteger}"/> instance to compare</param>
+        /// <returns><see langword="true"/> if the value of the <paramref name="other"/> parameter is the same as the value of this instance; otherwise <see langword="false"/>.
+        /// If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</returns>
+        /// <remarks>This is a Slow Equal Implementation to avoid a timing attack. See the reference for more details:
+        /// https://bryanavery.co.uk/cryptography-net-avoiding-timing-attack/</remarks>
+        [MethodImpl(MethodImplOptions.NoOptimization)]
+        public override bool Equals(Calculator<BigInteger> other)
+        {
+            var valueLeft = this.Value.ToByteArray();
+            var valueRight = other?.Value.ToByteArray() ?? Array.Empty<byte>();
+
+            var diff = (uint)valueLeft.Length ^ (uint)valueRight.Length;
+            for (var i = 0; i < valueLeft.Length && i < valueRight.Length; i++)
+            {
+                diff |= (uint)(valueLeft[i] ^ valueRight[i]);
+            }
+
+            return diff == 0;
+        }
 
         /// <summary>
         /// This method represents the Greater Than operator.

--- a/src/Math/Calculator`1.cs
+++ b/src/Math/Calculator`1.cs
@@ -299,7 +299,7 @@ namespace SecretSharingDotNet.Math
         /// <param name="other">The <see cref="Calculator{TNumber}"/> instance to compare</param>
         /// <returns><see langword="true"/> if the value of the <paramref name="other"/> parameter is the same as the value of this instance; otherwise <see langword="false"/>.
         /// If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</returns>
-        public bool Equals(Calculator<TNumber> other)
+        public virtual bool Equals(Calculator<TNumber> other)
         {
             return other != null && this.Value.Equals(other.Value);
         }


### PR DESCRIPTION
### Fixed
- Fixed BigIntCalculator's Equals method to avoid timing attacks. The slow equal implementation is used now.

For details see the following references:

1. https://bryanavery.co.uk/cryptography-net-avoiding-timing-attack/
2. https://paragonie.com/blog/2015/11/preventing-timing-attacks-on-string-comparison-with-double-hmac-strategy