### PR TITLE
Share class introduced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `Share` struct to represent individual shares for future extensibility.
+- Added `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel, out Secret<TNumber> secret)` method to generate shares and output the random secret.
+
 ### Changed
 - Changed String Encoding from UTF-16 to UTF-8 in `Secret<TNumber>` class for better interoperability. Encoding.Unicode (UTF-16 LE) is uncommon in cryptographic and web contexts. UTF-8 is the de facto standard and avoids unnecessary null bytes and payload bloat for ASCII-heavy input.
+- Chnaged `Shares` class to use the new `Share` struct instead of `FinitePoint<TNumber>` for better clarity and future extensibility.
+- Changeed constructor of `Shares` class to sort shares by their X (index) values upon creation to ensure consistent ordering.
+
+### Deprecated
+- The `FinitePoint` struct is marked as deprecated and will be set internal instead public in one of the next releases.
+- The `OriginalSecret` property in `Shares` class is marked as deprecated and will be removed in one of the next releases.
+- The `OriginalSecretExists` property in `Shares` class is marked as deprecated and will be removed in one of the next releases.
+- The `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel)` method is marked as deprecated and will be removed in one of the next releases.
+- The `Secret<TNumber> Reconstruction(FinitePoint<TNumber>[] shares)` method is marked as deprecated and will be removed in one of the next releases.
+- The `Secret<TNumber> Reconstruction(string[] shares)` method is marked as deprecated and will be removed in one of the next releases.
+- The `Secret<TNumber> Reconstruction(string shares)` method is marked as deprecated and will be removed in one of the next releases.
 
 ## [0.13.0] - 2025-11-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Console.WriteLine(shares);
 Similarly, an instance of `IReconstructionUseCase<BigInteger>` can be created to rebuild the original secret:
 ```csharp
 var reconstructionUseCase = serviceProvider.GetRequiredService<IReconstructionUseCase<BigInteger>>();
-var reconstruction = reconstructionUseCase.Reconstruction(shares.Where(p => p.X.IsEven).ToArray());
+var reconstruction = reconstructionUseCase.Reconstruction(shares.Where(p => p.IsIndexEven).ToArray());
 Console.WriteLine(reconstruction);
 ```
 
@@ -193,10 +193,7 @@ namespace Example1
       //// Minimum number of shared secrets for reconstruction: 3
       //// Maximum number of shared secrets: 7
       //// Security level: 127 (Mersenne prime exponent)
-      var shares = splitter.MakeShares(3, 7, 127);
-
-      //// The property 'shares.OriginalSecret' represents the random secret
-      var secret = shares.OriginalSecret;
+      var shares = splitter.MakeShares(3, 7, 127, out var secret);
 
       //// Secret as big integer number
       Console.WriteLine((BigInteger)secret);
@@ -207,9 +204,9 @@ namespace Example1
       var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
       //// The 'shares' instance contains the shared secrets
       var combiner = new SecretReconstructor<BigInteger>(gcd);
-      var subSet1 = shares.Where(p => p.X.IsEven).ToList();
+      var subSet1 = shares.Where(p => p.IsIndexEven).ToList();
       var recoveredSecret1 = combiner.Reconstruction(subSet1.ToArray());
-      var subSet2 = shares.Where(p => !p.X.IsEven).ToList();
+      var subSet2 = shares.Where(p => p.IsIndexOdd).ToList();
       var recoveredSecret2 = combiner.Reconstruction(subSet2.ToArray());
 
       //// String representation of all shares
@@ -259,15 +256,12 @@ namespace Example2
       //// or SecurityLevel property.
       var shares = splitter.MakeShares(3, 7, password);
 
-      //// The property 'shares.OriginalSecret' represents the original password
-      var secret = shares.OriginalSecret;
-
       var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
       //// The 'shares' instance contains the shared secrets
       var combiner = new SecretReconstructor<BigInteger>(gcd);
-      var subSet1 = shares.Where(p => p.X.IsEven).ToList();
+      var subSet1 = shares.Where(p => p.IsIndexEven).ToList();
       var recoveredSecret1 = combiner.Reconstruction(subSet1.ToArray());
-      var subSet2 = shares.Where(p => !p.X.IsEven).ToList();
+      var subSet2 = shares.Where(p => p.IsIndexOdd).ToList();
       var recoveredSecret2 = combiner.Reconstruction(subSet2.ToArray());
 
       //// String representation of all shares
@@ -314,15 +308,12 @@ namespace Example3
       //// or SecurityLevel property.
       var shares = splitter.MakeShares (3, 7, number, 521);
 
-      //// The property 'shares.OriginalSecret' represents the number (original secret)
-      var secret = shares.OriginalSecret;
-
       var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
       ////  The 'shares' instance contains the shared secrets
       var combiner = new SecretReconstructor<BigInteger>(gcd);
-      var subSet1 = shares.Where(p => p.X.IsEven).ToList();
+      var subSet1 = shares.Where(p => p.IsIndexEven).ToList();
       var recoveredSecret1 = combiner.Reconstruction(subSet1.ToArray());
-      var subSet2 = shares.Where(p => !p.X.IsEven).ToList();
+      var subSet2 = shares.Where(p => p.IsIndexOdd).ToList();
       var recoveredSecret2 = combiner.Reconstruction(subSet2.ToArray());
 
       //// String representation of all shares
@@ -368,7 +359,7 @@ namespace Example4
       var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
       //// The 'shares' instance contains the shared secrets
       var combiner = new SecretReconstructor<BigInteger>(gcd);
-      var subSet = shares.Where(p => p.X.IsEven).ToList();
+      var subSet = shares.Where(p => p.IsIndexEven).ToList();
       var recoveredSecret = combiner.Reconstruction(subSet.ToArray()).ToByteArray();
 
       //// String representation of all shares
@@ -410,9 +401,9 @@ namespace Example5
                           "05-CDECB88126DBC04D753E0C2D83D7B55D"};
 
       //// Another way to use shares
-      var fp1 = new FinitePoint<BigInteger>("05-CDECB88126DBC04D753E0C2D83D7B55D");
-      var fp2 = new FinitePoint<BigInteger>("07-54A83E34AB0310A7F5D80F2A68FD4F33");
-      var fp3 = new FinitePoint<BigInteger>("02-665C74ED38FDFF095B2FC9319A272A75");
+      var share1 = new Share<BigInteger>("05-CDECB88126DBC04D753E0C2D83D7B55D");
+      var share2 = new Share<BigInteger>("07-54A83E34AB0310A7F5D80F2A68FD4F33");
+      var share3 = new Share<BigInteger>("02-665C74ED38FDFF095B2FC9319A272A75");
 
       var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
       var combiner = new SecretReconstructor<BigInteger>(gcd);
@@ -426,7 +417,7 @@ namespace Example5
       Console.WriteLine((BigInteger)recoveredSecret2);
 
       //// Output should be 52199147989510990914370102003412153
-      var recoveredSecret3 = combiner.Reconstruction(fp1, fp2, fp3);
+      var recoveredSecret3 = combiner.Reconstruction(share1, share2, share3);
       Console.WriteLine((BigInteger)recoveredSecret3);
     }
   }

--- a/src/Cryptography/FinitePoint`1.cs
+++ b/src/Cryptography/FinitePoint`1.cs
@@ -46,18 +46,9 @@ using System.Runtime.CompilerServices;
 /// Represents the support point of the polynomial
 /// </summary>
 /// <typeparam name="TNumber">Numeric data type (An integer type)</typeparam>
-public readonly struct FinitePoint<TNumber> : IEquatable<FinitePoint<TNumber>>, IComparable<FinitePoint<TNumber>>
+[Obsolete("Use Share<TNumber> struct instead. This struct will be marked as internal in future releases.", false)]
+public readonly record struct FinitePoint<TNumber> : IComparable<FinitePoint<TNumber>>
 {
-    /// <summary>
-    /// Saves the X coordinate
-    /// </summary>
-    private readonly Calculator<TNumber> x;
-
-    /// <summary>
-    /// Saves the Y coordinate
-    /// </summary>
-    private readonly Calculator<TNumber> y;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="FinitePoint{TNumber}"/> struct.
     /// </summary>
@@ -68,8 +59,8 @@ public readonly struct FinitePoint<TNumber> : IEquatable<FinitePoint<TNumber>>, 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "x")]
     public FinitePoint(Calculator<TNumber> x, ICollection<Calculator<TNumber>> polynomial, Calculator<TNumber> prime)
     {
-        this.x = x ?? throw new ArgumentNullException(nameof(x));
-        this.y = Evaluate(polynomial ?? throw new ArgumentNullException(nameof(polynomial)), this.x, prime ?? throw new ArgumentNullException(nameof(prime)));
+        this.X = x ?? throw new ArgumentNullException(nameof(x));
+        this.Y = Evaluate(polynomial ?? throw new ArgumentNullException(nameof(polynomial)), this.X, prime ?? throw new ArgumentNullException(nameof(prime)));
     }
 
     /// <summary>
@@ -93,16 +84,16 @@ public readonly struct FinitePoint<TNumber> : IEquatable<FinitePoint<TNumber>>, 
         }
 
 #if NET8_0_OR_GREATER
-        var xReadOnlySpan = serialized[..serialized.IndexOf(SharedSeparator.CoordinateSeparator)];
-        var yReadOnlySpan = serialized[(serialized.IndexOf(SharedSeparator.CoordinateSeparator) + 1)..];
+        var xReadOnlySpan = serialized[..serialized.IndexOf(Share<TNumber>.CoordinateSeparator)];
+        var yReadOnlySpan = serialized[(serialized.IndexOf(Share<TNumber>.CoordinateSeparator) + 1)..];
         var numberType = typeof(TNumber);
-        this.x = Calculator.Create(ToByteArray(xReadOnlySpan), numberType) as Calculator<TNumber>;
-        this.y = Calculator.Create(ToByteArray(yReadOnlySpan), numberType) as Calculator<TNumber>;
+        this.X = Calculator.Create(ToByteArray(xReadOnlySpan), numberType) as Calculator<TNumber>;
+        this.Y = Calculator.Create(ToByteArray(yReadOnlySpan), numberType) as Calculator<TNumber>;
 #else
-        string[] s = serialized.Split(SharedSeparator.CoordinateSeparatorArray);
+        string[] s = serialized.Split(Share<TNumber>.CoordinateSeparatorArray);
         var numberType = typeof(TNumber);
-        this.x = Calculator.Create(ToByteArray(s[0]), numberType) as Calculator<TNumber>;
-        this.y = Calculator.Create(ToByteArray(s[1]), numberType) as Calculator<TNumber>;
+        this.X = Calculator.Create(ToByteArray(s[0]), numberType) as Calculator<TNumber>;
+        this.Y = Calculator.Create(ToByteArray(s[1]), numberType) as Calculator<TNumber>;
 #endif
     }
 
@@ -115,47 +106,32 @@ public readonly struct FinitePoint<TNumber> : IEquatable<FinitePoint<TNumber>>, 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "x")]
     public FinitePoint(Calculator<TNumber> x, Calculator<TNumber> y)
     {
-        if (x == null)
-        {
-            throw new ArgumentNullException(nameof(x));
-        }
+        this.X = x ?? throw new ArgumentNullException(nameof(x));
+        this.Y = y ?? throw new ArgumentNullException(nameof(y));
+    }
 
-        if (y == null)
-        {
-            throw new ArgumentNullException(nameof(y));
-        }
-
-        this.x = x;
-        this.y = y;
+    /// <summary>
+    /// Deconstructs this <see cref="FinitePoint{TNumber}"/> into its components.
+    /// </summary>
+    /// <param name="x">The X coordinate of the <see cref="FinitePoint{TNumber}"/>.</param>
+    /// <param name="y">The Y coordinate of the <see cref="FinitePoint{TNumber}"/>.</param>
+    public void Deconstruct(out Calculator<TNumber> x, out Calculator<TNumber> y)
+    {
+        x = this.X;
+        y = this.Y;
     }
 
     /// <summary>
     /// Gets the X coordinate
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "X")]
-    public Calculator<TNumber> X => this.x;
+    public Calculator<TNumber> X { get; }
 
     /// <summary>
     /// Gets the Y coordinate
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Y")]
-    public Calculator<TNumber> Y => this.y;
-
-    /// <summary>
-    /// Equality operator
-    /// </summary>
-    /// <param name="left">The left operand</param>
-    /// <param name="right">The right operand</param>
-    /// <returns>Returns <see langword="true"/> if its operands are equal, otherwise <see langword="false"/>.</returns>
-    public static bool operator ==(FinitePoint<TNumber> left, FinitePoint<TNumber> right) => left.Equals(right);
-
-    /// <summary>
-    /// Inequality operator
-    /// </summary>
-    /// <param name="left">The left operand</param>
-    /// <param name="right">The right operand</param>
-    /// <returns>Returns <see langword="true"/> if its operands aren't equal, otherwise <see langword="false"/>.</returns>
-    public static bool operator !=(FinitePoint<TNumber> left, FinitePoint<TNumber> right) => !left.Equals(right);
+    public Calculator<TNumber> Y { get; }
 
     /// <summary>
     /// Greater than operator
