### PR TITLE
Refactor visibility and syntax in Calculator classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added use-case interfaces `IMakeSharesUseCase` and `IReconstructUseCase` to the `SecretSharingDotNet` project.
 - Added a guide to the `README.md` file on how to use the use-case interfaces with dependency injection.
 
+### Changed
+- Changed the `Sqrt` signature in the `BigIntCalculator` class from property to method.
+- Changed method visibility from `public` to `protected` in the `BigIntCalculator`and `Calculator` classes to restrict access.
+
 ### Removed
 - Removed .NET 7 support, because it retires on May 14, 2024. See [.NET and .NET Core Support Policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).
 

--- a/src/Cryptography/FinitePoint`1.cs
+++ b/src/Cryptography/FinitePoint`1.cs
@@ -192,7 +192,7 @@ public readonly struct FinitePoint<TNumber> : IEquatable<FinitePoint<TNumber>>, 
     /// <inheritdoc />
     public int CompareTo(FinitePoint<TNumber> other)
     {
-        return ((this.X.Pow(2) + this.Y.Pow(2)).Sqrt - (other.X.Pow(2) + other.Y.Pow(2)).Sqrt).Sign;
+        return ((this.X.Pow(2) + this.Y.Pow(2)).Sqrt() - (other.X.Pow(2) + other.Y.Pow(2)).Sqrt()).Sign;
     }
 
     /// <summary>

--- a/src/Cryptography/Secret`1.cs
+++ b/src/Cryptography/Secret`1.cs
@@ -307,7 +307,7 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
 
     /// <summary>
     /// Converts the value of <see cref="Secret{TNumber}"/> structure to its equivalent <see cref="string"/> representation
-    /// that is unicode encoded.
+    /// that is Unicode encoded.
     /// </summary>
     /// <returns><see cref="string"/> representation of <see cref="Secret{TNumber}"/></returns>
     public override string ToString()

--- a/src/Math/BigIntCalculator.cs
+++ b/src/Math/BigIntCalculator.cs
@@ -82,28 +82,28 @@ public sealed class BigIntCalculator : Calculator<BigInteger>
     /// </summary>
     /// <param name="right">right-hand operand</param>
     /// <returns>This method returns <see langword="true"/> if this instance is greater than the <paramref name="right"/> instance, <see langword="false"/> otherwise.</returns>
-    public override bool GreaterThan(BigInteger right) => this.Value > right;
+    protected override bool GreaterThan(BigInteger right) => this.Value > right;
 
     /// <summary>
     /// This method represents the Lower Than operator.
     /// </summary>
     /// <param name="right">right-hand operand</param>
     /// <returns>This method returns <see langword="true"/> if this instance is less than the <paramref name="right"/> instance, <see langword="false"/> otherwise.</returns>
-    public override bool LowerThan(BigInteger right) => this.Value < right;
+    protected override bool LowerThan(BigInteger right) => this.Value < right;
 
     /// <summary>
     /// This method represents the Greater Than Or Equal To operator.
     /// </summary>
     /// <param name="right">right-hand operand</param>
     /// <returns>This method returns <see langword="true"/> if this instance is greater than or equal to the <paramref name="right"/> instance, <see langword="false"/> otherwise.</returns>
-    public override bool EqualOrGreaterThan(BigInteger right) => this.Value >= right;
+    protected override bool EqualOrGreaterThan(BigInteger right) => this.Value >= right;
 
     /// <summary>
     /// This method represents the Lower Than Or Equal To operator.
     /// </summary>
     /// <param name="right">right-hand operand</param>
     /// <returns>This method returns <see langword="true"/> if this instance is less than or equal to the <paramref name="right"/> instance, <see langword="false"/> otherwise.</returns>
-    public override bool EqualOrLowerThan(BigInteger right) => this.Value <= right;
+    protected override bool EqualOrLowerThan(BigInteger right) => this.Value <= right;
 
     /// <inheritdoc />
     /// <exception cref="T:System.OverflowException">Unable to convert the current instance of <see cref="BigIntCalculator"/> class to <see cref="Int32"/>.</exception>
@@ -127,7 +127,7 @@ public sealed class BigIntCalculator : Calculator<BigInteger>
     /// <param name="right">Right value to add (right summand).</param>
     /// <returns>The sum of the current <see cref="BigIntCalculator"/> instance and the <paramref name="right"/>
     /// <see cref="BigIntCalculator"/> instance.</returns>
