### PR TITLE
FinitePoint - ReadOnlySpan<char> for string parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- FinitePoint: Use `ReadOnlySpan<char>` for `string` parameters in ctor and methods.
+
 ## [0.10.1] - 2023-05-08
 ### Fixed
 - Fixed BigIntCalculator's Equals method to avoid timing attacks. The slow equal implementation is used now.

--- a/src/Cryptography/FinitePoint`1.cs
+++ b/src/Cryptography/FinitePoint`1.cs
@@ -282,14 +282,10 @@ namespace SecretSharingDotNet.Cryptography
         /// <returns>Returns a byte array</returns>
 #if NET6_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static byte[] ToByteArray(ReadOnlySpan<char> hexString)
+        private static byte[] ToByteArray(ReadOnlySpan<char> hexString) => Convert.FromHexString(hexString);
 #else
         private static byte[] ToByteArray(string hexString)
-#endif
         {
-#if NET6_0_OR_GREATER
-            return Convert.FromHexString(hexString);
-#else
             byte[] bytes = new byte[hexString.Length / 2];
             var hexValues = Array.AsReadOnly(new[]
             {
@@ -325,7 +321,7 @@ namespace SecretSharingDotNet.Cryptography
             }
 
             return bytes;
-#endif
         }
+#endif
     }
 }

--- a/src/Cryptography/FinitePoint`1.cs
+++ b/src/Cryptography/FinitePoint`1.cs
@@ -1,9 +1,9 @@
 // ----------------------------------------------------------------------------
-// <copyright file="FinitePoint.cs" company="Private">
-// Copyright (c) 2019 All Rights Reserved
+// <copyright file="FinitePoint`1.cs" company="Private">
+// Copyright (c) 2023 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
-// <date>04/20/2019 10:52:28 PM</date>
+// <date>05/27/2023 06:05:12 PM</date>
 // ----------------------------------------------------------------------------
 
 #region License
@@ -36,7 +36,11 @@ namespace SecretSharingDotNet.Cryptography
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+#if !NET6_0_OR_GREATER
     using System.Text;
+#else
+    using System.Runtime.CompilerServices;
+#endif
 
     /// <summary>
     /// Represents the support point of the polynomial
@@ -73,17 +77,33 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="serialized">string representation of the <see cref="FinitePoint{TNumber}"/> struct</param>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="serialized"/> is <see langword="null"/></exception>
+#if NET6_0_OR_GREATER
+        public FinitePoint(ReadOnlySpan<char> serialized)
+#else
         public FinitePoint(string serialized)
+#endif
         {
+#if NET6_0_OR_GREATER
+            if (serialized == null || serialized.IsEmpty)
+#else
             if (string.IsNullOrWhiteSpace(serialized))
+#endif
             {
                 throw new ArgumentNullException(nameof(serialized));
             }
 
-            string[] s = serialized.Split('-');
+#if NET6_0_OR_GREATER
+            var xReadOnlySpan = serialized[..serialized.IndexOf(SharedSeparator.CoordinateSeparator)];
+            var yReadOnlySpan = serialized[(serialized.IndexOf(SharedSeparator.CoordinateSeparator) + 1)..];
+            var numberType = typeof(TNumber);
+            this.x = Calculator.Create(ToByteArray(xReadOnlySpan), numberType) as Calculator<TNumber>;
+            this.y = Calculator.Create(ToByteArray(yReadOnlySpan), numberType) as Calculator<TNumber>;
+#else
+            string[] s = serialized.Split(SharedSeparator.CoordinateSeparatorArray);
             var numberType = typeof(TNumber);
             this.x = Calculator.Create(ToByteArray(s[0]), numberType) as Calculator<TNumber>;
             this.y = Calculator.Create(ToByteArray(s[1]), numberType) as Calculator<TNumber>;
+#endif
         }
 
         /// <summary>
@@ -95,6 +115,16 @@ namespace SecretSharingDotNet.Cryptography
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "x")]
         public FinitePoint(Calculator<TNumber> x, Calculator<TNumber> y)
         {
+            if (x == null)
+            {
+                throw new ArgumentNullException(nameof(x));
+            }
+
+            if (y == null)
+            {
+                throw new ArgumentNullException(nameof(y));
+            }
+
             this.x = x;
             this.y = y;
         }
@@ -196,7 +226,7 @@ namespace SecretSharingDotNet.Cryptography
         /// Returns the string representation of the <see cref="FinitePoint{TNumber}"/> structure.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => string.Format(CultureInfo.InvariantCulture, "{0}-{1}", ToHexString(this.x.ByteRepresentation), ToHexString(this.y.ByteRepresentation));