@@ -196,37 +172,10 @@ public readonly struct FinitePoint<TNumber> : IEquatable<FinitePoint<TNumber>>, 
     }
 
     /// <summary>
-    /// Determines whether this <see cref="FinitePoint{TNumber}"/> and a specified <see cref="FinitePoint{TNumber}"/> have the same value.
-    /// </summary>
-    /// <param name="other">The <see cref="FinitePoint{TNumber}"/> to compare to this instance.</param>
-    /// <returns><see langword="true"/> if the value of the value parameter is the same as this <see cref="FinitePoint{TNumber}"/>; otherwise, <see langword="false"/>.</returns>
-    public bool Equals(FinitePoint<TNumber> other)
-    {
-        return this.X.Equals(other.X) && this.Y.Equals(other.Y);
-    }
-
-    /// <summary>
-    /// Determines whether this structure and a specified object, which must also be a <see cref="FinitePoint{TNumber}"/> object, have the same value.
-    /// </summary>
-    /// <param name="obj">The <see cref="FinitePoint{TNumber}"/> to compare to this instance.</param>
-    /// <returns><see langword="true"/> if <paramref name="obj"/> is a <see cref="FinitePoint{TNumber}"/> and its value is the same as this instance; otherwise, <see langword="false"/>.
-    /// If <paramref name="obj"/> is <see langword="null"/>, the method returns <see langword="false"/>.</returns>
-    public override bool Equals(object obj)
-    {
-        return obj != null && this.Equals((FinitePoint<TNumber>)obj);
-    }
-
-    /// <summary>
-    /// Returns the hash code for the current <see cref="FinitePoint{TNumber}"/> structure.
-    /// </summary>
-    /// <returns>A 32-bit signed integer hash code.</returns>
-    public override int GetHashCode() => this.X.GetHashCode() ^ this.y.GetHashCode();
-
-    /// <summary>
     /// Returns the string representation of the <see cref="FinitePoint{TNumber}"/> structure.
     /// </summary>
-    /// <returns></returns>
-    public override string ToString() => string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", ToHexString(this.x.ByteRepresentation), SharedSeparator.CoordinateSeparator.ToString(), ToHexString(this.y.ByteRepresentation));
+    /// <returns>The string representation of the <see cref="FinitePoint{TNumber}"/> structure.</returns>
+    public override string ToString() => string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", ToHexString(this.X.ByteRepresentation), Share<TNumber>.CoordinateSeparator.ToString(), ToHexString(this.Y.ByteRepresentation));
 
     /// <summary>
     /// Evaluates polynomial (coefficient tuple) at x, used to generate a shamir pool.
@@ -255,6 +204,7 @@ public readonly struct FinitePoint<TNumber> : IEquatable<FinitePoint<TNumber>>, 
     /// <remarks>
     /// Based on discussion on <see href="https://stackoverflow.com/questions/623104/byte-to-hex-string/5919521#5919521">stackoverflow</see>
     /// </remarks>
+    [Obsolete("Will be removed in future releases.", false)]
 #if NET8_0_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
@@ -280,6 +230,7 @@ public readonly struct FinitePoint<TNumber> : IEquatable<FinitePoint<TNumber>>, 
     /// </summary>
     /// <param name="hexString">hexadecimal string</param>
     /// <returns>Returns a byte array</returns>
+    [Obsolete("Will be removed in future releases.", false)]
 #if NET8_0_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static byte[] ToByteArray(ReadOnlySpan<char> hexString) => Convert.FromHexString(hexString);

--- a/src/Cryptography/IMakeSharesUseCase.cs
+++ b/src/Cryptography/IMakeSharesUseCase.cs
@@ -1,5 +1,7 @@
 namespace SecretSharingDotNet.Cryptography;
 
+using System;
+
 /// <summary>
 /// Interface for the Shamir's Secret Sharing algorithm implementation for creating shared secrets. 
 /// </summary>
@@ -16,7 +18,21 @@ public interface IMakeSharesUseCase<TNumber>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
     /// </exception>
+    [Obsolete("Use MakeShares with out parameter secret instead", false)]
     Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel);
+
+    /// <summary>
+    /// Generates a random shamir pool, returns the random secret and the share points.
+    /// </summary>
+    /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
+    /// <param name="numberOfShares">Maximum number of shared secrets</param>
+    /// <param name="securityLevel">Security level (in number of bits). The minimum is 13.</param>
+    /// <param name="secret">output parameter returning the generated secret as <see cref="Secret{TNumber}"/></param>
+    /// <returns>A <see cref="Shares{TNumber}"/> object</returns>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">
+    /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
+    /// </exception>
+    Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel, out Secret<TNumber> secret);
 
     /// <summary>
     /// Generates a random shamir pool, returns the specified <paramref name="secret"/> and the share points.

--- a/src/Cryptography/IReconstructionUseCase.cs
+++ b/src/Cryptography/IReconstructionUseCase.cs
@@ -1,16 +1,19 @@
 namespace SecretSharingDotNet.Cryptography;
 
+using System;
+
 /// <summary>
 /// Interface for the Shamir's Secret Sharing algorithm implementation for reconstructing the secret.
 /// </summary>
 /// <typeparam name="TNumber"></typeparam>
 public interface IReconstructionUseCase<TNumber>
 {
-    /// <summary>
+    /// <summary>q
     /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
     /// </summary>
     /// <param name="shares">Shares represented by <see cref="string"/> and separated by newline.</param>
     /// <returns>Re-constructed secret</returns>
+    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
     Secret<TNumber> Reconstruction(string shares);
 
     /// <summary>
@@ -18,6 +21,7 @@ public interface IReconstructionUseCase<TNumber>
     /// </summary>
     /// <param name="shares">Shares represented by <see cref="string"/> array.</param>
     /// <returns>Re-constructed secret</returns>
+    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
     Secret<TNumber> Reconstruction(string[] shares);
 
     /// <summary>
@@ -30,9 +34,20 @@ public interface IReconstructionUseCase<TNumber>
     /// <summary>
     /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
     /// </summary>
+    /// <param name="shares">Two or more shares</param>
+    /// <returns>Re-constructed secret</returns>
+    /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/>.</exception>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">The length of <paramref name="shares"/> is lower than 2.</exception>
+    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
+    Secret<TNumber> Reconstruction(Share<TNumber>[] shares);
+
+    /// <summary>
+    /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
+    /// </summary>
     /// <param name="shares">Two or more shares represented by a set of <see cref="FinitePoint{TNumber}"/></param>
     /// <returns>Re-constructed secret</returns>
     /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/>.</exception>
     /// <exception cref="T:System.ArgumentOutOfRangeException">The length of <paramref name="shares"/> is lower than 2.</exception>
+    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
     Secret<TNumber> Reconstruction(FinitePoint<TNumber>[] shares);
 }

--- a/src/Cryptography/IReconstructionUseCase.cs
+++ b/src/Cryptography/IReconstructionUseCase.cs
@@ -8,7 +8,7 @@ using System;
 /// <typeparam name="TNumber"></typeparam>
 public interface IReconstructionUseCase<TNumber>
 {
-    /// <summary>q
+    /// <summary>
     /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
     /// </summary>
     /// <param name="shares">Shares represented by <see cref="string"/> and separated by newline.</param>

--- a/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
@@ -31,6 +31,7 @@
 
 namespace SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
 
+using Extension;
 using Math;
 using System;
 using System.Collections.Generic;
@@ -102,12 +103,12 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
     /// <returns>The re-constructed secret.</returns>
     private Secret<TNumber> LagrangeInterpolate(FinitePoint<TNumber>[] finitePoints, Calculator<TNumber> prime)
     {
-        if (finitePoints == null)
+        if (finitePoints is null)
         {
             throw new ArgumentNullException(nameof(finitePoints));
         }
 
-        if (prime == null)
+        if (prime is null)
         {
             throw new ArgumentNullException(nameof(prime));
         }
@@ -159,6 +160,7 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
     /// </summary>
     /// <param name="shares">Shares represented by <see cref="string"/> and separated by newline.</param>
     /// <returns>Re-constructed secret</returns>
+    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
     public Secret<TNumber> Reconstruction(string shares)
     {
         if (string.IsNullOrWhiteSpace(shares))
@@ -175,9 +177,10 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
     /// </summary>
     /// <param name="shares">Shares represented by <see cref="string"/> array.</param>
     /// <returns>Re-constructed secret</returns>
+    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
     public Secret<TNumber> Reconstruction(string[] shares)
     {
-        if (shares == null)
+        if (shares is null)
         {
             throw new ArgumentNullException(nameof(shares));
         }
@@ -198,7 +201,25 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
     /// <returns>Re-constructed secret</returns>
     public Secret<TNumber> Reconstruction(Shares<TNumber> shares)
     {
-        return this.Reconstruction((FinitePoint<TNumber>[])shares);
+        if (shares is null)
+        {
+            throw new ArgumentNullException(nameof(shares));
+        }
+
+        if (shares.Count < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(shares), ErrorMessages.MinNumberOfSharesLowerThanTwo);
+        }
+
+        var finitePoints = shares.ToFinitePoints();
+        var maximumY = finitePoints.Select(point => point.Y).Max();
+        if (maximumY is null)
+        {
+            throw new ArgumentException(ErrorMessages.NoMaximumY, nameof(shares));
+        }
+
+        this.securityLevelManager.AdjustSecurityLevel(maximumY);
+        return this.LagrangeInterpolate(finitePoints, this.securityLevelManager.MersennePrime);
     }
 
     /// <summary>
@@ -208,9 +229,10 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
     /// <returns>Re-constructed secret</returns>
     /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/>.</exception>
     /// <exception cref="T:System.ArgumentOutOfRangeException">The length of <paramref name="shares"/> is lower than 2.</exception>
-    public Secret<TNumber> Reconstruction(FinitePoint<TNumber>[] shares)
+    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
+    public Secret<TNumber> Reconstruction(Share<TNumber>[] shares)
     {
-        if (shares == null)
+        if (shares is null)
         {
             throw new ArgumentNullException(nameof(shares));
         }
@@ -220,14 +242,28 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
             throw new ArgumentOutOfRangeException(nameof(shares), ErrorMessages.MinNumberOfSharesLowerThanTwo);
         }
 
-        var maximumY = shares.Select(point => point.Y).Max();
+        var finitePoints = shares.ToFinitePoints();
+        var maximumY = finitePoints.Select(point => point.Y).Max();
         if (maximumY == null)
         {
             throw new ArgumentException(ErrorMessages.NoMaximumY, nameof(shares));
         }
 
         this.securityLevelManager.AdjustSecurityLevel(maximumY);
-        return this.LagrangeInterpolate(shares, this.securityLevelManager.MersennePrime);
+        return this.LagrangeInterpolate(finitePoints, this.securityLevelManager.MersennePrime);
+    }
+
+    /// <summary>
+    /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
+    /// </summary>
+    /// <param name="shares">Two or more shares represented by a set of <see cref="FinitePoint{TNumber}"/></param>
+    /// <returns>Re-constructed secret</returns>
+    /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/>.</exception>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">The length of <paramref name="shares"/> is lower than 2.</exception>
+    [Obsolete("Use Reconstruction(Share<TNumber>[] shares) instead", false)]
+    public Secret<TNumber> Reconstruction(FinitePoint<TNumber>[] shares)
+    {
+        return this.Reconstruction(shares.ToShares());
     }
 
     /// <summary>
@@ -249,17 +285,17 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
         Calculator<TNumber> denominator,
         Calculator<TNumber> prime)
     {
-        if (numerator == null)
+        if (numerator is null)
         {
             throw new ArgumentNullException(nameof(numerator));
         }
 
-        if (denominator == null)
+        if (denominator is null)
         {
             throw new ArgumentNullException(nameof(denominator));
         }
 
-        if (prime == null)
+        if (prime is null)
         {
             throw new ArgumentNullException(nameof(prime));
         }

--- a/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
@@ -31,6 +31,7 @@
 
 namespace SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
 
+using Extension;
 using Math;
 using System;
 using System.Collections.Generic;
@@ -90,6 +91,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
     /// </exception>
+    [Obsolete("Use MakeShares with out parameter secret instead", false)]
     public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel)
     {
         try
@@ -121,8 +123,54 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
         var secret = Secret<TNumber>.CreateRandom(this.securityLevelManager.MersennePrime);
         var polynomial = this.CreatePolynomial(min);
         polynomial[0] = secret.ToCoefficient;
-        var points = this.CreateSharedSecrets(max, polynomial);
-        return new Shares<TNumber>(secret, points);
+        var points = this.CreateFinitePoints(max, polynomial);
+        return new Shares<TNumber>(secret, points.ToShares());
+    }
+
+    /// <summary>
+    /// Generates a random shamir pool, returns the random secret and the share points.
+    /// </summary>
+    /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
+    /// <param name="numberOfShares">Maximum number of shared secrets</param>
+    /// <param name="securityLevel">Security level (in number of bits). The minimum is 13.</param>
+    /// <param name="secret">output parameter returning the generated secret as <see cref="Secret{TNumber}"/></param>
+    /// <returns></returns>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">
+    /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
+    /// </exception>
+    public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel, out Secret<TNumber> secret)
+    {
+        try
+        {
+            this.SecurityLevel = securityLevel;
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            throw new ArgumentOutOfRangeException(nameof(securityLevel), securityLevel, e.Message);
+        }
+
+        int min = ((Calculator<TNumber>)numberOfMinimumShares).ToInt32();
+        int max = ((Calculator<TNumber>)numberOfShares).ToInt32();
+        if (min < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numberOfMinimumShares), numberOfMinimumShares, ErrorMessages.MinNumberOfSharesLowerThanTwo);
+        }
+
+        if (min > max)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numberOfShares), numberOfShares, ErrorMessages.MaxSharesLowerThanMinShares);
+        }
+
+        if (this.securityLevelManager.MersennePrime == null)
+        {
+            throw new InvalidOperationException("Security Level is not initialized!");
+        }
+
+        secret = Secret<TNumber>.CreateRandom(this.securityLevelManager.MersennePrime);
+        var polynomial = this.CreatePolynomial(min);
+        polynomial[0] = secret.ToCoefficient;
+        var points = this.CreateFinitePoints(max, polynomial);
+        return new Shares<TNumber>(secret, points.ToShares());
     }
 
     /// <summary>