-    public override Calculator<BigInteger> Add(BigInteger right) => this.Value + right;
+    protected override Calculator<BigInteger> Add(BigInteger right) => this.Value + right;
 
     /// <summary>
     /// Subtracts the current <see cref="BigIntCalculator"/> instance with the <paramref name="right"/>
@@ -136,7 +136,7 @@ public sealed class BigIntCalculator : Calculator<BigInteger>
     /// <param name="right">Right value to subtract (subtrahend).</param>
     /// <returns>The difference of the current <see cref="BigIntCalculator"/> instance and the <paramref name="right"/>
     /// <see cref="BigIntCalculator"/> instance.</returns>
-    public override Calculator<BigInteger> Subtract(BigInteger right) => this.Value - right;
+    protected override Calculator<BigInteger> Subtract(BigInteger right) => this.Value - right;
 
     /// <summary>
     /// Multiplies the current <see cref="BigIntCalculator"/> instance with the <paramref name="right"/>
@@ -145,7 +145,7 @@ public sealed class BigIntCalculator : Calculator<BigInteger>
     /// <param name="right">multiplicand</param>
     /// <returns>The product of the current <see cref="BigIntCalculator"/> instance and the <paramref name="right"/>
     /// <see cref="BigIntCalculator"/> instance.</returns>
-    public override Calculator<BigInteger> Multiply(BigInteger right) => this.Value * right;
+    protected override Calculator<BigInteger> Multiply(BigInteger right) => this.Value * right;
 
     /// <summary>
     /// Divides the current <see cref="BigIntCalculator"/> instance with the <paramref name="right"/>
@@ -154,26 +154,26 @@ public sealed class BigIntCalculator : Calculator<BigInteger>
     /// <param name="right">divisor</param>
     /// <returns>The quotient of the current <see cref="BigIntCalculator"/> instance and the <paramref name="right"/>
     /// <see cref="BigIntCalculator"/> instance.</returns>
-    public override Calculator<BigInteger> Divide(BigInteger right) => this.Value / right;
+    protected override Calculator<BigInteger> Divide(BigInteger right) => this.Value / right;
 
     /// <summary>
     /// The modulo operation
     /// </summary>
     /// <param name="right">divisor</param>
     /// <returns>The remainder as <see cref="BigIntCalculator"/> instance.</returns>
-    public override Calculator<BigInteger> Modulo(BigInteger right) => this.Value % right;
+    protected override Calculator<BigInteger> Modulo(BigInteger right) => this.Value % right;
 
     /// <summary>
     /// The unary increment method increments this instance by 1.
     /// </summary>
     /// <returns>This <see cref="BigIntCalculator"/> instance plus <see cref="Calculator{BigInteger}.One"/></returns>
-    public override Calculator<BigInteger> Increment() => ++this.Clone().Value;
+    protected override Calculator<BigInteger> Increment() => ++this.Clone().Value;
 
     /// <summary>
     /// The unary decrement method decrements this instance by 1.
     /// </summary>
     /// <returns>This <see cref="BigIntCalculator"/> instance minus <see cref="Calculator{BigInteger}.One"/></returns>
-    public override Calculator<BigInteger> Decrement() => --this.Clone().Value;
+    protected override Calculator<BigInteger> Decrement() => --this.Clone().Value;
 
     /// <summary>
     /// Returns the absolute value of the current <see cref="BigIntCalculator"/> object.
@@ -225,30 +225,27 @@ public sealed class BigIntCalculator : Calculator<BigInteger>
     /// Returns the square root of the current <see cref="BigIntCalculator"/> object.
     /// </summary>
     /// <exception cref="T:System.ArithmeticException" accessor="get">NaN (value is lower than zero)</exception>
-    public override Calculator<BigInteger> Sqrt
+    public override Calculator<BigInteger> Sqrt()
     {
-        get
+        if (this.Value == BigInteger.Zero)
         {
-            if (this.Value == BigInteger.Zero)
-            {
-                return Zero;
-            }
-
-            if (this.Value < BigInteger.Zero)
-            {
-                throw new ArithmeticException("NaN");
-            }
-
-            int bitLength = Convert.ToInt32(Math.Ceiling(BigInteger.Log(this.Value, 2)));
-            var root = BigInteger.One << (bitLength >> 1);
-            bool IsSqrt(BigInteger n, BigInteger r) => n >= r * r && n < (r + 1) * (r + 1);
-            while (!IsSqrt(this.Value, root))
-            {
-                root = root + this.Value / root >> 1;
-            }
-
-            return root;
+            return Zero;
         }
+
+        if (this.Value < BigInteger.Zero)
+        {
+            throw new ArithmeticException("NaN");
+        }
+
+        int bitLength = Convert.ToInt32(Math.Ceiling(BigInteger.Log(this.Value, 2)));
+        var root = BigInteger.One << (bitLength >> 1);
+        bool IsSqrt(BigInteger n, BigInteger r) => n >= r * r && n < (r + 1) * (r + 1);
+        while (!IsSqrt(this.Value, root))
+        {
+            root = root + this.Value / root >> 1;
+        }
+
+        return root;
     }
 
     /// <summary>

