### PR TITLE
Remove .NET Framework 4.6.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `IMersennePrimeProvider` and `MersennePrimeProvider` (Default Implementation) to manage Mersenne primes in one place.
 
 ### Changed
-- Changed the implementation by modularizing and separating responsibilities of `ShamirsSecretSharing` class into the `ShamirsSecretSharing` and `SecretReconstructor` classes.
+- Changed the implementation by modularizing and separating responsibilities of `ShamirsSecretSharing` class into the `SecretSplitter` and `SecretReconstructor` classes.
+
+### Removed
+- Removed .NET Framework 4.6.2 support
 
 ## [0.12.0] - 2024-11-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,16 +13,13 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/dotnetall.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/dotnetall.yml/badge.svg?branch=main" alt="Build status"/></a></td>
-          <td rowspan=9><code>SecretSharingDotNet.sln</code></td>
-          <td rowspan=9>SDK</td>
+          <td rowspan=8><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/dotnetall.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/dotnetall.yml/badge.svg?branch=main" alt="Build status"/></a></td>
+          <td rowspan=8><code>SecretSharingDotNet.sln</code></td>
+          <td rowspan=8>SDK</td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
           <td>Standard 2.1</td>
-      </tr>
-      <tr>
-          <td>FX 4.6.2</td>
       </tr>
       <tr>
           <td>FX 4.7</td>
@@ -58,16 +55,13 @@ An C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml/badge.svg" alt="SecretSharingDotNet - NuGet Publishing"/></a></td>
-          <td rowspan=9><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.12.0"/></a></td>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.12.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.12.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml/badge.svg" alt="SecretSharingDotNet - NuGet Publishing"/></a></td>
+          <td rowspan=8><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.12.0"/></a></td>
+          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.12.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.12.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
           <td>Standard 2.1</td>
-      </tr>
-      <tr>
-          <td>FX 4.6.2</td>
       </tr>
       <tr>
           <td>FX 4.7</td>
@@ -437,10 +431,10 @@ namespace Example5
 ## Prerequisites
 For the following instructions, please make sure that you are connected to the internet. If necessary, NuGet will try to restore the [xUnit](https://xunit.net/) packages.
 
-If you start the unit tests on Linux, you must install the `mono-complete` package in case of the .NET Frameworks 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8 and 4.8.1.
+If you start the unit tests on Linux, you must install the `mono-complete` package in case of the .NET Frameworks 4.7, 4.7.1, 4.7.2, 4.8 and 4.8.1.
 You can find the Mono installation instructions [here](https://www.mono-project.com/download/stable/#download-lin).
 
-The .NET Frameworks 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8 and 4.8.1 can be found [here](https://dotnet.microsoft.com/download/dotnet-framework).
+The .NET Frameworks 4.7, 4.7.1, 4.7.2, 4.8 and 4.8.1 can be found [here](https://dotnet.microsoft.com/download/dotnet-framework).
 
 The .NET SDKs 8.0 and 9.0 can be found [here](https://dotnet.microsoft.com/download/dotnet).
 

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -5,7 +5,7 @@
         <RootNamespace>SecretSharingDotNet</RootNamespace>
         <OutputType>Library</OutputType>
         <LangVersion>latest</LangVersion>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net47;net471;net472;net48;net481;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net47;net471;net472;net48;net481;net8.0;net9.0</TargetFrameworks>
         <AssemblyOriginatorKeyFile>SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>True</SignAssembly>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net47;net471;net472;net48;net481;net8.0;net9.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\src\SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This pull request removes support for .NET Framework 4.6.2 from the project, updates documentation and configuration files to reflect this change, and clarifies the modularization of the secret sharing implementation. The most important changes are grouped below:

**Platform Support Updates:**

* Removed .NET Framework 4.6.2 from the list of supported target frameworks in `src/SecretSharingDotNet.csproj` and `tests/SecretSharingDotNetTest.csproj`. [[1]](diffhunk://#diff-0ca99e18c59d3eef1c95b0938a1d210c7446318be08a04e01d78a1641fd16a69L8-R8) [[2]](diffhunk://#diff-031231e27b18c1fa8bb1165dd28274ddf0085d3a5e27987516089d745e605d5eL5-R5)
* Updated the README and changelog to remove references to .NET Framework 4.6.2, including badges, build matrix, and prerequisites. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-L26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-L71) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L440-R437) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL13-R16)

**Documentation and Changelog:**

* Added a "Removed" section to the changelog documenting the dropped .NET Framework 4.6.2 support.
* Clarified the modularization of the `ShamirsSecretSharing` class, specifying the split into `SecretSplitter` and `SecretReconstructor` classes in the changelog.