@@ -182,9 +230,9 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
 
         var polynomial = this.CreatePolynomial(min);
         polynomial[0] = secret.ToCoefficient;
-        var points = this.CreateSharedSecrets(max, polynomial);
+        var points = this.CreateFinitePoints(max, polynomial);
 
-        return new Shares<TNumber>(secret, points);
+        return new Shares<TNumber>(secret, points.ToShares());
     }
 
     /// <summary>
@@ -208,17 +256,17 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     }
 
     /// <summary>
-    /// Creates shared Secrets
+    /// Creates finite points representing the shared secrets
     /// </summary>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>
-    /// <param name="polynomial"></param>
+    /// <param name="polynomial">The polynomial coefficients</param>
     /// <returns>Finite points representing the shared secrets</returns>
-    private FinitePoint<TNumber>[] CreateSharedSecrets(int numberOfShares, ICollection<Calculator<TNumber>> polynomial)
+    private FinitePoint<TNumber>[] CreateFinitePoints(int numberOfShares, ICollection<Calculator<TNumber>> polynomial)
     {
-        int size = numberOfShares + 1;
+        var size = numberOfShares + 1;
         var points = new FinitePoint<TNumber>[numberOfShares];
 
-        for (int i = 1; i < size; i++)
+        for (var i = 1; i < size; i++)
         {
             var x = Calculator.Create(BitConverter.GetBytes(i), typeof(TNumber)) as Calculator<TNumber>;
             points[i - 1] = new FinitePoint<TNumber>(x, polynomial, this.securityLevelManager.MersennePrime);

--- a/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
@@ -87,7 +87,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>
     /// <param name="securityLevel">Security level (in number of bits). The minimum is 13.</param>
-    /// <returns></returns>
+    /// <returns>A <see cref="Shares{TNumber}"/> collection containing the generated shares.</returns>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
     /// </exception>
@@ -134,7 +134,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>
     /// <param name="securityLevel">Security level (in number of bits). The minimum is 13.</param>
     /// <param name="secret">output parameter returning the generated secret as <see cref="Secret{TNumber}"/></param>
-    /// <returns></returns>
+    /// <returns>A <see cref="Shares{TNumber}"/> collection containing the generated shares.</returns>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
     /// </exception>
@@ -180,7 +180,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>
     /// <param name="secret">secret text as <see cref="Secret{TNumber}"/> or see cref="string"/></param>
     /// <param name="securityLevel">Security level (in number of bits). The minimum is 13.</param>
-    /// <returns></returns>
+    /// <returns>A <see cref="Shares{TNumber}"/> collection containing the generated shares.</returns>
     /// <remarks>This method can modify the <see cref="SecurityLevel"/> based on the <paramref name="secret"/> length.</remarks>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> is lower than 13 or greater than 43.112.609. OR <paramref name="numberOfMinimumShares"/> is lower than 2 or greater than <paramref name="numberOfShares"/>.
@@ -205,7 +205,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>
     /// <param name="secret">secret text as <see cref="Secret{TNumber}"/> or see cref="string"/></param>
-    /// <returns></returns>
+    /// <returns>A <see cref="Shares{TNumber}"/> collection containing the generated shares.</returns>
     /// <remarks>This method modifies the <see cref="SecurityLevel"/> based on the <paramref name="secret"/> length</remarks>
     /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="numberOfMinimumShares"/> is lower than 2 or greater than <paramref name="numberOfShares"/>.</exception>
     public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret)

--- a/src/Cryptography/Share`1.cs
+++ b/src/Cryptography/Share`1.cs
@@ -1,0 +1,564 @@
+// ----------------------------------------------------------------------------
+// <copyright file="Share`1.cs" company="Private">
+// Copyright (c) 2025 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>12/24/2025 08:50:07 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2025 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography;
+
+using Math;
+using System;
+#if NET8_0_OR_GREATER
+using System.Buffers;
+#endif
+using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Represents an immutable share in a secret sharing scheme.
+/// A share consists of an index (X coordinate) and a value (Y coordinate).
+/// </summary>
+/// <remarks>
+/// This type provides a simplified, type-safe wrapper for secret sharing operations.
+/// It supports parsing from and formatting to the standard share format "X-Y" where
+/// X is the hexadecimal index and Y is the hexadecimal share value.
+/// </remarks>
+public readonly record struct Share<TNumber> : IComparable<Share<TNumber>>, IFormattable
+#if NET8_0_OR_GREATER
+    , ISpanParsable<Share<TNumber>>
+#endif
+{
+#if NET8_0_OR_GREATER
+    private static readonly SearchValues<char> HexChars =
+        SearchValues.Create("0123456789ABCDEFabcdef" + CoordinateSeparator);
+#endif
+
+    /// <summary>
+    /// The separator between the X and Y coordinate
+    /// </summary>
+    /// <remarks>Todo: Make private and configure via options in future versions.</remarks>
+    internal const char CoordinateSeparator = '-';
+
+    /// <summary>
+    /// Separator array for <see cref="string.Split(char[])"/> method usage to avoid allocation of a new array.
+    /// </summary>
+    /// <remarks>Todo: Make private in future versions.</remarks>
+    internal static readonly char[] CoordinateSeparatorArray = [CoordinateSeparator];
+
+    /// <summary>
+    /// The index (X coordinate) of this share.
+    /// </summary>
+    /// <remarks>
+    /// In Shamir's Secret Sharing, each share is a point on a polynomial.
+    /// The index represents the X coordinate of this point.
+    /// </remarks>
+    public Calculator<TNumber> Index { get; }
+
+    /// <summary>
+    /// Represents the `Index` of the Share structure, exposed under the alias `X`.
+    /// </summary>
+    /// <remarks>
+    /// This property is marked as obsolete. Use the `Index` property directly for clarity.
+    /// </remarks>
+    [Obsolete("Use 'Index' property instead.")]
+    public Calculator<TNumber> X => this.Index;
+
+    /// <summary>
+    /// The value (Y coordinate) of this share.
+    /// </summary>
+    /// <remarks>
+    /// In Shamir's Secret Sharing, this represents the Y coordinate of the point
+    /// on the polynomial at the given index.
+    /// </remarks>
+    public Calculator<TNumber> Value { get; }
+
+    /// <summary>
+    /// Gets the value associated with the share.
+    /// </summary>
+    /// <remarks>
+    /// This property is marked as obsolete. Use the 'Value' property instead for accessing the share value.
+    /// </remarks>
+    [Obsolete("Use 'Value' property instead.")]
+    public Calculator<TNumber> Y => this.Value;
+
+    /// <summary>
+    /// Gets a value indicating whether the share index is even.
+    /// </summary>
+    public bool IsIndexEven => this.Index.IsEven;
+
+    /// <summary>
+    /// Gets a value indicating whether the share index is odd.
+    /// </summary>
+    public bool IsIndexOdd => !this.Index.IsEven;
+
+    /// <summary>
+    /// Gets a value indicating whether this share is empty (default/uninitialized).
+    /// </summary>
+    public bool IsEmpty => (this.Index is null || this.Index.IsZero) && (this.Value is null || this.Value.IsZero);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Share{TNumber}"/> struct with the specified index and value.
+    /// </summary>
+    /// <param name="index">The index (X coordinate) of the share. Must be positive.</param>
+    /// <param name="value">The value (Y coordinate) of the share.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="index"/> is less than or equal to one.
+    /// </exception>
+    public Share(Calculator<TNumber> index, Calculator<TNumber> value)
+    {
+        if (index < Calculator<TNumber>.One)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(index),
+                index,
+                ErrorMessages.ShareIndexMustBePositive);
+        }
+
+        this.Index = index;
+        this.Value = value;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Share{TNumber}"/> struct by parsing a character span.
+    /// </summary>
+    /// <param name="shareString">A character span in the format "X-Y" where X and Y are hexadecimal values.</param>
+    /// <exception cref="FormatException">
+    /// Thrown when <paramref name="shareString"/> is not in the expected format.
+    /// </exception>
+#if NET8_0_OR_GREATER
+    public Share(ReadOnlySpan<char> shareString)
+#else
+    public Share(string shareString)
+#endif
+    {
+        var (index, value) = ParseCore(shareString);
+        this.Index = index;
+        this.Value = value;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Share{TNumber}"/> struct from raw byte arrays.
+    /// </summary>
+    /// <param name="indexBytes">The byte array representing the index (X coordinate).</param>
+    /// <param name="valueBytes">The byte array representing the value (Y coordinate).</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="indexBytes"/> or <paramref name="valueBytes"/> is null.
+    /// </exception>
+    public Share(byte[] indexBytes, byte[] valueBytes)
+    {
+        this.Index = Calculator.Create(indexBytes, typeof(TNumber)) as Calculator<TNumber>;
+        if (this.Index < Calculator<TNumber>.One)
+        {
+            throw new ArgumentOutOfRangeException(nameof(indexBytes), ErrorMessages.ShareIndexMustBePositive);
+        }
+
+        this.Value = Calculator.Create(valueBytes, typeof(TNumber)) as Calculator<TNumber>;
+    }
+
+    /// <summary>
+    /// Parses a string into a <see cref="Share{TNumber}"/>.
+    /// </summary>
+    /// <param name="s">The string to parse.</param>
+    /// <returns>A new <see cref="Share{TNumber}"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="s"/> is null.</exception>
+    /// <exception cref="FormatException">Thrown when <paramref name="s"/> is not in the expected format.</exception>
+    public static Share<TNumber> Parse(string s)
+    {
+        return string.IsNullOrWhiteSpace(s) ? throw new ArgumentNullException(nameof(s)) : new Share<TNumber>(s);
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Parses a character span into a <see cref="Share{TNumber}"/>.
+    /// </summary>
+    /// <param name="s">The character span to parse.</param>
+    /// <returns>A new <see cref="Share{TNumber}"/> instance.</returns>
+    /// <exception cref="FormatException">Thrown when <paramref name="s"/> is not in the expected format.</exception>
+    public static Share<TNumber> Parse(ReadOnlySpan<char> s) => new Share<TNumber>(s);
+
+    /// <inheritdoc/>
+    public static Share<TNumber> Parse(ReadOnlySpan<char> s, IFormatProvider provider) => Parse(s);
+#endif
+    
+    /// <inheritdoc/>
+    public static Share<TNumber> Parse(string s, IFormatProvider provider) => Parse(s);
+
+    /// <summary>
+    /// Tries to parse a string into a <see cref="Share{TNumber}"/>.
+    /// </summary>
+    /// <param name="s">The string to parse.</param>
+    /// <param name="result">
+    /// When this method returns, <paramref name="result"/> contains the parsed <see cref="Share{TNumber}"/> if parsing
+    /// succeeded, or the default value if parsing failed.
+    /// </param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise, <see langword="false"/>.</returns>
+#if NET8_0_OR_GREATER
+    public static bool TryParse([NotNullWhen(true)] string s, out Share<TNumber> result)
+#else
+    public static bool TryParse(string s, out Share<TNumber> result)
+#endif
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            result = default;
+            return false;
+        }
+
+        try
+        {
+            result = new Share<TNumber>(s);
+            return true;
+        }
+        catch
+        {
+            result = default;
+            return false;
+        }
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Tries to parse a character span into a <see cref="Share{TNumber}"/>.
+    /// </summary>
+    /// <param name="s">The character span to parse.</param>
+    /// <param name="result">
+    /// When this method returns, <paramref name="result"/> contains the parsed <see cref="Share{TNumber}"/> if parsing
+    /// succeeded, or the default value if parsing failed.
+    /// </param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise, <see langword="false"/>.</returns>
+    public static bool TryParse(ReadOnlySpan<char> s, out Share<TNumber> result)
+    {
+        try
+        {
+            result = new Share<TNumber>(s);
+            return true;
+        }
+        catch
+        {
+            result = default;
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Share<TNumber> result)
+        => TryParse(s, out result);
+
+    /// <inheritdoc/>
+    public static bool TryParse([NotNullWhen(true)] string s, IFormatProvider provider, out Share<TNumber> result)
+#else
+    /// <summary>
+    /// Attempts to parse the specified string representation of a share into a <see cref="Share{TNumber}"/> instance.
+    /// </summary>
+    /// <param name="s">The string representation of the share to parse.</param>
+    /// <param name="provider">An object that provides culture-specific formatting information.</param>
+    /// <param name="result">
+    /// When this method returns, contains the parsed <see cref="Share{TNumber}"/> value if the parse was successful;
+    /// otherwise, it is set to the default value of <see cref="Share{TNumber}"/>. This parameter is passed uninitialized.
+    /// </param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise, <see langword="false"/>.</returns>
+    public static bool TryParse(string s, IFormatProvider provider, out Share<TNumber> result)
+#endif
+        => TryParse(s, out result);
+
+    /// <summary>
+    /// Compares this share to another share by their indices.
+    /// </summary>
+    /// <param name="other">The other share to compare to.</param>
+    /// <returns>
+    /// A negative value if this share's index is less than the other's,
+    /// zero if they are equal, or a positive value if this share's index is greater.
+    /// </returns>
+    public int CompareTo(Share<TNumber> other) => this.Index.CompareTo(other.Index);
+
+    /// <summary>
+    /// Returns a string representation of the current <see cref="Share{TNumber}"/> instance.
+    /// </summary>
+    /// <returns>A string that represents the current share, including its index and value.</returns>
+    public override string ToString() => this.ToString(format: null, formatProvider: null);
+
+    /// <summary>
+    /// Returns the string representation of this share in the format "X-Y".
+    /// </summary>
+    /// <returns>A string representation of this share.</returns>
+    public string ToString(string format) => this.ToString(format, formatProvider: null);
+
+    /// <summary>
+    /// Returns the string representation of this share using the specified format.
+    /// </summary>
+    /// <param name="format">
+    /// The format string. Use "X" (default) or "x" for hexadecimal.
+    /// </param>
+    /// <param name="formatProvider">The format provider (currently unused).</param>
+    /// <returns>A string representation of this share.</returns>
+    public string ToString(string format, IFormatProvider formatProvider)
+    {
+        if (string.IsNullOrEmpty(format))
+        {
+            format = "X";
+        }
+
+        return format switch
+        {
+            "X" => this.FormatHex(uppercase: true),
+            "x" => this.FormatHex(uppercase: false),
+            _ => throw new FormatException($"Unknown format string: {format}")
+        };
+    }
+
+    /// <summary>
+    /// Implicitly converts a string to a <see cref="Share{TNumber}"/>.
+    /// </summary>
+    /// <param name="shareString">The string representation of the share.</param>
+    public static implicit operator Share<TNumber>(string shareString) => Parse(shareString);
+
+    /// <summary>
+    /// Determines whether one share is less than another based on their indices.
+    /// </summary>
+    public static bool operator <(Share<TNumber> left, Share<TNumber> right) => left.CompareTo(right) < 0;
+
+    /// <summary>
+    /// Determines whether one share is greater than another based on their indices.
+    /// </summary>
+    public static bool operator >(Share<TNumber> left, Share<TNumber> right) => left.CompareTo(right) > 0;
+
+    /// <summary>
+    /// Determines whether one share is less than or equal to another based on their indices.
+    /// </summary>
+    public static bool operator <=(Share<TNumber> left, Share<TNumber> right) => left.CompareTo(right) <= 0;
+
+    /// <summary>
+    /// Determines whether one share is greater than or equal to another based on their indices.
+    /// </summary>
+    public static bool operator >=(Share<TNumber> left, Share<TNumber> right) => left.CompareTo(right) >= 0;
+
+    /// <summary>
+    /// Deconstructs this share into its index and value components.
+    /// </summary>
+    /// <param name="index">The index (X coordinate) of the share.</param>
+    /// <param name="value">The value (Y coordinate) of the share.</param>
+    public void Deconstruct(out Calculator<TNumber> index, out Calculator<TNumber> value)
+    {
+        index = this.Index;
+        value = this.Value;
+    }
+
+    /// <summary>
+    /// Determines whether the provided string consists only of hexadecimal characters and the coordinate separator.
+    /// </summary>
+    /// <param name="s">The string to check for hexadecimal characters and the coordinate separator.</param>
+    /// <returns>
+    /// <see langword="true"/> if the string only contains characters representing hexadecimal
+    /// digits ('0'-'9', 'A'-'F', 'a'-'f', '-') and the coordinate separator; otherwise, <see langword="false"/>.
+    /// </returns>
+#if NET8_0_OR_GREATER
+    private static bool IsHexWithCoordinateSeparatorOnly(ReadOnlySpan<char> s)
+    {
+        return s.IndexOfAnyExcept(HexChars) < 0;
+    }
+#else
+    private static bool IsHexWithCoordinateSeparatorOnly(string s)
+    {
+        return s.Select(c => c is >= '0' and <= '9' or >= 'A' and <= 'F' or >= 'a' and <= 'f' or CoordinateSeparator)
+            .All(isHex => isHex);
+    }
+#endif
+
+#if NET8_0_OR_GREATER
+    private static (Calculator<TNumber> Index, Calculator<TNumber> Value) ParseCore(ReadOnlySpan<char> serialized)
+#else
+    private static (Calculator<TNumber> Index, Calculator<TNumber> Value) ParseCore(string serialized)
+#endif
+    {
+        serialized = serialized.Trim();
+        var separatorIndex = serialized.IndexOf(CoordinateSeparator);
+        if (separatorIndex < 0 || !IsHexWithCoordinateSeparatorOnly(serialized))
+        {
+            throw new ArgumentException(string.Format(ErrorMessages.InvalidShareFormat, CoordinateSeparator));
+        }
+
+#if NET8_0_OR_GREATER
+        if (serialized.IsEmpty)
+#else
+        if (string.IsNullOrWhiteSpace(serialized))
+#endif
+        {
+            throw new ArgumentNullException(nameof(serialized), ErrorMessages.ShareStringCannotBeEmpty);
+        }
+
+#if NET8_0_OR_GREATER
+        var indexReadOnlySpan = serialized[..serialized.IndexOf(CoordinateSeparator)];
+        var valueReadOnlySpan = serialized[(serialized.IndexOf(CoordinateSeparator) + 1)..];
+        if (indexReadOnlySpan.IsEmpty || valueReadOnlySpan.IsEmpty)
+        {
+            throw new FormatException(ErrorMessages.ShareIndexAndValueMustBeNonEmpty);
+        }
+
+        var numberType = typeof(TNumber);
+        var index = Calculator.Create(ToByteArray(FormatHexWithLeadingZero(indexReadOnlySpan)), numberType) as Calculator<TNumber>;
+        var value = Calculator.Create(ToByteArray(FormatHexWithLeadingZero(valueReadOnlySpan)), numberType) as Calculator<TNumber>;
+#else
+        var shareCoordinates = serialized.Split(CoordinateSeparatorArray);
+        var numberType = typeof(TNumber);
+        var index = Calculator.Create(ToByteArray(FormatHexWithLeadingZero(shareCoordinates[0])), numberType) as Calculator<TNumber>;
+        var value = Calculator.Create(ToByteArray(FormatHexWithLeadingZero(shareCoordinates[1])), numberType) as Calculator<TNumber>;
+#endif
+        if (index < Calculator<TNumber>.One)
+        {
+            throw new FormatException(ErrorMessages.ShareIndexMustBePositive);
+        }
+
+        return (index, value);
+    }
+
+    private string FormatHex(bool uppercase)
+    {
+        var indexHex = ToHexString(this.Index.ByteRepresentation, uppercase);
+        var valueHex = ToHexString(this.Value.ByteRepresentation, uppercase);
+        indexHex = FormatHexWithLeadingZero(indexHex);
+        valueHex = FormatHexWithLeadingZero(valueHex);
+
+        return $"{indexHex}{CoordinateSeparator}{valueHex}";
+    }
+
+#if NET8_0_OR_GREATER
+    private static ReadOnlySpan<char> FormatHexWithLeadingZero(ReadOnlySpan<char> valueHex)
+    {
+        if (valueHex.Length % 2 == 0)
+        {
+            return valueHex;
+        }
+
+        var paddedHex = new Span<char>(new char[valueHex.Length + 1]);
+        valueHex.CopyTo(paddedHex[1..]);
+        paddedHex[0] = '0';
+        return paddedHex;
+    }
+#else
+    private static string FormatHexWithLeadingZero(string valueHex)
+        {
+            if (valueHex.Length % 2 == 0)
+            {
+                return valueHex;
+            }
+
+            return "0" + valueHex;
+    }
+#endif
+
+#if NET8_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ReadOnlySpan<char> ToHexString(IEnumerable<byte> bytes, bool uppercase)
+#else
+    private static string ToHexString(IEnumerable<byte> bytes, bool uppercase)
+#endif
+    {
+#if NET8_0_OR_GREATER
+        var byteArray = bytes as byte[] ?? bytes.ToArray();
+        var hexString = Convert.ToHexString(byteArray);
+
+        if (uppercase)
+        {
+            return hexString;
+        }
+
+        var chars = hexString.Length <= 512 ? stackalloc char[hexString.Length] : new char[hexString.Length];
+        hexString.AsSpan().ToLowerInvariant(chars);
+        return new string(chars);
+#else
+        var byteArray = bytes as byte[] ?? bytes.ToArray();
+        var hexAlphabet = uppercase ? "0123456789ABCDEF" : "0123456789abcdef";
+
+        var result = new char[byteArray.Length * 2];
+        var pos = 0;
+        foreach (byte b in byteArray)
+        {
+            result[pos++] = hexAlphabet[b >> 4];
+            result[pos++] = hexAlphabet[b & 0xF];
+        }
+
+        return new string(result);
+#endif
+    }
+
+    /// <summary>
+    /// Converts a hexadecimal string to a byte array.
+    /// </summary>
+    /// <param name="hexString">hexadecimal string</param>
+    /// <returns>Returns a byte array</returns>
+#if NET8_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static byte[] ToByteArray(ReadOnlySpan<char> hexString) => Convert.FromHexString(hexString);
+#else
+    private static byte[] ToByteArray(string hexString)
+    {
+        if (string.IsNullOrEmpty(hexString))
+        {
+            return [];
+        }
+
+        if ((hexString.Length & 1) != 0)
+        {
+            throw new ArgumentException(ErrorMessages.HexStringMustBeEven, nameof(hexString));
+        }
+
+        var bytes = new byte[hexString.Length >> 1];
+
+        for (int i = 0, j = 0; j < hexString.Length; j += 2, i++)
+        {
+            var high = GetHexValue(hexString[j]);
+            var low = GetHexValue(hexString[j + 1]);
+
+            if (high < 0 || low < 0)
+            {
+                throw new FormatException(string.Format(ErrorMessages.InvalidHexCharacter, high < 0 ? j : j + 1));
+            }
+
+            bytes[i] = (byte)(high << 4 | low);
+        }
+
+        return bytes;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int GetHexValue(char c)
+    {
+        return c switch
+        {
+            >= '0' and <= '9' => c - '0',
+            >= 'A' and <= 'F' => c - 'A' + 10,
+            >= 'a' and <= 'f' => c - 'a' + 10,
+            _ => -1
+        };
+    }
+#endif
+}

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -44,12 +44,12 @@ using System.Threading;
 /// </summary>
 /// <typeparam name="TNumber">Numeric data type (An integer type)</typeparam>
 [Serializable]
-public sealed class Shares<TNumber> : ICollection<FinitePoint<TNumber>>, ICollection
+public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection
 {
     /// <summary>
     /// Saves a collection of shares.
     /// </summary>
-    private readonly Collection<FinitePoint<TNumber>> shareList;
+    private readonly Collection<Share<TNumber>> shareList;
 
     /// <summary>
     /// Saves an object that can be used to synchronize access to the <see cref="Shares{TNumber}"/>
@@ -60,43 +60,50 @@ public sealed class Shares<TNumber> : ICollection<FinitePoint<TNumber>>, ICollec
     /// <summary>
     /// Initializes a new instance of the <see cref="Shares{TNumber}"/> class.
     /// </summary>
-    /// <param name="shares">A list of <see cref="FinitePoint{TNumber}"/> objects.</param>
+    /// <param name="shares">A list of <see cref="Share{TNumber}"/> objects.</param>
     /// <exception cref="ArgumentNullException"><paramref name="shares"/> is <see langword="null"/>.</exception>
-    private Shares(IList<FinitePoint<TNumber>> shares)
+    private Shares(IList<Share<TNumber>> shares)
     {
         _ = shares ?? throw new ArgumentNullException(nameof(shares));
-        this.shareList = shares as Collection<FinitePoint<TNumber>> ?? new Collection<FinitePoint<TNumber>>(shares);
+        var sortedShares = shares.ToArray();
+        Array.Sort(sortedShares);
+        this.shareList = new Collection<Share<TNumber>>(sortedShares);
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Shares{TNumber}"/> class.
     /// </summary>
     /// <param name="secret">The original secret which was split into <paramref name="shares"/>.</param>
-    /// <param name="shares">A list of <see cref="FinitePoint{TNumber}"/> objects.</param>
+    /// <param name="shares">A list of <see cref="Share{TNumber}"/> objects.</param>
     /// <exception cref="ArgumentNullException"><paramref name="secret"/> or <paramref name="shares"/> is <see langword="null"/>.</exception>
-    internal Shares(Secret<TNumber> secret, IList<FinitePoint<TNumber>> shares)
+    [Obsolete("This constructor is obsolete and will be removed in future versions.", false)]
+    internal Shares(Secret<TNumber> secret, IList<Share<TNumber>> shares)
     {
         this.OriginalSecret = secret;
         _ = shares ?? throw new ArgumentNullException(nameof(shares));
-        this.shareList = shares as Collection<FinitePoint<TNumber>> ?? new Collection<FinitePoint<TNumber>>(shares);
+        var sortedShares = shares.ToArray();
+        Array.Sort(sortedShares);
+        this.shareList = new Collection<Share<TNumber>>(sortedShares);
     }
 
     /// <summary>
     /// Gets the original secret
     /// </summary>
+    [Obsolete("The property OriginalSecret is obsolete and will be removed in future versions.", false)]
     public Secret<TNumber>? OriginalSecret { get; }
 
     /// <summary>
-    /// Gets the <see cref="FinitePoint{TNumber}"/> associated with the specified index.
+    /// Gets the <see cref="Share{TNumber}"/> associated with the specified index.
     /// </summary>
-    /// <param name="i">The index of the <see cref="FinitePoint{TNumber}"/> to get.</param>
-    /// <returns>Returns a share (shared secret) represented by a <see cref="FinitePoint{TNumber}"/>.</returns>
+    /// <param name="i">The index of the <see cref="Share{TNumber}"/> to get.</param>
+    /// <returns>Returns a share (shared secret) represented by a <see cref="Share{TNumber}"/>.</returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "i")]
-    public FinitePoint<TNumber> this[int i] => this.shareList[i];
+    public Share<TNumber> this[int i] => this.shareList[i];
 
     /// <summary>
     /// Gets a value indicating whether the original secret is available.
     /// </summary>
+    [Obsolete("The property OriginalSecretExists is obsolete and will be removed in future versions.", false)]
     public bool OriginalSecretExists => this.OriginalSecret != null;
 
     /// <summary>
@@ -119,7 +126,9 @@ public sealed class Shares<TNumber> : ICollection<FinitePoint<TNumber>>, ICollec
     {
         var points = s
             .Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries)
-            .Select(line => new FinitePoint<TNumber>(line))
+            .Select(line => line.Trim())
+            .Where(line => !string.IsNullOrEmpty(line))
+            .Select(line => new Share<TNumber>(line))
             .ToArray();
         return new Shares<TNumber>(points);
     }
@@ -131,17 +140,25 @@ public sealed class Shares<TNumber> : ICollection<FinitePoint<TNumber>>, ICollec
     public static implicit operator Shares<TNumber>(string[] s)
     {
         var points = s
-            .Select(line => new FinitePoint<TNumber>(line))
+            .Select(line => line.Trim())
+            .Where(line => !string.IsNullOrEmpty(line))
+            .Select(line => new Share<TNumber>(line))
             .ToArray();
         return new Shares<TNumber>(points);
     }
 
     /// <summary>
-    /// Casts a <see cref="Shares{TNumber}"/> object to an array of <see cref="FinitePoint{TNumber}"/> items.
+    /// Casts a <see cref="Shares{TNumber}"/> object to an array of <see cref="Share{TNumber}"/> items.
     /// </summary>
     /// <param name="shares">A <see cref="Shares{TNumber}"/> object.</param>
-    public static explicit operator FinitePoint<TNumber>[](Shares<TNumber> shares) =>
-        shares.Select(s => s).ToArray();
+    public static implicit operator Share<TNumber>[](Shares<TNumber> shares) => shares.ToArray();
+
+    /// <summary>
+    /// Casts an array of <see cref="Share{TNumber}"/> items to a <see cref="Shares{TNumber}"/> object.
+    /// </summary>
+    /// <param name="shares">An array of <see cref="Share{TNumber}"/> items.</param>
+    /// <returns></returns>
+    public static implicit operator Shares<TNumber>(Share<TNumber>[] shares) => new Shares<TNumber>(shares);
 
     /// <summary>
     /// Returns the string representation of the <see cref="Shares{TNumber}"/> instance.
@@ -150,7 +167,7 @@ public sealed class Shares<TNumber> : ICollection<FinitePoint<TNumber>>, ICollec
     public override string ToString()
     {
         var stringBuilder = new StringBuilder();
-        var shares = this.shareList as FinitePoint<TNumber>[] ?? this.shareList.ToArray();
+        var shares = this.shareList as Share<TNumber>[] ?? this.shareList.ToArray();
         foreach (var share in shares)
         {
             stringBuilder.AppendLine(share.ToString());
@@ -163,7 +180,7 @@ public sealed class Shares<TNumber> : ICollection<FinitePoint<TNumber>>, ICollec
     /// Returns an enumerator that iterates through a <see cref="Shares{TNumber}"/> collection.
     /// </summary>
     /// <returns>An enumerator that can be used to iterate through the <see cref="Shares{TNumber}"/> collection.</returns>
-    IEnumerator<FinitePoint<TNumber>> IEnumerable<FinitePoint<TNumber>>.GetEnumerator() => this.GetEnumerator();
+    IEnumerator<Share<TNumber>> IEnumerable<Share<TNumber>>.GetEnumerator() => this.GetEnumerator();
 
     /// <summary>
     /// Returns an enumerator that iterates through a <see cref="Shares{TNumber}"/> collection.
@@ -184,16 +201,16 @@ public sealed class Shares<TNumber> : ICollection<FinitePoint<TNumber>>, ICollec
     public bool IsReadOnly => true;
 
     /// <summary>
-    /// Gets the number of <see cref="FinitePoint{TNumber}"/> items contained in the <see cref="Shares{TNumber}"/> collection.
+    /// Gets the number of <see cref="Share{TNumber}"/> items contained in the <see cref="Shares{TNumber}"/> collection.
     /// </summary>
     public int Count => this.shareList.Count;
 
     /// <summary>
-    /// Determines whether the <see cref="Shares{TNumber}"/> collection contains a specific <see cref="FinitePoint{TNumber}"/>.
+    /// Determines whether the <see cref="Shares{TNumber}"/> collection contains a specific <see cref="Share{TNumber}"/>.
     /// </summary>
-    /// <param name="item">The <see cref="FinitePoint{TNumber}"/> to locate in the <see cref="Shares{TNumber}"/> collection.</param>
+    /// <param name="item">The <see cref="Share{TNumber}"/> to locate in the <see cref="Shares{TNumber}"/> collection.</param>
     /// <returns><see langword="true"/> if item is found in the <see cref="Shares{TNumber}"/> collection; otherwise, <see langword="false"/>.</returns>
-    public bool Contains(FinitePoint<TNumber> item) => this.shareList.Any(share => share.Equals(item));
+    public bool Contains(Share<TNumber> item) => this.shareList.Any(share => share.Equals(item));
 
     /// <summary>
     /// Removes all items from the <see cref="Shares{TNumber}"/> collection.
@@ -212,13 +229,13 @@ public sealed class Shares<TNumber> : ICollection<FinitePoint<TNumber>>, ICollec
     }
 
     /// <summary>
-    /// Adds an <see cref="FinitePoint{TNumber}"/> to the <see cref="Shares{TNumber}"/> collection.
+    /// Adds an <see cref="Share{TNumber}"/> to the <see cref="Shares{TNumber}"/> collection.
     /// </summary>
-    /// <param name="item">The <see cref="FinitePoint{TNumber}"/> to add to the <see cref="Shares{TNumber}"/> collection.</param>
+    /// <param name="item">The <see cref="Share{TNumber}"/> to add to the <see cref="Shares{TNumber}"/> collection.</param>
     /// <remarks>This method is implemented. However, this method does nothing as long as the property <see cref="IsReadOnly"/> is
     /// set to <see langword="true"/>.</remarks>
     /// <exception cref="NotSupportedException">The <see cref="Shares{TNumber}"/> collection is read-only.</exception>
-    public void Add(FinitePoint<TNumber> item)
+    public void Add(Share<TNumber> item)
     {
         if (this.IsReadOnly)
         {
@@ -232,14 +249,14 @@ public sealed class Shares<TNumber> : ICollection<FinitePoint<TNumber>>, ICollec
     }
 
     /// <summary>
-    /// Removes the first occurrence of a specific <see cref="FinitePoint{TNumber}"/> from the <see cref="Shares{TNumber}"/> collection.
+    /// Removes the first occurrence of a specific <see cref="Share{TNumber}"/> from the <see cref="Shares{TNumber}"/> collection.
     /// </summary>
     /// <param name="item">The <see cref="FinitePoint{TNumber}"/> to remove from the <see cref="Shares{TNumber}"/> collection.</param>
     /// <returns></returns>
     /// <remarks>This method is implemented. However, this method does nothing as long as the property <see cref="IsReadOnly"/> is
     /// set to <see langword="true"/>.</remarks>
     /// <exception cref="NotSupportedException">The <see cref="Shares{TNumber}"/> collection is read-only.</exception>
-    public bool Remove(FinitePoint<TNumber> item)
+    public bool Remove(Share<TNumber> item)
     {
         if (this.IsReadOnly)
         {
@@ -260,23 +277,23 @@ public sealed class Shares<TNumber> : ICollection<FinitePoint<TNumber>>, ICollec
         _ = array ?? throw new ArgumentNullException(nameof(array));
         switch (array)
         {
-            case FinitePoint<TNumber>[] x:
+            case Share<TNumber>[] x:
                 this.CopyTo(x, index);
                 break;
             default:
-                throw new InvalidCastException(string.Format(ErrorMessages.InvalidArrayTypeCast, nameof(array), array.GetType().GetElementType(), typeof(FinitePoint<TNumber>)));
+                throw new InvalidCastException(string.Format(ErrorMessages.InvalidArrayTypeCast, nameof(array), array.GetType().GetElementType(), typeof(Share<TNumber>)));
         }
     }
 
     /// <summary>
-    /// Copies the items of the <see cref="Shares{TNumber}"/> collection to an array of <see cref="FinitePoint{TNumber}"/> items,
+    /// Copies the items of the <see cref="Shares{TNumber}"/> collection to an array of <see cref="Share{TNumber}"/> items,
     /// starting at a particular array index.
     /// </summary>
-    /// <param name="array">The one-dimensional array of <see cref="FinitePoint{TNumber}"/> items that is the destination of the
+    /// <param name="array">The one-dimensional array of <see cref="Share{TNumber}"/> items that is the destination of the
     /// items copied from <see cref="Shares{TNumber}"/> collection.
     /// The array must have zero-based indexing.</param>
     /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
-    public void CopyTo(FinitePoint<TNumber>[] array, int arrayIndex)
+    public void CopyTo(Share<TNumber>[] array, int arrayIndex)
     {
         _ = array ?? throw new ArgumentNullException(nameof(array));
         if (arrayIndex < 0)

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -157,7 +157,7 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection
     /// Casts an array of <see cref="Share{TNumber}"/> items to a <see cref="Shares{TNumber}"/> object.
     /// </summary>
     /// <param name="shares">An array of <see cref="Share{TNumber}"/> items.</param>
-    /// <returns></returns>
+    /// <returns>A <see cref="Shares{TNumber}"/> instance that contains the specified shares.</returns>
     public static implicit operator Shares<TNumber>(Share<TNumber>[] shares) => new Shares<TNumber>(shares);
 
     /// <summary>

--- a/src/Cryptography/SharesEnumerator.cs
+++ b/src/Cryptography/SharesEnumerator.cs
@@ -41,12 +41,12 @@ using System.Collections.ObjectModel;
 /// </summary>
 /// <typeparam name="TNumber">The type of integer which is used by the <see cref="FinitePoint{TNumber}"/> items of the
 /// <see cref="Shares{TNumber}"/> collection.</typeparam>
-public sealed class SharesEnumerator<TNumber> : IEnumerator<FinitePoint<TNumber>>
+public sealed class SharesEnumerator<TNumber> : IEnumerator<Share<TNumber>>
 {
     /// <summary>
     /// Saves a list of <see cref="FinitePoint{TNumber}"/>.
     /// </summary>
-    private readonly ReadOnlyCollection<FinitePoint<TNumber>> shareList;
+    private readonly ReadOnlyCollection<Share<TNumber>> shareList;
 
     /// <summary>
     /// Saves the current of the enumerator
@@ -58,10 +58,10 @@ public sealed class SharesEnumerator<TNumber> : IEnumerator<FinitePoint<TNumber>
     /// </summary>
     /// <param name="shares">A collection of <see cref="FinitePoint{TNumber}"/> items representing the shares.</param>
     /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/></exception>
-    public SharesEnumerator(Collection<FinitePoint<TNumber>> shares)
+    public SharesEnumerator(Collection<Share<TNumber>> shares)
     {
         _ = shares ?? throw new ArgumentNullException(nameof(shares));
-        this.shareList = new ReadOnlyCollection<FinitePoint<TNumber>>(shares);
+        this.shareList = new ReadOnlyCollection<Share<TNumber>>(shares);
     }
 
     /// <summary>
@@ -93,7 +93,7 @@ public sealed class SharesEnumerator<TNumber> : IEnumerator<FinitePoint<TNumber>
     /// <summary>
     /// Gets the element in the <see cref="Shares{TNumber}"/> collection at the current position of the enumerator.
     /// </summary>
-    public FinitePoint<TNumber> Current
+    public Share<TNumber> Current
     {
         get
         {

--- a/src/Extension/ShareExtensions.cs
+++ b/src/Extension/ShareExtensions.cs
@@ -1,14 +1,14 @@
 // ----------------------------------------------------------------------------
-// <copyright file="SharedSeparator.cs" company="Private">
-// Copyright (c) 2023 All Rights Reserved
+// <copyright file="ShareExtensions.cs" company="Private">
+// Copyright (c) 2025 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
-// <date>05/27/2023 06:05:12 PM</date>
+// <date>12/24/2025 10:44:47 PM</date>
 // ----------------------------------------------------------------------------
 
 #region License
 // ----------------------------------------------------------------------------
-// Copyright 2019 Sebastian Walther
+// Copyright 2025 Sebastian Walther
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -29,17 +29,44 @@
 // THE SOFTWARE.
 #endregion
 
-namespace SecretSharingDotNet.Cryptography;
+namespace SecretSharingDotNet.Extension;
 
-internal static class SharedSeparator
+using Cryptography;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Provides extension methods for working with shares.
+/// </summary>
+public static class ShareExtensions
 {
     /// <summary>
-    /// The separator between the X and Y coordinate
+    /// Converts a collection of shares to an array of <see cref="FinitePoint{TNumber}"/>.
     /// </summary>
-    internal const char CoordinateSeparator = '-';
+    /// <param name="shares">The collection of shares to convert.</param>
+    /// <returns>An array of finite points.</returns>
+    public static FinitePoint<TNumber>[] ToFinitePoints<TNumber>(this IEnumerable<Share<TNumber>> shares)
+    {
+        if (shares is null)
+        {
+            throw new ArgumentNullException(nameof(shares));
+        }
+
+        return shares.Select(s => new FinitePoint<TNumber>(s.Index, s.Value)).ToArray();
+    }
 
     /// <summary>
-    /// Separator array for <see cref="string.Split(char[])"/> method usage to avoid allocation of a new array.
+    /// Converts a collection of <see cref="FinitePoint{T}"/> to an array of shares.
     /// </summary>
-    internal static readonly char[] CoordinateSeparatorArray = [CoordinateSeparator];
+    /// <param name="points">The collection of finite points to convert.</param>
+    /// <returns>An array of shares.</returns>
+    public static Share<TNumber>[] ToShares<TNumber>(this IEnumerable<FinitePoint<TNumber>> points)
+    {
+        if (points is null)
+        {
+            throw new ArgumentNullException(nameof(points));
+        }
+        return points.Select(p => new Share<TNumber>(p.X, p.Y)).ToArray();
+    }
 }

--- a/src/Math/BigIntCalculator.cs
+++ b/src/Math/BigIntCalculator.cs
@@ -300,12 +300,6 @@ public sealed class BigIntCalculator : Calculator<BigInteger>
     }
 
     /// <summary>
-    /// Converts the numeric value of the current <see cref="BigIntCalculator"/> object to its equivalent string representation.
-    /// </summary>
-    /// <returns>The <see cref="System.String"/> representation of the current <see cref="BigIntCalculator"/> value.</returns>
-    public override string ToString() => this.Value.ToString();
-
-    /// <summary>
     /// Creates a lazily initialized instance to compute the byte count of the backing <see cref="BigInteger"/> value.
     /// </summary>
     /// <returns>A lazily initialized function that calculates the length of the byte array representing the <see cref="BigInteger"/> value.

--- a/src/Math/Calculator`1.cs
+++ b/src/Math/Calculator`1.cs
@@ -382,8 +382,15 @@ public abstract class Calculator<TNumber> :
     public abstract int CompareTo(Calculator<TNumber> other);
 
     /// <summary>
-    /// Converts the numeric value of the current <see cref="Calculator{TNumber}"/> object to its equivalent string representation.
+    /// Converts the numeric value of the current <see cref="Calculator{TNumber}"/> instance to its equivalent <see cref="System.String"/> representation.
     /// </summary>
     /// <returns>The <see cref="System.String"/> representation of the current <see cref="Calculator{TNumber}"/> value.</returns>
-    public abstract override string ToString();
+    public override string ToString()
+    {
+#if DEBUG
+        return $"{this.GetType().Name}({this.Value})";
+#else
+        return "*** Secured Value ***";
+#endif
+    }
 }

--- a/src/Resources/ErrorMessages.Designer.cs
+++ b/src/Resources/ErrorMessages.Designer.cs
@@ -131,16 +131,52 @@ namespace SecretSharingDotNet {
                 return ResourceManager.GetString("NoValidMersennePrimeExponentAvailable", resourceCulture);
             }
         }
-
+        
         internal static string InverseOfZeroDoesNotExist {
             get {
                 return ResourceManager.GetString("InverseOfZeroDoesNotExist", resourceCulture);
             }
         }
-
+        
         internal static string DenominatorIsNotInvertibleModuloPrime {
             get {
                 return ResourceManager.GetString("DenominatorIsNotInvertibleModuloPrime", resourceCulture);
+            }
+        }
+        
+        internal static string ShareIndexMustBePositive {
+            get {
+                return ResourceManager.GetString("ShareIndexMustBePositive", resourceCulture);
+            }
+        }
+        
+        internal static string ShareStringCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("ShareStringCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        internal static string ShareIndexAndValueMustBeNonEmpty {
+            get {
+                return ResourceManager.GetString("ShareIndexAndValueMustBeNonEmpty", resourceCulture);
+            }
+        }
+        
+        internal static string HexStringMustBeEven {
+            get {
+                return ResourceManager.GetString("HexStringMustBeEven", resourceCulture);
+            }
+        }
+        
+        internal static string InvalidHexCharacter {
+            get {
+                return ResourceManager.GetString("InvalidHexCharacter", resourceCulture);
+            }
+        }
+        
+        internal static string InvalidShareFormat {
+            get {
+                return ResourceManager.GetString("InvalidShareFormat", resourceCulture);
             }
         }
     }

--- a/src/Resources/ErrorMessages.de-DE.resx
+++ b/src/Resources/ErrorMessages.de-DE.resx
@@ -73,7 +73,7 @@
         <value>Hex-String muss eine gerade Länge haben.</value>
     </data>
     <data name="InvalidHexCharacter" xml:space="preserve">
-        <value>UIngültiges Hex-Zeichen an Position {0}</value>
+        <value>Ungültiges Hex-Zeichen an Position {0}</value>
     </data>
     <data name="InvalidShareFormat" xml:space="preserve">
         <value>Ungültiges Share-Format. Erwartetes Format: 'X{0}Y', wobei X und Y hexadezimale Werte sind.</value>

--- a/src/Resources/ErrorMessages.de-DE.resx
+++ b/src/Resources/ErrorMessages.de-DE.resx
@@ -60,4 +60,22 @@
         <value>Der Nenner ist nicht invertierbar modulo Primzahl (ggT != 1).
 Überprüfe, ob alle Berechnungen in GF(p) mit einem Primzahlmodul durchgeführt werden.</value>
     </data>
+    <data name="ShareIndexMustBePositive" xml:space="preserve">
+        <value>Der Share-Index muss eine positive ganze Zahl größer Null sein.</value>
+    </data>
+    <data name="ShareStringCannotBeEmpty" xml:space="preserve">
+        <value>Der Share-String darf nicht leer sein.</value>
+    </data>
+    <data name="ShareIndexAndValueMustBeNonEmpty" xml:space="preserve">
+        <value>Ungültiges Share-Format. Der Index und der Wert des Shares dürfen nicht leer sein.</value>
+    </data>
+    <data name="HexStringMustBeEven" xml:space="preserve">
+        <value>Hex-String muss eine gerade Länge haben.</value>
+    </data>
+    <data name="InvalidHexCharacter" xml:space="preserve">
+        <value>UIngültiges Hex-Zeichen an Position {0}</value>
+    </data>
+    <data name="InvalidShareFormat" xml:space="preserve">
+        <value>Ungültiges Share-Format. Erwartetes Format: 'X{0}Y', wobei X und Y hexadezimale Werte sind.</value>
+    </data>
 </root>

--- a/src/Resources/ErrorMessages.resx
+++ b/src/Resources/ErrorMessages.resx
@@ -67,4 +67,22 @@
         <value>Denominator is not invertible modulo prime (gcd != 1).
 Check that all computations are performed in GF(p) with a prime modulus.</value>
     </data>
+    <data name="ShareIndexMustBePositive" xml:space="preserve">
+        <value>Share index must be a positive integer greater than zero.</value>
+    </data>
+    <data name="ShareStringCannotBeEmpty" xml:space="preserve">
+        <value>Share string cannot be empty.</value>
+    </data>
+    <data name="ShareIndexAndValueMustBeNonEmpty" xml:space="preserve">
+        <value>Invalid share format. Both index and value parts must be non-empty.</value>
+    </data>
+    <data name="HexStringMustBeEven" xml:space="preserve">
+        <value>Hex string must have even length</value>
+    </data>
+    <data name="InvalidHexCharacter" xml:space="preserve">
+        <value>Invalid hex character at position {0}</value>
+    </data>
+    <data name="InvalidShareFormat" xml:space="preserve">
+        <value>Invalid share format. Expected format: 'X{0}Y' where X and Y are hexadecimal values.</value>
+    </data>
 </root>

--- a/tests/Cryptography/ShamirsSecretSharing/ShamirsSecretSharingTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/ShamirsSecretSharingTest.cs
@@ -80,26 +80,25 @@ public class SecretSplitterTest
         var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
 
         // Act & Assert
-        Shares<BigInteger> shares = null;
+        Secret<BigInteger> s;
         switch (secret)
         {
             case string password:
-                shares = secretSplitter.MakeShares(3, 7, password);
+                s = password;
                 break;
             case BigInteger number:
-                shares = secretSplitter.MakeShares(3, 7, number);
+                s = number;
                 break;
             case null:
                 return;
         }
+        var shares = secretSplitter.MakeShares(3, 7, s);
 
         Assert.NotNull(shares);
-        Assert.True(shares.OriginalSecretExists);
-        Assert.NotNull(shares.OriginalSecret);
-        var subSet1 = shares.Where(p => p.X.IsEven).ToList();
-        var recoveredSecret1 = secretReconstructor.Reconstruction(subSet1.ToArray());
-        var subSet2 = shares.Where(p => !p.X.IsEven).ToList();
-        var recoveredSecret2 = secretReconstructor.Reconstruction(subSet2.ToArray());
+        var subSet1 = shares.Where(p => p.IsIndexOdd).ToArray();
+        var recoveredSecret1 = secretReconstructor.Reconstruction(subSet1);
+        var subSet2 = shares.Where(p => p.IsIndexEven).ToArray();
+        var recoveredSecret2 = secretReconstructor.Reconstruction(subSet2);
 
         switch (secret)
         {
@@ -111,8 +110,8 @@ public class SecretSplitterTest
                 break;
         }
 
-        Assert.Equal(shares.OriginalSecret, recoveredSecret1);
-        Assert.Equal(shares.OriginalSecret, recoveredSecret2);
+        Assert.Equal(s, recoveredSecret1);
+        Assert.Equal(s, recoveredSecret2);
         Assert.Equal(expectedSecurityLevel, secretSplitter.SecurityLevel);
     }
 
@@ -133,18 +132,14 @@ public class SecretSplitterTest
 
         // Act
         var shares = secretSplitter.MakeShares(3, 7, password, splitSecurityLevel);
-        var secret = shares.OriginalSecret;
-        var subSet1 = shares.Where(p => p.X.IsEven).ToList();
-        var recoveredSecret1 = secretReconstructor.Reconstruction(subSet1.ToArray());
-        var subSet2 = shares.Where(p => !p.X.IsEven).ToList();
-        var recoveredSecret2 = secretReconstructor.Reconstruction(subSet2.ToArray());
+        var subSet1 = shares.Where(p => p.IsIndexOdd).ToArray();
+        var recoveredSecret1 = secretReconstructor.Reconstruction(subSet1);
+        var subSet2 = shares.Where(p => p.IsIndexEven).ToArray();
+        var recoveredSecret2 = secretReconstructor.Reconstruction(subSet2);
 
         // Assert
-        Assert.True(shares.OriginalSecretExists);
-        Assert.NotNull(shares.OriginalSecret);
         Assert.Equal(password, recoveredSecret1);
-        Assert.Equal(secret, recoveredSecret1);
-        Assert.Equal(secret, recoveredSecret2);
+        Assert.Equal(password, recoveredSecret2);
         Assert.Equal(expectedSecurityLevel, secretSplitter.SecurityLevel);
     }
 
@@ -165,18 +160,14 @@ public class SecretSplitterTest
 
         // Act
         var shares = secretSplitter.MakeShares(3, 7, number, splitSecurityLevel);
-        var secret = shares.OriginalSecret;
-        var subSet1 = shares.Where(p => p.X.IsEven).ToList();
-        var recoveredSecret1 = secretReconstructor.Reconstruction(subSet1.ToArray());
-        var subSet2 = shares.Where(p => !p.X.IsEven).ToList();
-        var recoveredSecret2 = secretReconstructor.Reconstruction(subSet2.ToArray());
+        var subSet1 = shares.Where(p => p.IsIndexOdd).ToArray();
+        var recoveredSecret1 = secretReconstructor.Reconstruction(subSet1);
+        var subSet2 = shares.Where(p => p.IsIndexEven).ToArray();
+        var recoveredSecret2 = secretReconstructor.Reconstruction(subSet2);
 
         // Assert
-        Assert.True(shares.OriginalSecretExists);
-        Assert.NotNull(shares.OriginalSecret);
         Assert.Equal(number, (BigInteger)recoveredSecret1);
-        Assert.Equal(secret, recoveredSecret1);
-        Assert.Equal(secret, recoveredSecret2);
+        Assert.Equal(number, (BigInteger)recoveredSecret2);
         Assert.Equal(expectedSecurityLevel, secretSplitter.SecurityLevel);
     }
 
@@ -195,23 +186,20 @@ public class SecretSplitterTest
         var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
 
         // Act
-        var shares = secretSplitter.MakeShares(3, 7, splitSecurityLevel);
-        var secret = shares.OriginalSecret;
-        var subSet1 = shares.Where(p => p.X.IsEven).ToList();
-        var recoveredSecret1 = secretReconstructor.Reconstruction(subSet1.ToArray());
-        var subSet2 = shares.Where(p => !p.X.IsEven).ToList();
-        var recoveredSecret2 = secretReconstructor.Reconstruction(subSet2.ToArray());
+        var shares = secretSplitter.MakeShares(3, 7, splitSecurityLevel, out var originalSecret);
+        var subSet1 = shares.Where(p => p.IsIndexOdd).ToArray();
+        var recoveredSecret1 = secretReconstructor.Reconstruction(subSet1);
+        var subSet2 = shares.Where(p => p.IsIndexEven).ToArray();
+        var recoveredSecret2 = secretReconstructor.Reconstruction(subSet2);
 
         // Assert
-        Assert.True(shares.OriginalSecretExists);
-        Assert.NotNull(shares.OriginalSecret);
-        Assert.Equal(secret, recoveredSecret1);
-        Assert.Equal(secret, recoveredSecret2);
+        Assert.Equal(originalSecret, recoveredSecret1);
+        Assert.Equal(originalSecret, recoveredSecret2);
         Assert.Equal(expectedSecurityLevel, secretSplitter.SecurityLevel);
     }
 
     /// <summary>
-    /// Tests the MakeShares method with a minimum shares number of 1 to be sure that a error occurs.
+    /// Tests the MakeShares method with a minimum shares number of 1 to be sure that an error occurs.
     /// Only a minimum shares number of greater or equal to 2 is valid.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
@@ -222,7 +210,7 @@ public class SecretSplitterTest
         var secretSplitter = new SecretSplitter<BigInteger>();
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => secretSplitter.MakeShares(1, 7, 5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => secretSplitter.MakeShares(1, 7, 5, out _));
     }
 
     /// <summary>
@@ -237,9 +225,9 @@ public class SecretSplitterTest
         var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
 
         // Act & Assert
-        var shares = secretSplitter.MakeShares(2, 7, 13);
-        var subSet = shares.Where(p => p.X == Calculator<BigInteger>.One).ToList();
-        Assert.Throws<ArgumentOutOfRangeException>(() => secretReconstructor.Reconstruction(subSet.ToArray()));
+        var shares = secretSplitter.MakeShares(2, 7, 13, out _);
+        var subSet = shares.Where(p => p.Index == Calculator<BigInteger>.One).ToArray();
+        Assert.Throws<ArgumentOutOfRangeException>(() => secretReconstructor.Reconstruction(subSet));
     }
 
     /// <summary>
@@ -254,12 +242,12 @@ public class SecretSplitterTest
         var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
 
         // Act
-        var shares = secretSplitter.MakeShares(3, 7, 51);
-        var subSet = shares.Take(2).ToList();
-        var secret = secretReconstructor.Reconstruction(subSet.ToArray());
+        var shares = secretSplitter.MakeShares(3, 7, 51, out var originalSecret);
+        var subSet = shares.Take(2).ToArray();
+        var secret = secretReconstructor.Reconstruction(subSet);
 
         // Assert
-        Assert.NotEqual(shares.OriginalSecret, secret);
+        Assert.NotEqual(originalSecret, secret);
     }
 
     /// <summary>
