### PR TITLE
Fix - SecurityLevels-Property Location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for .NET FX v4.8.1
 
+### Changed
+- Moved `SecurityLevels` from `ShamirsSecretSharing<TNumber, TExtendedGcdAlgorithm, TExtendedGcdResult>` to `ShamirsSecretSharing`
+
 ## [0.10.2] - 2023-09-16
 ### Changed
 - FinitePoint: Use `ReadOnlySpan<char>` for `string` parameters in ctor and methods.

--- a/src/Cryptography/ShamirsSecretSharing.cs
+++ b/src/Cryptography/ShamirsSecretSharing.cs
@@ -1,0 +1,18 @@
+namespace SecretSharingDotNet.Cryptography
+{
+    /// <summary>
+    /// Abstract class for Shamir's secret sharing algorithm implementation
+    /// </summary>
+    public abstract class ShamirsSecretSharing
+    {
+        /// <summary>
+        /// Saves the known security levels (Mersenne prime exponents)
+        /// </summary>
+        protected static readonly int[] SecurityLevels = new int[]
+        {
+            5, 7, 13, 17, 19, 31, 61, 89, 107, 127, 521, 607, 1279, 2203, 2281, 3217, 4253, 4423, 9689, 9941, 11213,
+            19937, 21701, 23209, 44497, 86243, 110503, 132049, 216091, 756839, 859433, 1257787, 1398269, 2976221,
+            3021377, 6972593, 13466917, 20996011, 24036583, 25964951, 30402457, 32582657, 37156667, 42643801, 43112609
+        };
+    }
+}

--- a/src/Cryptography/ShamirsSecretSharing`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing`1.cs
@@ -32,7 +32,6 @@
 namespace SecretSharingDotNet.Cryptography
 {
     using Math;
-    using System;
 
     /// <inheritdoc />
     public class ShamirsSecretSharing<TNumber> : ShamirsSecretSharing<TNumber, IExtendedGcdAlgorithm<TNumber>, ExtendedGcdResult<TNumber>>

--- a/src/Cryptography/ShamirsSecretSharing`3.cs
+++ b/src/Cryptography/ShamirsSecretSharing`3.cs
@@ -43,20 +43,10 @@ namespace SecretSharingDotNet.Cryptography
     /// <typeparam name="TNumber">Numeric data type</typeparam>
     /// <typeparam name="TExtendedGcdAlgorithm"></typeparam>
     /// <typeparam name="TExtendedGcdResult"></typeparam>
-    public class ShamirsSecretSharing<TNumber, TExtendedGcdAlgorithm, TExtendedGcdResult>
+    public class ShamirsSecretSharing<TNumber, TExtendedGcdAlgorithm, TExtendedGcdResult> : ShamirsSecretSharing
         where TExtendedGcdAlgorithm : class, IExtendedGcdAlgorithm<TNumber, TExtendedGcdResult>
         where TExtendedGcdResult : struct, IExtendedGcdResult<TNumber>
     {
-        /// <summary>
-        /// Saves the known security levels (Mersenne prime exponents)
-        /// </summary>
-        private readonly int[] securityLevels = new int[]
-        {
-            5, 7, 13, 17, 19, 31, 61, 89, 107, 127, 521, 607, 1279, 2203, 2281, 3217, 4253, 4423, 9689, 9941, 11213,
-            19937, 21701, 23209, 44497, 86243, 110503, 132049, 216091, 756839, 859433, 1257787, 1398269, 2976221,
-            3021377, 6972593, 13466917, 20996011, 24036583, 25964951, 30402457, 32582657, 37156667, 42643801, 43112609
-        };
-
         /// <summary>
         /// Saves the fixed security level
         /// </summary>
@@ -104,12 +94,12 @@ namespace SecretSharingDotNet.Cryptography
                     value = 13;
                 }
 
-                int index = Array.BinarySearch(this.securityLevels, value);
+                int index = Array.BinarySearch(SecurityLevels, value);
                 if (index < 0)
                 {
                     try
                     {
-                        value = this.securityLevels.ElementAt(~index);
+                        value = SecurityLevels.ElementAt(~index);
                     }
                     catch (ArgumentOutOfRangeException)
                     {
@@ -446,13 +436,13 @@ namespace SecretSharingDotNet.Cryptography
             }
 
             this.SecurityLevel = maximumY.ByteCount * 8;
-            int index = Array.IndexOf(this.securityLevels, this.SecurityLevel);
+            int index = Array.IndexOf(SecurityLevels, this.SecurityLevel);
             while ((maximumY % this.mersennePrime + this.mersennePrime) % this.mersennePrime == maximumY && index > 0 && this.SecurityLevel > 5)
             {
-                this.SecurityLevel = this.securityLevels[--index];
+                this.SecurityLevel = SecurityLevels[--index];
             }
 
-            this.SecurityLevel = this.securityLevels[this.SecurityLevel > 5 ? ++index : index];
+            this.SecurityLevel = SecurityLevels[this.SecurityLevel > 5 ? ++index : index];
 
             return this.LagrangeInterpolate(shares, this.mersennePrime);
         }

--- a/src/SecretSharingDotNetFx4.6.2.csproj
+++ b/src/SecretSharingDotNetFx4.6.2.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Cryptography\FinitePoint`1.cs" />
     <Compile Include="Cryptography\Secret.cs" />
     <Compile Include="Cryptography\Secret`1.cs" />
+    <Compile Include="Cryptography\ShamirsSecretSharing.cs" />
     <Compile Include="Cryptography\ShamirsSecretSharing`1.cs" />
     <Compile Include="Cryptography\ShamirsSecretSharing`3.cs" />
     <Compile Include="Cryptography\SharedSeparator.cs" />


### PR DESCRIPTION
### Changed
- Moved `SecurityLevels` from `ShamirsSecretSharing<TNumber, TExtendedGcdAlgorithm, TExtendedGcdResult>` to `ShamirsSecretSharing`
