### PR TITLE
Release  v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.0] - 2025-12-25
 ### Added
 - Added `Share` struct to represent individual shares for future extensibility.
 - Added `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel, out Secret<TNumber> secret)` method to generate shares and output the random secret.
@@ -257,7 +257,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LICENSE.md`
 - Added `README.md`
 
-[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.13.0...develop
+[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.14.0...develop
+[0.14.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.10.2...v0.11.0

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ A C# implementation of Shamir's Secret Sharing.
   <tbody>
       <tr>
           <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml/badge.svg" alt="SecretSharingDotNet - NuGet Publishing"/></a></td>
-          <td rowspan=9><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.13.0"/></a></td>
-          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.13.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.13.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=9><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.14.0"/></a></td>
+          <td rowspan=9><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.14.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.14.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
@@ -94,10 +94,10 @@ A C# implementation of Shamir's Secret Sharing.
 
 1. Open a console and switch to the directory, containing your project file.
 
-2. Use the following command to install version 0.13.0 of the SecretSharingDotNet package:
+2. Use the following command to install version 0.14.0 of the SecretSharingDotNet package:
 
     ```dotnetcli
-    dotnet add package SecretSharingDotNet -v 0.13.0 -f <FRAMEWORK>
+    dotnet add package SecretSharingDotNet -v 0.14.0 -f <FRAMEWORK>
     ```
 
 3. After the completion of the command, look at the project file to make sure that the package is successfully installed.
@@ -106,7 +106,7 @@ A C# implementation of Shamir's Secret Sharing.
 
     ```xml
     <ItemGroup>
-      <PackageReference Include="SecretSharingDotNet" Version="0.13.0" />
+      <PackageReference Include="SecretSharingDotNet" Version="0.14.0" />
     </ItemGroup>
     ```
 ## Remove SecretSharingDotNet package 📤

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("1c21b99c-2de4-4ca5-b4ce-bc95cf89369e")]
 
-[assembly: AssemblyVersion("0.13.0")]
-[assembly: AssemblyFileVersion("0.13.0")]
+[assembly: AssemblyVersion("0.14.0")]
+[assembly: AssemblyFileVersion("0.14.0")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -11,14 +11,14 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <PackageId>SecretSharingDotNet</PackageId>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v0.13.0/CHANGELOG.md</PackageReleaseNotes>
+        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v0.14.0/CHANGELOG.md</PackageReleaseNotes>
         <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
         <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
         <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>0.13.0</Version>
+        <Version>0.14.0</Version>
         <Authors>Sebastian Walther</Authors>
         <Company>Private Person</Company>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This pull request prepares the project for the 0.14.0 release by updating all version references and related documentation. The main focus is to ensure consistency across metadata, changelog, and installation instructions to reflect the new version.

Version bump and release documentation:

* Updated all version references from `0.13.0` to `0.14.0` in `AssemblyInfo.cs`, `SecretSharingDotNet.csproj`, and `README.md` to prepare for the new release. [[1]](diffhunk://#diff-ff8fcd0928b1ba132674b5170262b0d8c22d6e0ad6f72bfde9366f2000c0ffc2L18-R19) [[2]](diffhunk://#diff-0ca99e18c59d3eef1c95b0938a1d210c7446318be08a04e01d78a1641fd16a69L14-R21) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R63) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R100) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R109)
* Updated the changelog to create a new section for version `0.14.0` with release date and updated the comparison links accordingly. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL7-R7) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL260-R261)