@@ -277,10 +265,10 @@ public class SecretSplitterTest
 
         // Act
         var shares = secretSplitter.MakeShares(3, 7, longSecret, 1024);
-        var subSet1 = shares.Where(p => p.X.IsEven).ToList();
-        var recoveredSecret1 = secretReconstructor.Reconstruction(subSet1.ToArray());
-        var subSet2 = shares.Where(p => !p.X.IsEven).ToList();
-        var recoveredSecret2 = secretReconstructor.Reconstruction(subSet2.ToArray());
+        var subSet1 = shares.Where(p => p.IsIndexOdd).ToArray();
+        var recoveredSecret1 = secretReconstructor.Reconstruction(subSet1);
+        var subSet2 = shares.Where(p => p.IsIndexEven).ToArray();
+        var recoveredSecret2 = secretReconstructor.Reconstruction(subSet2);
 
         // Assert
         Assert.Equal(longSecret, recoveredSecret1);

--- a/tests/Cryptography/ShareTest.cs
+++ b/tests/Cryptography/ShareTest.cs
@@ -1,0 +1,189 @@
+using Xunit;
+using SecretSharingDotNet.Cryptography;
+using System;
+
+namespace SecretSharingDotNetTest.Cryptography;
+
+using SecretSharingDotNet.Math;
+using System.Numerics;
+
+public class ShareTest
+{
+    [Theory]
+    [InlineData(5, 10)]
+    [InlineData(1, 0)]
+    [InlineData(12345678901234567890, 987654321098765430)]
+    public void Constructor_ValidInputs_ShouldInitializeCorrectly(BigInteger index, BigInteger value)
+    {
+        // Arrange & Act
+        var share = new Share<BigInteger>(index, value);
+
+        // Assert
+        Assert.Equal(new BigIntCalculator(index), share.Index);
+        Assert.Equal(new BigIntCalculator(value), share.Value);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-50)]
+    [InlineData(-100)]
+    public void Constructor_NegativeIndex_ShouldThrowArgumentOutOfRangeException(BigInteger index)
+    {
+        // Arrange
+        var value = new BigIntCalculator(10);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Share<BigInteger>(index, value));
+    }
+
+    [Fact]
+    public void Constructor_DefaultIndexValue_ShouldThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        var index = BigIntCalculator.Zero;
+        var value = new BigIntCalculator(10);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Share<BigInteger>(index, value));
+    }
+
+    [Fact]
+    public void IsEven_ShouldReturnTrueIfIndexIsEven()
+    {
+        // Arrange
+        var index = new BigIntCalculator(4);
+        var value = new BigIntCalculator(10);
+        var share = new Share<BigInteger>(index, value);
+
+        // Act & Assert
+        Assert.True(share.IsIndexEven);
+    }
+
+    [Fact]
+    public void IsOdd_ShouldReturnTrueIfIndexIsOdd()
+    {
+        // Arrange
+        var index = new BigIntCalculator(5);
+        var value = new BigIntCalculator(10);
+        var share = new Share<BigInteger>(index, value);
+
+        // Act & Assert
+        Assert.True(share.IsIndexOdd);
+    }
+
+    [Fact]
+    public void IsEmpty_ShouldReturnTrueIfShareIsDefault()
+    {
+        // Arrange
+        var share = new Share<BigInteger>();
+
+        // Act & Assert
+        Assert.True(share.IsEmpty);
+    }
+
+    [Theory]
+    [InlineData(5, 10, "05-0A")]
+    [InlineData(255, 255, "FF00-FF00")]
+    [InlineData(16, 32, "10-20")]
+    [InlineData(11, -86, "0B-AA")]
+    [InlineData(1, 1, "01-01")]
+    [InlineData(1000, 4096, "E803-0010")]
+    public void ToString_ValidShare_ShouldReturnFormattedString(BigInteger index, BigInteger value, string expected)
+    {
+        // Arrange
+        var share = new Share<BigInteger>(index, value);
+
+        // Act & Assert
+        Assert.Equal(expected, share.ToString());
+    }
+
+    [Theory]
+    [InlineData(5, 10, "05-0a")]
+    [InlineData(255, 255, "ff00-ff00")]
+    [InlineData(16, 32, "10-20")]
+    [InlineData(11, -86, "0b-aa")]
+    [InlineData(1, 1, "01-01")]
+    [InlineData(1000, 4096, "e803-0010")]
+    public void ToString_WithFormatSpecifier_ShouldReturnFormattedString(BigInteger index, BigInteger value, string expected)
+    {
+        // Arrange
+        var share = new Share<BigInteger>(index, value);
+
+        // Act & Assert
+        Assert.Equal(expected, share.ToString("x"));
+    }
+
+    [Fact]
+    public void Parse_ValidString_ShouldParseCorrectly()
+    {
+        // Arrange
+        const string shareString = "B-AA";
+
+        // Act
+        var share = Share<BigInteger>.Parse(shareString);
+
+        // Assert
+        Assert.Equal(new BigIntCalculator(11), share.Index);
+        Assert.Equal(new BigIntCalculator(-86), share.Value);
+    }
+
+    [Fact]
+    public void Parse_InvalidString_ShouldThrowFormatException()
+    {
+        // Arrange
+        const string shareString = "invalid-input";
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => Share<BigInteger>.Parse(shareString));
+    }
+
+    [Fact]
+    public void TryParse_ValidString_ShouldReturnTrueAndOutputParsedShare()
+    {
+        // Arrange
+        const string shareString = "05-10";
+
+        // Act & Assert
+        Assert.True(Share<BigInteger>.TryParse(shareString, out var share));
+        Assert.Equal(new BigIntCalculator(5), share.Index);
+        Assert.Equal(new BigIntCalculator(16), share.Value);
+    }
+
+    [Fact]
+    public void TryParse_InvalidString_ShouldReturnFalse()
+    {
+        // Arrange
+        const string shareString = "invalid-input";
+
+        // Act & Assert
+        Assert.False(Share<BigInteger>.TryParse(shareString, out var share));
+        Assert.True(share.IsEmpty);
+    }
+
+    [Fact]
+    public void CompareTo_ShouldReturnCorrectComparisonResult()
+    {
+        // Arrange
+        var share1 = new Share<BigInteger>(new BigIntCalculator(5), new BigIntCalculator(10));
+        var share2 = new Share<BigInteger>(new BigIntCalculator(10), new BigIntCalculator(20));
+
+        // Act & Assert
+        Assert.True(share1.CompareTo(share2) < 0);
+        Assert.True(share2.CompareTo(share1) > 0);
+        Assert.Equal(0, share1.CompareTo(new Share<BigInteger>(new BigIntCalculator(5), new BigIntCalculator(15))));
+    }
+
+    [Fact]
+    public void Operators_ShouldPerformComparisonsCorrectly()
+    {
+        // Arrange
+        var share1 = new Share<BigInteger>(new BigIntCalculator(5), new BigIntCalculator(10));
+        var share2 = new Share<BigInteger>(new BigIntCalculator(10), new BigIntCalculator(20));
+
+        // Act & Assert
+        Assert.True(share1 < share2);
+        Assert.False(share1 > share2);
+        Assert.True(share1 <= share2);
+        Assert.True(share2 >= share1);
+    }
+}