--- a/src/Math/Calculator`1.cs
+++ b/src/Math/Calculator`1.cs
@@ -39,7 +39,11 @@ using System.Collections.ObjectModel;
 /// implementation from the concrete numeric data type like BigInteger.
 /// </summary>
 /// <typeparam name="TNumber">Numeric data type</typeparam>
-public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TNumber>>, IComparable, IComparable<Calculator<TNumber>>
+public abstract class Calculator<TNumber> :
+    Calculator,
+    IEquatable<Calculator<TNumber>>,
+    IComparable,
+    IComparable<Calculator<TNumber>>
 {
     /// <summary>
     /// Saves a dictionary of constructors of number data types derived from the <see cref="Calculator{TNumber}"/> class.
@@ -59,7 +63,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="right">Right value to add (right summand).</param>
     /// <returns>The sum of the current <see cref="Calculator{TNumber}"/> instance and the <paramref name="right"/> 
     /// <see cref="Calculator{TNumber}"/> instance.</returns>
-    public abstract Calculator<TNumber> Add(TNumber right);
+    protected abstract Calculator<TNumber> Add(TNumber right);
 
     /// <summary>
     /// Subtracts the current <see cref="Calculator{TNumber}"/> instance with the <paramref name="right"/> 
@@ -68,7 +72,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="right">Right value to subtract (subtrahend).</param>
     /// <returns>The difference of the current <see cref="Calculator{TNumber}"/> instance and the <paramref name="right"/> 
     /// <see cref="Calculator{TNumber}"/> instance.</returns>
-    public abstract Calculator<TNumber> Subtract(TNumber right);
+    protected abstract Calculator<TNumber> Subtract(TNumber right);
 
     /// <summary>
     /// Multiplies the current <see cref="Calculator{TNumber}"/> instance with the <paramref name="right"/> 
@@ -77,7 +81,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="right">multiplicand</param>
     /// <returns>The product of the current <see cref="Calculator{TNumber}"/> instance and the <paramref name="right"/> 
     /// <see cref="Calculator{TNumber}"/> instance.</returns>
-    public abstract Calculator<TNumber> Multiply(TNumber right);
+    protected abstract Calculator<TNumber> Multiply(TNumber right);
 
     /// <summary>
     /// Divides the current <see cref="Calculator{TNumber}"/> instance with the <paramref name="right"/> 
@@ -86,26 +90,26 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="right">divisor</param>
     /// <returns>The quotient of the current <see cref="Calculator{TNumber}"/> instance and the <paramref name="right"/> 
     /// <see cref="Calculator{TNumber}"/> instance.</returns>
-    public abstract Calculator<TNumber> Divide(TNumber right);
+    protected abstract Calculator<TNumber> Divide(TNumber right);
 
     /// <summary>
     /// The modulo operation
     /// </summary>
     /// <param name="right">divisor</param>
     /// <returns>The remainder</returns>
-    public abstract Calculator<TNumber> Modulo(TNumber right);
+    protected abstract Calculator<TNumber> Modulo(TNumber right);
 
     /// <summary>
     /// The unary increment method increments this instance by 1.
     /// </summary>
     /// <returns>This <see cref="Calculator{TNumber}"/> instance plus <see cref="Calculator{TNumber}.One"/></returns>
-    public abstract Calculator<TNumber> Increment();
+    protected abstract Calculator<TNumber> Increment();
 
     /// <summary>
     /// The unary decrement method decrements this instance by 1.
     /// </summary>
     /// <returns>This <see cref="Calculator{TNumber}"/> instance minus <see cref="Calculator{TNumber}.One"/></returns>
-    public abstract Calculator<TNumber> Decrement();
+    protected abstract Calculator<TNumber> Decrement();
 
     /// <summary>
     /// Returns the absolute value of the current <see cref="Calculator{TNumber}"/> object.
@@ -123,35 +127,35 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <summary>
     /// Returns the square root of the current <see cref="Calculator{TNumber}"/>.
     /// </summary>
-    public abstract Calculator<TNumber> Sqrt { get; }
+    public abstract Calculator<TNumber> Sqrt();
 
     /// <summary>
     /// This method represents the Greater Than operator.
     /// </summary>
     /// <param name="right">right-hand operand</param>
     /// <returns>This method returns <see langword="true"/> if this instance is greater than the <paramref name="right"/> instance, <see langword="false"/> otherwise.</returns>
-    public abstract bool GreaterThan(TNumber right);
+    protected abstract bool GreaterThan(TNumber right);
 
     /// <summary>
     /// This method represents the Greater Than Or Equal To operator.
     /// </summary>
     /// <param name="right">right-hand operand</param>
     /// <returns>This method returns <see langword="true"/> if this instance is greater than or equal to the <paramref name="right"/> instance, <see langword="false"/> otherwise.</returns>
-    public abstract bool EqualOrGreaterThan(TNumber right);
+    protected abstract bool EqualOrGreaterThan(TNumber right);
 
     /// <summary>
     /// This method represents the Lower Than operator.
     /// </summary>
     /// <param name="right">right-hand operand</param>
     /// <returns>This method returns <see langword="true"/> if this instance is less than the <paramref name="right"/> instance, <see langword="false"/> otherwise.</returns>
-    public abstract bool LowerThan(TNumber right);
+    protected abstract bool LowerThan(TNumber right);
 
     /// <summary>
     /// This method represents the Lower Than Or Equal To operator.
     /// </summary>
     /// <param name="right">right-hand operand</param>
     /// <returns>This method returns <see langword="true"/> if this instance is less than or equal to the <paramref name="right"/> instance, <see langword="false"/> otherwise.</returns>
-    public abstract bool EqualOrLowerThan(TNumber right);
+    protected abstract bool EqualOrLowerThan(TNumber right);
 
     /// <summary>
     /// Greater than operator
@@ -159,7 +163,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="left">The 1st operand</param>
     /// <param name="right">The 2nd operand</param>
     /// <returns>Returns <see langword="true"/> if its 1st operand is greater than its 2nd operand, otherwise <see langword="false"/>.</returns>
-    public static bool operator >(Calculator<TNumber> left, Calculator<TNumber> right) => !(left is null) && !(right is null) && left.GreaterThan(right.Value);
+    public static bool operator >(Calculator<TNumber> left, Calculator<TNumber> right) => left is not null && right is not null && left.GreaterThan(right.Value);
 
     /// <summary>
     /// Less than operator
@@ -167,7 +171,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="left">The 1st operand</param>
     /// <param name="right">The 2nd operand</param>
     /// <returns>Returns <see langword="true"/> if its 1st operand is less than its 2nd operand, otherwise <see langword="false"/>.</returns>
-    public static bool operator <(Calculator<TNumber> left, Calculator<TNumber> right) => !(left is null) && !(right is null) && left.LowerThan(right.Value);
+    public static bool operator <(Calculator<TNumber> left, Calculator<TNumber> right) => left is not null && right is not null && left.LowerThan(right.Value);
 
     /// <summary>
     /// Greater than or equal operator
@@ -175,7 +179,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="left">The 1st operand</param>
     /// <param name="right">The 2nd operand</param>
     /// <returns>Returns <see langword="true"/> if its 1st operand is greater than or equal to its 2nd operand, otherwise <see langword="false"/>.</returns>
-    public static bool operator >=(Calculator<TNumber> left, Calculator<TNumber> right) => !(left is null) && !(right is null) && left.EqualOrGreaterThan(right.Value);
+    public static bool operator >=(Calculator<TNumber> left, Calculator<TNumber> right) => left is not null && right is not null && left.EqualOrGreaterThan(right.Value);
 
     /// <summary>
     /// Less than or equal operator
@@ -183,7 +187,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="left">The 1st operand</param>
     /// <param name="right">The 2nd operand</param>
     /// <returns>Returns <see langword="true"/> if its 1st operand is less than or equal to its 2nd operand, otherwise <see langword="false"/>.</returns>
-    public static bool operator <=(Calculator<TNumber> left, Calculator<TNumber> right) => !(left is null) && !(right is null) && left.EqualOrLowerThan(right.Value);
+    public static bool operator <=(Calculator<TNumber> left, Calculator<TNumber> right) => left is not null && right is not null && left.EqualOrLowerThan(right.Value);
 
     /// <summary>
     /// Addition operation
@@ -191,7 +195,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="left">The 1st summand</param>
     /// <param name="right">The 2nd summand</param>
     /// <returns>The sum</returns>
-    public static Calculator<TNumber> operator +(Calculator<TNumber> left, Calculator<TNumber> right) => !(right is null) ? left?.Add(right.Value) ?? throw new ArgumentNullException(nameof(left)) : throw new ArgumentNullException(nameof(right));
+    public static Calculator<TNumber> operator +(Calculator<TNumber> left, Calculator<TNumber> right) => right is not null ? left?.Add(right.Value) ?? throw new ArgumentNullException(nameof(left)) : throw new ArgumentNullException(nameof(right));
 
     /// <summary>
     /// Subtraction operation
@@ -199,7 +203,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="left">The minuend</param>
     /// <param name="right">The subtrahend</param>
     /// <returns>The difference</returns>
-    public static Calculator<TNumber> operator -(Calculator<TNumber> left, Calculator<TNumber> right) => !(right is null) ? left?.Subtract(right.Value) ?? throw new ArgumentNullException(nameof(left)) : throw new ArgumentNullException(nameof(right));
+    public static Calculator<TNumber> operator -(Calculator<TNumber> left, Calculator<TNumber> right) => right is not null ? left?.Subtract(right.Value) ?? throw new ArgumentNullException(nameof(left)) : throw new ArgumentNullException(nameof(right));
 
     /// <summary>
     /// Multiplication operation
@@ -207,7 +211,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="left">multiplier</param>
     /// <param name="right">multiplicand</param>
     /// <returns>The product</returns>
-    public static Calculator<TNumber> operator *(Calculator<TNumber> left, Calculator<TNumber> right) => !(right is null) ? left?.Multiply(right.Value) ?? throw new ArgumentNullException(nameof(left)) : throw new ArgumentNullException(nameof(right));
+    public static Calculator<TNumber> operator *(Calculator<TNumber> left, Calculator<TNumber> right) => right is not null ? left?.Multiply(right.Value) ?? throw new ArgumentNullException(nameof(left)) : throw new ArgumentNullException(nameof(right));
 
     /// <summary>
     /// Divide operation
@@ -215,7 +219,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="left">dividend</param>
     /// <param name="right">divisor</param>
     /// <returns>The quotient</returns>
-    public static Calculator<TNumber> operator /(Calculator<TNumber> left, Calculator<TNumber> right) => !(right is null) ? left?.Divide(right.Value) ?? throw new ArgumentNullException(nameof(left)) : throw new ArgumentNullException(nameof(right));
+    public static Calculator<TNumber> operator /(Calculator<TNumber> left, Calculator<TNumber> right) => right is not null ? left?.Divide(right.Value) ?? throw new ArgumentNullException(nameof(left)) : throw new ArgumentNullException(nameof(right));
 
     /// <summary>
     /// Modulo operation
@@ -223,7 +227,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// <param name="left">dividend</param>
     /// <param name="right">divisor</param>
     /// <returns>The remainder</returns>
-    public static Calculator<TNumber> operator %(Calculator<TNumber> left, Calculator<TNumber> right) => !(right is null) ? left?.Modulo(right.Value) ?? throw new ArgumentNullException(nameof(left)) : throw new ArgumentNullException(nameof(right));
+    public static Calculator<TNumber> operator %(Calculator<TNumber> left, Calculator<TNumber> right) => right is not null ? left?.Modulo(right.Value) ?? throw new ArgumentNullException(nameof(left)) : throw new ArgumentNullException(nameof(right));
 
     /// <summary>
     /// Increment operator
@@ -275,7 +279,7 @@ public abstract class Calculator<TNumber> : Calculator, IEquatable<Calculator<TN
     /// Casts the <see cref="Calculator{TNumber}"/> instance to an <typeparamref name="TNumber"/> instance.
     /// </summary>
     /// <param name="calculatorInstance">A data type from basic class <see cref="Calculator{TNumber}"/>.</param>
-    public static implicit operator TNumber(Calculator<TNumber> calculatorInstance) => !(calculatorInstance is null) ? calculatorInstance.Value : default;
+    public static implicit operator TNumber(Calculator<TNumber> calculatorInstance) => calculatorInstance is not null ? calculatorInstance.Value : default;
 
     /// <summary>
     /// Casts the <typeparamref name="TNumber"/> instance to an <see cref="Calculator{TNumber}"/> instance.


### PR DESCRIPTION
Update method visibility from public to protected in BigIntCalculator and Calculator`1 classes to restrict access. Also, fix method call syntax for Sqrt in FinitePoint`1 and improve null checks in operator overloads.

Resolves: No entry