### PR TITLE
Feature: Switched to UTF-8 encoding for secret string parsing and conversion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Changed String Encoding from UTF-16 to UTF-8 in `Secret<TNumber>` class for better interoperability. Encoding.Unicode (UTF-16 LE) is uncommon in cryptographic and web contexts. UTF-8 is the de facto standard and avoids unnecessary null bytes and payload bloat for ASCII-heavy input.
+
 ## [0.13.0] - 2025-11-16
 ### Added
 - Added `ISecurityLevelManager` and `SecurityLevelManager` (Default Implementation) to manage security levels in one place.

--- a/src/Cryptography/Secret`1.cs
+++ b/src/Cryptography/Secret`1.cs
@@ -213,7 +213,7 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
     public static implicit operator Secret<TNumber>(ReadOnlySpan<char> secretText)
     {
         ArrayBufferWriter<byte> arrayBufferWriter = new();
-        Encoding.Unicode.GetBytes(secretText, arrayBufferWriter);
+        Encoding.UTF8.GetBytes(secretText, arrayBufferWriter);
         Secret<TNumber> secret = new(arrayBufferWriter.WrittenSpan);
         arrayBufferWriter.Clear();
         return secret;
@@ -222,7 +222,7 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
     /// <summary>
     /// Casts the <see cref="string"/> instance to an <see cref="Secret{TNumber}"/> instance
     /// </summary>
-    public static implicit operator Secret<TNumber>(string secretText) => new Secret<TNumber>(Encoding.Unicode.GetBytes(secretText));
+    public static implicit operator Secret<TNumber>(string secretText) => new Secret<TNumber>(Encoding.UTF8.GetBytes(secretText));
 #endif
 
     /// <summary>
@@ -336,19 +336,12 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
     /// <returns><see cref="string"/> representation of <see cref="Secret{TNumber}"/></returns>
     public override string ToString()
     {
-        int padCount = (this.secretNumber.Length - MarkByteCount) % sizeof(char);
-        if (padCount == 0)
+        if (this.secretNumber is not { Length: > MarkByteCount })
         {
-            return Encoding.Unicode.GetString(this.secretNumber, 0, this.secretNumber.Length - MarkByteCount);
+            return string.Empty;
         }
 
-        var padded = new List<byte>(this.secretNumber.Subset(0, this.secretNumber.Length - MarkByteCount));
-        for (int i = 0; i < padCount; i++)
-        {
-            padded.Add(0x00);
-        }
-
-        return Encoding.Unicode.GetString(padded.ToArray(), 0, padded.Count);
+        return Encoding.UTF8.GetString(this.secretNumber, 0, this.secretNumber.Length - MarkByteCount);
     }
 
     /// <summary>

--- a/tests/TestData.cs
+++ b/tests/TestData.cs
@@ -80,14 +80,24 @@ public static class TestData
     public static IEnumerable<object[]> TestPasswordData =>
         new List<object[]>
         {
-            new object[] {13, 31, " "},
-            new object[] {13, 31, "0"},
-            new object[] {13, 31, "A"},
-            new object[] {13, 31, "Z"},
+            new object[] {13, 17, " "},
+            new object[] {17, 17, " "},
+            new object[] {31, 31, " "},
+            new object[] {13, 17, "0"},
+            new object[] {17, 17, "0"},
+            new object[] {31, 31, "0"},
+            new object[] {13, 17, "A"},
+            new object[] {17, 17, "A"},
+            new object[] {31, 31, "A"},
+            new object[] {13, 17, "Z"},
+            new object[] {17, 17, "Z"},
+            new object[] {31, 31, "Z"},
             new object[] {13, 31, "ÿ"},
-            new object[] {13, 521, DefaultTestPassword},
-            new object[] {17, 521, DefaultTestPassword},
-            new object[] {127, 521, DefaultTestPassword},
+            new object[] {17, 31, "ÿ"},
+            new object[] {31, 31, "ÿ"},
+            new object[] {13, 127, DefaultTestPassword},
+            new object[] {17, 127, DefaultTestPassword},
+            new object[] {127, 127, DefaultTestPassword},
             new object[] {130, 521, DefaultTestPassword},
             new object[] {500, 521, DefaultTestPassword},
             new object[] {1279, 1279, DefaultTestPassword}
@@ -120,7 +130,7 @@ public static class TestData
         new List<object[]>
         {
             new object[] {DefaultPosTestNumber, 31},
-            new object[] {DefaultTestPassword, 521},
+            new object[] {DefaultTestPassword, 127},
         };
 
     /// <summary>
@@ -129,13 +139,13 @@ public static class TestData
     /// <remarks>The reconstruction with these shares should be result in <see cref="DefaultTestPassword"/></remarks>
     public static string[] GetPredefinedShares() =>
     [
-        "01-0131621CFFE838F31347293CC1093C91C7BF50F64AD0F3F09AAF1844F26EECC7F84A23376E5786E8B34DDDFAC957F025201A42114D4C114B42DBC70B96453A19D600",
-        "02-520CE6164D5030CC3670DE39F29EE241A5CC70B5FE5001C1C33A6551C5DE34065B486FAAEA4B51C738352496E78F36096915FF7FE6870E741B859AE72C8D0EF1BC01",
-        "03-3C92F0EF5536528BD77B3FF9E9BF62120B27CC3D7F8249709BA15D28794FD9BA26F8E35975DD609C8EB6D4D158A8D2A9DAF1364CCCB2F77A8BFD7793C4D67C87B400",
-        "04-BDC281A7199B9E30F6694C7AA86CBC02F9CE628FCC64CCFE21E401C90DC1D9E55B5A81450E0CB567B5D1EEAD1DA1C40775AFE975FECCCC5F9244600F5D2285DCBC01",
-        "05-D79D993D987E15BC923A05BD2DA5EF126FC434AAE6F7896C5702523383333687FA6E476DB5D74D29AD86722A367A0C23384E17FD7CD68D22305A535BF66F27F0D500",
-        "06-882338B2D1E0B62DADED69C17969FC426D07428ECD3B82B93BFC4D67D9A6EE9E023636D16A402BE175D55F47A233AAFB23CEBFE147CF3AC3643E517790BF63C2FF01",
-        "07-D2535D05C6C1828545837A878CB9E292F3978A3B8130B5E5CED1F564101B032D74AF4D712E464D8F0FBEB60462CD9D91382FE3235FB7D34130F159632B113A533A01"
+        "01-F4E6D807C77FD480E7ABF046A8578331",
+        "02-217BDFE1200E1C93D2C4A3A8249E3630",
+        "03-CE2180FA7CCB2DA633B77D4696131A7C",
+        "04-FDDABA51DBB709BA0A837E20FDB72D15",
+        "05-ABA68FE73BD3AFCE5728A636598B717B",
+        "06-DB84FEBB9E1D20E41AA7F488AA8DE52E",
+        "07-8B7507CF03975AFA53FF6917F1BE892F"
     ];
 
     /// <summary>


### PR DESCRIPTION
This pull request updates the string encoding used in the `Secret<TNumber>` class from UTF-16 to UTF-8 for improved interoperability, particularly in cryptographic and web contexts. It also updates related tests and test data to reflect the new encoding and associated changes in data length and content.

### Encoding Change and Code Updates

* Changed the string encoding in the `Secret<TNumber>` class from UTF-16 (`Encoding.Unicode`) to UTF-8 (`Encoding.UTF8`) for all conversions, including implicit operators and the `ToString` method, to reduce payload size and improve compatibility. [[1]](diffhunk://#diff-ef07605af7f69c58bfd300728f310228f913ed09436753585952d524ac9cc9a3L216-R216) [[2]](diffhunk://#diff-ef07605af7f69c58bfd300728f310228f913ed09436753585952d524ac9cc9a3L225-R225) [[3]](diffhunk://#diff-ef07605af7f69c58bfd300728f310228f913ed09436753585952d524ac9cc9a3L339-R344)
* Updated the changelog (`CHANGELOG.md`) to document the encoding change and its rationale.

### Test and Test Data Updates

* Adjusted test data in `TestData.cs` to use the new UTF-8 encoding, including updating expected lengths and values in test cases. [[1]](diffhunk://#diff-b502b5d38fc546899a3781426ff0e04f95477f5504f7d464596eb0484019ab73L83-R100) [[2]](diffhunk://#diff-b502b5d38fc546899a3781426ff0e04f95477f5504f7d464596eb0484019ab73L123-R133)
* Replaced predefined share strings in `GetPredefinedShares()` with new values compatible with UTF-8 encoding.