--- a/tests/Cryptography/SharesTest.cs
+++ b/tests/Cryptography/SharesTest.cs
@@ -34,7 +34,6 @@ namespace SecretSharingDotNetTest.Cryptography;
 using SecretSharingDotNet.Cryptography;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Xunit;
@@ -45,63 +44,87 @@ using Xunit;
 public class SharesTest
 {
     /// <summary>
-    /// Tests the cast from <see cref="string"/> array to <see cref="Shares{TNumber}"/> and vice versa.
+    /// Tests the Contains method of the <see cref="Shares{TNumber}"/> class
+    /// to verify that it returns true when a specified share exists
+    /// within the collection.
     /// </summary>
-    [Fact]
-    public void TestSharesToStringArray()
+    /// <param name="index">The index of the share in the predefined shares collection to validate its presence in the collection.</param>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void Contains_ShareExists_ReturnsTrue(int index)
     {
         // Arrange
         var stringArray = TestData.GetPredefinedShares();
+        Shares<BigInteger> sharesCollection = stringArray;
 
-        // Act
+        // Act & Assert
+        Assert.Contains(new Share<BigInteger>(TestData.GetPredefinedShares()[index]), sharesCollection);
+    }
+
+    /// <summary>
+    /// Tests the Contains method of the <see cref="Shares{TNumber}"/> class
+    /// to verify that it returns false when a specified share does not exist
+    /// within the collection.
+    /// </summary>
+    [Fact]
+    public void Contains_ShareDoesNotExist_ReturnsFalse()
+    {
+        // Arrange
+        var stringArray = TestData.GetPredefinedShares();
+        Shares<BigInteger> sharesCollection = stringArray;
+        var nonExistingShare = new Share<BigInteger>("4-9999999999999999999999");
+
+        // Act & Assert
+        Assert.DoesNotContain(nonExistingShare, sharesCollection);
+    }
+
+    /// <summary>
+    /// Validates the explicit cast operation from the <see cref="Shares{TNumber}"/> class to a string array.
+    /// </summary>
+    /// <remarks>
+    /// Ensures that the explicit cast produces the expected array of shares in string format,
+    /// verifying correctness in transformation.
+    /// </remarks>
+    [Fact]
+    public void ExplicitCastToStringArray_ReturnsExpectedArray()
+    {
+        // Arrange
+        var stringArray = TestData.GetPredefinedShares();
         Shares<BigInteger> shares = stringArray;
 
-        // Assert
+        // Act & Assert
         Assert.Equal(TestData.GetPredefinedShares(), (string[])shares);
     }
 
     /// <summary>
-    /// Tests the cast from <see cref="string"/> to <see cref="Shares{TNumber}"/> and vice versa.
+    /// Verifies that the <see cref="Shares{TNumber}.ToString"/> method returns a string representation
+    /// that accurately reflects the expected format and content of the shares.
     /// </summary>
     [Fact]
-    public void TestSharesToString()
+    public void ToString_ReturnsExpectedString()
     {
         // Arrange
         var text = string.Join(Environment.NewLine, TestData.GetPredefinedShares()) + Environment.NewLine;
-
-        // Act
         Shares<BigInteger> shares = text;
 
-        // Assert
+        // Act & Assert
         Assert.Equal(text, shares.ToString());
     }
 
     /// <summary>
-    /// Tests the Contains method of the <see cref="Shares{TNumber}"/> class.
+    /// Verifies that the <see cref="Shares{TNumber}"/> class implements the
+    /// <see cref="IEnumerable"/> interface correctly and returns an enumerator
+    /// that iterates through the collection as expected.
     /// </summary>
     [Fact]
-    public void TestShareContains()
-    {
-        // Arrange
-        var stringArray = TestData.GetPredefinedShares();
-
-        // Act
-        Shares<BigInteger> shares = stringArray;
-
-        // Assert
-        Assert.Contains(new FinitePoint<BigInteger>(TestData.GetPredefinedShares()[0]), shares);
-    }
-
-    /// <summary>
-    /// Tests the <see cref="IEnumerator{T}"/> implementation of the <see cref="SharesEnumerator{TNumber}"/> class in the <see cref="Shares{TNumber}"/> class.
-    /// </summary>
-    [Fact]
-    public void TestSharesEnumerator()
+    public void GetEnumerator_ReturnsExpectedEnumerator()
     {
         // Arrange
         Shares<BigInteger> shares = TestData.GetPredefinedShares();
-        var testDataSequence = TestData.GetPredefinedShares().Select(entry => new FinitePoint<BigInteger>(entry));
-        var testDataArray = testDataSequence as FinitePoint<BigInteger>[] ?? testDataSequence.ToArray();
+        var testDataSequence = TestData.GetPredefinedShares().Select(entry => new Share<BigInteger>(entry));
+        var testDataArray = testDataSequence as Share<BigInteger>[] ?? testDataSequence.ToArray();
 
         // Act
         var actual = ((IEnumerable)shares).GetEnumerator();
@@ -116,5 +139,120 @@ public class SharesTest
         }
 
         Assert.True(shares.SequenceEqual(testDataArray));
+    }
+    
+    [Fact]
+    public void Count_ReturnsExpectedCount()
+    {
+        // Arrange
+        Shares<BigInteger> shares = TestData.GetPredefinedShares();
+        var expectedCount = TestData.GetPredefinedShares().Length;
+
+        // Act
+        var actualCount = shares.Count;
+
+        // Assert
+        Assert.Equal(expectedCount, actualCount);
+    }
+
+    [Fact]
+    public void Indexer_ReturnsExpectedShare()
+    {
+        // Arrange
+        Shares<BigInteger> shares = TestData.GetPredefinedShares();
+        var expectedShares = TestData.GetPredefinedShares()
+            .Select(entry => new Share<BigInteger>(entry))
+            .ToArray();
+
+        // Act & Assert
+        for (int i = 0; i < shares.Count; i++)
+        {
+            Assert.Equal(expectedShares[i], shares[i]);
+        }
+    }
+    
+    [Fact]
+    public void CopyTo_CopiesSharesToArray()
+    {
+        // Arrange
+        Shares<BigInteger> shares = TestData.GetPredefinedShares();
+        var sharesArray = new Share<BigInteger>[shares.Count];
+        
+        // Act
+        shares.CopyTo(sharesArray, 0);
+        
+        // Assert
+        for (int i = 0; i < shares.Count; i++)
+        {
+            Assert.Equal(shares[i], sharesArray[i]);
+        }
+    }
+
+    [Fact]
+    public void IsReadOnly_ReturnsTrue()
+    {
+        // Arrange
+        Shares<BigInteger> shares = TestData.GetPredefinedShares();
+
+        // Act
+        var isReadOnly = shares.IsReadOnly;
+
+        // Assert
+        Assert.True(isReadOnly);
+    }
+    
+    [Fact]
+    public void Constructor_WithStringArray_InitializesShares()
+    {
+        // Arrange
+        var stringArray = TestData.GetPredefinedShares();
+
+        // Act
+        Shares<BigInteger> shares = stringArray;
+
+        // Assert
+        Assert.Equal(stringArray.Length, shares.Count);
+        for (int i = 0; i < stringArray.Length; i++)
+        {
+            Assert.Equal(new Share<BigInteger>(stringArray[i]), shares[i]);
+        }
+    }
+    
+    [Fact]
+    public void AscendingOrder_WithStringArray_SortsSharesByIndex()
+    {
+        // Arrange
+        var stringArray = new[]
+        {
+            "3-300",
+            "1-100",
+            "2-200"
+        };
+
+        // Act
+        Shares<BigInteger> sortedShares = stringArray;
+
+        // Assert
+        Assert.Equal(new Share<BigInteger>("1-100"), sortedShares[0]);
+        Assert.Equal(new Share<BigInteger>("2-200"), sortedShares[1]);
+        Assert.Equal(new Share<BigInteger>("3-300"), sortedShares[2]);
+    }
+    
+    [Fact]
+    public void AscendingOrder_WithStringInput_SortsSharesByIndex()
+    {
+        // Arrange
+        var input =
+            "3-300" + Environment.NewLine +
+            "1-100" + Environment.NewLine +
+            "2-200";
+
+        // Act
+        Shares<BigInteger> sortedShares = input;
+
+        // Assert
+        Assert.Equal(new Share<BigInteger>("1-100"), sortedShares[0]);
+        Assert.Equal(new Share<BigInteger>("2-200"), sortedShares[1]);
+        Assert.Equal(new Share<BigInteger>("3-300"), sortedShares[2]);
     }
 }


