### PR TITLE
Release - v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.0] - 2024-11-17
 ### Added
 - Added .NET 9.0 support
 - Added use-case interfaces `IMakeSharesUseCase` and `IReconstructUseCase` to the `SecretSharingDotNet` project.
@@ -220,7 +220,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LICENSE.md`
 - Added `README.md`
 
-[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.11.0...develop
+[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.12.0...develop
+[0.12.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.10.2...v0.11.0
 [0.10.2]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.10.0...v0.10.1

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.11.0" alt="SecretSharingDotNet NuGet"/></a></td>
-          <td rowspan=9><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.11.0"/></a></td>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.11.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.11.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/actions?query=workflow%3A%22SecretSharingDotNet+NuGet%22" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/workflows/SecretSharingDotNet%20NuGet/badge.svg?branch=v0.12.0" alt="SecretSharingDotNet NuGet"/></a></td>
+          <td rowspan=9><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.12.0"/></a></td>
+          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.12.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.12.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
@@ -94,10 +94,10 @@ An C# implementation of Shamir's Secret Sharing.
 
 1. Open a console and switch to the directory, containing your project file.
 
-2. Use the following command to install version 0.11.0 of the SecretSharingDotNet package:
+2. Use the following command to install version 0.12.0 of the SecretSharingDotNet package:
 
     ```dotnetcli
-    dotnet add package SecretSharingDotNet -v 0.11.0 -f <FRAMEWORK>
+    dotnet add package SecretSharingDotNet -v 0.12.0 -f <FRAMEWORK>
     ```
 
 3. After the completion of the command, look at the project file to make sure that the package is successfully installed.
@@ -106,7 +106,7 @@ An C# implementation of Shamir's Secret Sharing.
 
     ```xml
     <ItemGroup>
-      <PackageReference Include="SecretSharingDotNet" Version="0.11.0" />
+      <PackageReference Include="SecretSharingDotNet" Version="0.12.0" />
     </ItemGroup>
     ```
 ## Remove SecretSharingDotNet package

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("1c21b99c-2de4-4ca5-b4ce-bc95cf89369e")]
 
-[assembly: AssemblyVersion("0.11.0")]
-[assembly: AssemblyFileVersion("0.11.0")]
+[assembly: AssemblyVersion("0.12.0")]
+[assembly: AssemblyFileVersion("0.12.0")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -11,14 +11,14 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <PackageId>SecretSharingDotNet</PackageId>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v0.11.0/CHANGELOG.md</PackageReleaseNotes>
+        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v0.12.0/CHANGELOG.md</PackageReleaseNotes>
         <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
         <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
         <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>0.11.0</Version>
+        <Version>0.12.0</Version>
         <Authors>Sebastian Walther</Authors>
         <Company>Private Person</Company>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
### Added
- Added .NET 9.0 support
- Added use-case interfaces `IMakeSharesUseCase` and `IReconstructUseCase` to the `SecretSharingDotNet` project.
- Added a guide to the `README.md` file on how to use the use-case interfaces with dependency injection.

### Changed
- Changed the `Sqrt` signature in the `BigIntCalculator` class from property to method.
- Changed method visibility from `public` to `protected` in the `BigIntCalculator`and `Calculator` classes to restrict access.

### Removed
- Removed .NET 7 support, because it retires on May 14, 2024. See [.NET and .NET Core Support Policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).
- Removed .NET 6 support, because it retires on November 12, 2024. See [.NET and .NET Core Support Policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).
