### PR TITLE
Remove .NET 6 Support

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,19 +41,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v4.1.0
-      with:
-        dotnet-version: 6.0.425
-
     - name: Setup .NET 8
       uses: actions/setup-dotnet@v4.1.0
       with:
-        dotnet-version: 8.0.401
+        dotnet-version: 8.0.404
 
     - name: .NET Core SxS
       run: |
-        rsync -a ${DOTNET_ROOT/8.0.100/7.0.403/6.0.416}/* $DOTNET_ROOT/
+        rsync -a ${DOTNET_ROOT/8.0.404}/* $DOTNET_ROOT/
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -18,15 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v4.1.0
-      with:
-        dotnet-version: 6.0.425
-
     - name: Setup .NET 8
       uses: actions/setup-dotnet@v4.1.0
       with:
-        dotnet-version: 8.0.401
+        dotnet-version: 8.0.404
 
     - name: Restore
       run: dotnet restore SecretSharingDotNet.sln

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -16,15 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v4.1.0
-      with:
-        dotnet-version: 6.0.425
-
     - name: Setup .NET 8
       uses: actions/setup-dotnet@v4.1.0
       with:
-        dotnet-version: 8.0.401
+        dotnet-version: 8.0.404
 
     - name: Decrypt large secret
       run: ./.github/secrets/decrypt_publisher_snk.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed .NET 7 support, because it retires on May 14, 2024. See [.NET and .NET Core Support Policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).
+- Removed .NET 6 support, because it retires on November 12, 2024. See [.NET and .NET Core Support Policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).
 
 ## [0.11.0] - 2023-12-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
+          <td rowspan=8><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+%28All+supported+TFM%29%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20(All%20supported%20TFM)/badge.svg" alt="Build status"/></a></td>
           <td rowspan=9><code>SecretSharingDotNet.sln</code></td>
-          <td rowspan=9>SDK</td>
+          <td rowspan=8>SDK</td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
@@ -35,9 +35,6 @@ An C# implementation of Shamir's Secret Sharing.
       </tr>
       <tr>
           <td>FX 4.8</td>
-      </tr>
-      <tr>
-          <td>.NET 6</td>
       </tr>
       <tr>
           <td>.NET 8</td>
@@ -58,9 +55,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.11.0" alt="SecretSharingDotNet NuGet"/></a></td>
-          <td rowspan=9><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.11.0"/></a></td>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.11.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.11.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.11.0" alt="SecretSharingDotNet NuGet"/></a></td>
+          <td rowspan=8><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.11.0"/></a></td>
+          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.11.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.11.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
@@ -80,9 +77,6 @@ An C# implementation of Shamir's Secret Sharing.
       </tr>
       <tr>
           <td>FX 4.8</td>
-      </tr>
-      <tr>
-          <td>.NET 6</td>
       </tr>
       <tr>
           <td>.NET 8</td>
@@ -441,7 +435,7 @@ You can find the Mono installation instructions [here](https://www.mono-project.
 
 The .NET Frameworks 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8 and 4.8.1 can be found [here](https://dotnet.microsoft.com/download/dotnet-framework).
 
-The .NET SDKs 6.0, 7.0 and 8.0 can be found [here](https://dotnet.microsoft.com/download/dotnet).
+The .NET SDK 8.0 can be found [here](https://dotnet.microsoft.com/download/dotnet).
 
 ## Build and test the solution
 You can use the `SecretSharingDotNet.sln` solution file with the `dotnet` command to build the [SecretSharingDotNet](#secretsharingdotnet) library in the `Debug` or `Release` configuration. You can also use the `dotnet` command to start the unit tests.

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -5,7 +5,7 @@
         <RootNamespace>SecretSharingDotNet</RootNamespace>
         <OutputType>Library</OutputType>
         <LangVersion>latest</LangVersion>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net47;net471;net472;net48;net481;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net47;net471;net472;net48;net481;net8.0</TargetFrameworks>
         <AssemblyOriginatorKeyFile>SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>True</SignAssembly>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net462;net47;net471;net472;net48;net481;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\src\SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
### Removed
- Removed .NET 6 support, because it retires on November 12, 2024. See [.NET and .NET Core Support Policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).