### PR DESCRIPTION
This pull request introduces several significant improvements to the secret sharing library, focusing on extensibility, API modernization, and future-proofing. The most notable changes include the introduction of a new `Share` struct to replace `FinitePoint`, updates to the `Shares` class and related APIs, and comprehensive deprecation of older methods and properties. The documentation and examples have also been updated to reflect these changes.

### API Modernization and Extensibility

* Added a new `Share<TNumber>` struct to represent individual shares, replacing the previous use of `FinitePoint<TNumber>`, and updated the codebase and documentation to use `Share` for improved clarity and future extensibility. (`CHANGELOG.md`, `README.md`, `src/Cryptography/FinitePoint`1.cs`, `src/Cryptography/IMakeSharesUseCase.cs`, `src/Cryptography/IReconstructionUseCase.cs`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L413-R406) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L429-R420) [[4]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL49-L60)

* Marked the `FinitePoint<TNumber>` struct as obsolete and indicated it will become internal in future releases. (`CHANGELOG.md`, `src/Cryptography/FinitePoint`1.cs`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R24) [[2]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL49-L60)

### Shares API Changes

* Changed the `Shares` class to use the new `Share` struct instead of `FinitePoint<TNumber>`, and updated its constructor to ensure shares are sorted by their X (index) values for consistent ordering. (`CHANGELOG.md`)