+        public override string ToString() => string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", ToHexString(this.x.ByteRepresentation), SharedSeparator.CoordinateSeparator.ToString(), ToHexString(this.y.ByteRepresentation));
 
         /// <summary>
         /// Evaluates polynomial (coefficient tuple) at x, used to generate a shamir pool.
@@ -225,8 +255,14 @@ namespace SecretSharingDotNet.Cryptography
         /// <remarks>
         /// Based on discussion on <see href="https://stackoverflow.com/questions/623104/byte-to-hex-string/5919521#5919521">stackoverflow</see>
         /// </remarks>
+#if NET6_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private static string ToHexString(IEnumerable<byte> bytes)
         {
+#if NET6_0_OR_GREATER
+            return Convert.ToHexString(bytes as byte[] ?? bytes.ToArray());
+#else
             byte[] byteArray = bytes as byte[] ?? bytes.ToArray();
             var hexRepresentation = new StringBuilder(byteArray.Length * 2);
             foreach (byte b in byteArray)
@@ -236,6 +272,7 @@ namespace SecretSharingDotNet.Cryptography
             }
 
             return hexRepresentation.ToString();
+#endif
         }
 
         /// <summary>
@@ -243,8 +280,16 @@ namespace SecretSharingDotNet.Cryptography
         /// </summary>
         /// <param name="hexString">hexadecimal string</param>
         /// <returns>Returns a byte array</returns>
+#if NET6_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static byte[] ToByteArray(ReadOnlySpan<char> hexString)
+#else
         private static byte[] ToByteArray(string hexString)
+#endif
         {
+#if NET6_0_OR_GREATER
+            return Convert.FromHexString(hexString);
+#else
             byte[] bytes = new byte[hexString.Length / 2];
             var hexValues = Array.AsReadOnly(new[]
             {
@@ -280,6 +325,7 @@ namespace SecretSharingDotNet.Cryptography
             }
 
             return bytes;
+#endif
         }
     }
 }

--- a/src/Cryptography/SharedSeparator.cs
+++ b/src/Cryptography/SharedSeparator.cs
@@ -1,0 +1,47 @@
+// ----------------------------------------------------------------------------
+// <copyright file="SharedSeparator.cs" company="Private">
+// Copyright (c) 2023 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>05/27/2023 06:05:12 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2019 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography
+{
+    internal static class SharedSeparator
+    {
+        /// <summary>
+        /// The separator between the X and Y coordinate
+        /// </summary>
+        internal const char CoordinateSeparator = '-';
+
+        /// <summary>
+        /// Separator array for <see cref="string.Split(char[])"/> method usage to avoid allocation of a new array.
+        /// </summary>
+        internal static readonly char[] CoordinateSeparatorArray = { CoordinateSeparator };
+    }
+
+}

--- a/src/SecretSharingDotNetFx4.6.2.csproj
+++ b/src/SecretSharingDotNetFx4.6.2.csproj
@@ -44,11 +44,12 @@
     <Reference Include="System.Numerics" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Cryptography\FinitePoint.cs" />
+    <Compile Include="Cryptography\FinitePoint`1.cs" />
     <Compile Include="Cryptography\Secret.cs" />
     <Compile Include="Cryptography\Secret`1.cs" />
     <Compile Include="Cryptography\ShamirsSecretSharing`1.cs" />
     <Compile Include="Cryptography\ShamirsSecretSharing`3.cs" />
+    <Compile Include="Cryptography\SharedSeparator.cs" />
     <Compile Include="Cryptography\SharesEnumerator.cs" />
     <Compile Include="Cryptography\Shares.cs" />
     <Compile Include="Helper\Extensions.cs" />

--- a/tests/FinitePointTest.cs
+++ b/tests/FinitePointTest.cs
@@ -1,9 +1,9 @@
 // ----------------------------------------------------------------------------
 // <copyright file="FinitePointTest.cs" company="Private">
-// Copyright (c) 2019 All Rights Reserved
+// Copyright (c) 2023 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
-// <date>04/20/2019 10:52:28 PM</date>
+// <date>05/27/2023 06:05:12 PM</date>
 // ----------------------------------------------------------------------------
 
 #region License
