### PR TITLE
Fix - XunitConsole462Path in SecretSharingDotNetFx4.6.2Test.csproj

### DIFF
--- a/tests/SecretSharingDotNetFx4.6.2Test.csproj
+++ b/tests/SecretSharingDotNetFx4.6.2Test.csproj
@@ -12,7 +12,7 @@
 		<TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
 		<Deterministic>true</Deterministic>
-		<XunitConsole462Path>$(NuGetPackageRoot)xunit.runner.console\2.5.1\tools\net462\xunit.console.x86.exe</XunitConsole462Path>
+		<XunitConsole462Path>$(NuGetPackageRoot)xunit.runner.console\2.6.1\tools\net462\xunit.console.x86.exe</XunitConsole462Path>
 		<XunitConsole>&quot;$(XunitConsole462Path)&quot;</XunitConsole>
 		<NuGetPackageImportStamp>
 		</NuGetPackageImportStamp>


### PR DESCRIPTION
After the update of the xunit.runner.console package from version `2.5.1` to `2.6.1`, the XunitConsole462Path must be modified, because the version is part of this path.