### PR TITLE
Fix - CI/CD-Pipline -  Switch back to  Ubuntu 22

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: "SecretSharingDotNet - CodeQL"
 
 on:
   push:
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -1,4 +1,4 @@
-name: SecretSharingDotNet (All supported TFM)
+name: SecretSharingDotNet - Build and Test All .NET Versions
 
 on:
   push:

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1,4 +1,4 @@
-name: SecretSharingDotNet NuGet
+name: SecretSharingDotNet - NuGet Publishing
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for the SecretSharingDotNet project. The changes involve renaming workflows for clarity and updating the runner version.

Workflow renaming for clarity:

* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L12-R12): Changed the workflow name to "SecretSharingDotNet - CodeQL" for better identification.
* [`.github/workflows/dotnetall.yml`](diffhunk://#diff-41ab2c28d621ef59806d61fb5286fc0cd88039bf56293febcdf3895606f1cd78L1-R1): Updated the workflow name to "SecretSharingDotNet - Build and Test All .NET Versions" to clearly reflect its purpose.
* [`.github/workflows/publishing.yml`](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26L1-R1): Renamed the workflow to "SecretSharingDotNet - NuGet Publishing" for better clarity.

Runner version update:

* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L26-R26): Changed the runner from `ubuntu-latest` to `ubuntu-22.04` for consistency and potentially better performance.
* [`.github/workflows/dotnetall.yml`](diffhunk://#diff-41ab2c28d621ef59806d61fb5286fc0cd88039bf56293febcdf3895606f1cd78L15-R15): Updated the runner from `ubuntu-latest` to `ubuntu-22.04` to ensure compatibility with the latest .NET versions.
* [`.github/workflows/publishing.yml`](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26L13-R13): Modified the runner from `ubuntu-latest` to `ubuntu-22.04` for improved stability and performance.