@@ -31,26 +31,73 @@
 
 namespace SecretSharingDotNet.Test
 {
-    using System.Linq;
     using System.Numerics;
     using Cryptography;
-    using Math;
     using Xunit;
 
     public class FinitePointTest
     {
+        private const string FinitePointTextRepresentation1 = "01-2929AA3E809003D578AA69B1C3E6F62C517437FEFBAD5BFBB240";
+        private const string FinitePointTextRepresentation2 = "02-665C74ED38FDFF095B2FC9319A272A75";
+
         /// <summary>
         /// Check <see cref="FinitePoint{TNumber}"/> to <see cref="string"/> conversion and vice vera.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-        [Fact]
-        public void FinitePointToString()
+        [Theory]
+        [InlineData(FinitePointTextRepresentation1, FinitePointTextRepresentation1)]
+        [InlineData(FinitePointTextRepresentation2, FinitePointTextRepresentation2)]
+        public void ToString_FromValidFinitePoint_ReturnsCoordinatesSeparatedWithMinus(string input, string expected)
         {
-            var split = new ShamirsSecretSharing<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
-            FinitePoint<BigInteger> fp = split.MakeShares(3, 7, 500).First();
-            string s1 = fp.ToString();
-            string s2 = new FinitePoint<BigInteger>(s1).ToString();
-            Assert.Equal(s1, s2);
+            // Arrange
+            var finitePointUnderTest = new FinitePoint<BigInteger>(input);
+
+            // Act
+            string actual = finitePointUnderTest.ToString();
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CompareTo_BigFinitePointToSmallFinitePoint_ReturnsOne()
+        {
+            // Arrange
+            var finitePointUnder1Test = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
+            var finitePointUnder2Test = new FinitePoint<BigInteger>(FinitePointTextRepresentation2);
+
+            // Act
+            int actual = finitePointUnder1Test.CompareTo(finitePointUnder2Test);
+
+            // Assert
+            Assert.Equal(1, actual);
+        }
+
+        [Fact]
+        public void CompareTo_SmallFinitePointToBigFinitePoint_ReturnsMinusOne()
+        {
+            // Arrange
+            var finitePointUnder1Test = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
+            var finitePointUnder2Test = new FinitePoint<BigInteger>(FinitePointTextRepresentation2);
+
+            // Act
+            int actual = finitePointUnder2Test.CompareTo(finitePointUnder1Test);
+
+            // Assert
+            Assert.Equal(-1, actual);
+        }
+
+        [Fact]
+        public void CompareTo_FinitePointToSameFinitePoint_ReturnsZero()
+        {
+            // Arrange
+            var finitePointUnderTest = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
+
+            // Act
+            int actual = finitePointUnderTest.CompareTo(finitePointUnderTest);
+
+            // Assert
+            Assert.Equal(0, actual);
         }
     }
 }

--- a/tests/FinitePointTest.cs
+++ b/tests/FinitePointTest.cs
@@ -7,6 +7,7 @@
 // ----------------------------------------------------------------------------
 
 #region License
+
 // ----------------------------------------------------------------------------
 // Copyright 2019 Sebastian Walther
 //
@@ -27,6 +28,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 #endregion
 
 namespace SecretSharingDotNet.Test
@@ -98,6 +100,75 @@ namespace SecretSharingDotNet.Test
 
             // Assert
             Assert.Equal(0, actual);
+        }
+
+        [Fact]
+        public void Equals_FinitePointToSameFinitePoint_ReturnsTrue()
+        {
+            // Arrange
+            var finitePointUnderTest1 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
+            var finitePointUnderTest2 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
+
+            // Act
+            bool actual = finitePointUnderTest1.Equals(finitePointUnderTest2);
+
+            // Assert
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_FinitePointToDifferentFinitePoint_ReturnsFalse()
+        {
+            // Arrange
+            var finitePointUnderTest1 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
+            var finitePointUnderTest2 = new FinitePoint<BigInteger>(FinitePointTextRepresentation2);
+
+            // Act
+            bool actual = finitePointUnderTest1.Equals(finitePointUnderTest2);
+
+            // Assert
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_FinitePointToNull_ReturnsFalse()
+        {
+            // Arrange
+            var finitePointUnderTest1 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
+
+            // Act
+            bool actual = finitePointUnderTest1.Equals(null);
+
+            // Assert
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Equals_FinitePointToSameFinitePointAsObject_ReturnsTrue()
+        {
+            // Arrange
+            var finitePointUnderTest1 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
+            object finitePointUnderTest2 = finitePointUnderTest1;
+
+            // Act
+            bool actual = finitePointUnderTest1.Equals(finitePointUnderTest2);
+
+            // Assert
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Equals_FinitePointToDifferentFinitePointAsObject_ReturnsFalse()
+        {
+            // Arrange
+            var finitePointUnderTest1 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
+            object finitePointUnderTest2 = new FinitePoint<BigInteger>(FinitePointTextRepresentation2);
+
+            // Act
+            bool actual = finitePointUnderTest1.Equals(finitePointUnderTest2);
+
+            // Assert
+            Assert.False(actual);
         }
     }
 }


### PR DESCRIPTION
### Changed
- FinitePoint: Use `ReadOnlySpan<char>` for `string` parameters in ctor and methods.