### Deprecations

* Marked several properties and methods as deprecated, including `OriginalSecret`, `OriginalSecretExists`, and all reconstruction methods that use `FinitePoint` or string arrays, in favor of new APIs using `Share`. (`CHANGELOG.md`, `src/Cryptography/IMakeSharesUseCase.cs`, `src/Cryptography/IReconstructionUseCase.cs`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R24) [[2]](diffhunk://#diff-cb6999316f426a0a7b5ce559ced9bc0e05c2037dc945df949815dca98df1eb11R21-R36) [[3]](diffhunk://#diff-41a9106d15bf2ceba5fd00a89ad13f61b68050cff5dd960fa59329bcf18269b5R3-R24)

### Documentation and Example Updates

* Updated the `README.md` examples and usage to reflect the new `Share` struct and API changes, replacing usage of `FinitePoint` and deprecated properties/methods. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-R166) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L196-R196) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L210-R209) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L262-R264) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L317-R316) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L371-R362) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L413-R406) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L429-R420)

### Internal Improvements

* Refactored `FinitePoint<TNumber>` to a `record struct`, removed equality operators and some methods, and added deconstruction support and obsolescence attributes for smoother migration to the new `Share` struct. (`src/Cryptography/FinitePoint`1.cs`) [[1]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL49-L60) [[2]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL71-R63) [[3]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL96-R96) [[4]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL118-R134) [[5]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL198-R178) [[6]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aR207) [[7]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aR233)

These changes set the foundation for a more robust, maintainable, and user-friendly secret sharing library moving forward.