### PR TITLE
Remove obsolete `OriginalSecret` and `OriginalSecretExists` propertie…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Removed
+- Removed `OriginalSecret` property from `Shares` class.
+- Removed `OriginalSecretExists` property from `Shares` class.
+
 ## [0.14.0] - 2025-12-25
 ### Added
 - Added `Share` struct to represent individual shares for future extensibility.

--- a/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
@@ -124,7 +124,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
         var polynomial = this.CreatePolynomial(min);
         polynomial[0] = secret.ToCoefficient;
         var points = this.CreateFinitePoints(max, polynomial);
-        return new Shares<TNumber>(secret, points.ToShares());
+        return new Shares<TNumber>(points.ToShares());
     }
 
     /// <summary>
@@ -170,7 +170,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
         var polynomial = this.CreatePolynomial(min);
         polynomial[0] = secret.ToCoefficient;
         var points = this.CreateFinitePoints(max, polynomial);
-        return new Shares<TNumber>(secret, points.ToShares());
+        return new Shares<TNumber>(points.ToShares());
     }
 
     /// <summary>
@@ -232,7 +232,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
         polynomial[0] = secret.ToCoefficient;
         var points = this.CreateFinitePoints(max, polynomial);
 
-        return new Shares<TNumber>(secret, points.ToShares());
+        return new Shares<TNumber>(points.ToShares());
     }
 
     /// <summary>

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -62,35 +62,13 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection
     /// </summary>
     /// <param name="shares">A list of <see cref="Share{TNumber}"/> objects.</param>
     /// <exception cref="ArgumentNullException"><paramref name="shares"/> is <see langword="null"/>.</exception>
-    private Shares(IList<Share<TNumber>> shares)
+    internal Shares(IList<Share<TNumber>> shares)
     {
         _ = shares ?? throw new ArgumentNullException(nameof(shares));
         var sortedShares = shares.ToArray();
         Array.Sort(sortedShares);
         this.shareList = new Collection<Share<TNumber>>(sortedShares);
     }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Shares{TNumber}"/> class.
-    /// </summary>
-    /// <param name="secret">The original secret which was split into <paramref name="shares"/>.</param>
-    /// <param name="shares">A list of <see cref="Share{TNumber}"/> objects.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="secret"/> or <paramref name="shares"/> is <see langword="null"/>.</exception>
-    [Obsolete("This constructor is obsolete and will be removed in future versions.", false)]
-    internal Shares(Secret<TNumber> secret, IList<Share<TNumber>> shares)
-    {
-        this.OriginalSecret = secret;
-        _ = shares ?? throw new ArgumentNullException(nameof(shares));
-        var sortedShares = shares.ToArray();
-        Array.Sort(sortedShares);
-        this.shareList = new Collection<Share<TNumber>>(sortedShares);
-    }
-
-    /// <summary>
-    /// Gets the original secret
-    /// </summary>
-    [Obsolete("The property OriginalSecret is obsolete and will be removed in future versions.", false)]
-    public Secret<TNumber>? OriginalSecret { get; }
 
     /// <summary>
     /// Gets the <see cref="Share{TNumber}"/> associated with the specified index.
@@ -99,12 +77,6 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection
     /// <returns>Returns a share (shared secret) represented by a <see cref="Share{TNumber}"/>.</returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "i")]
     public Share<TNumber> this[int i] => this.shareList[i];
-
-    /// <summary>
-    /// Gets a value indicating whether the original secret is available.
-    /// </summary>
-    [Obsolete("The property OriginalSecretExists is obsolete and will be removed in future versions.", false)]
-    public bool OriginalSecretExists => this.OriginalSecret != null;
 
     /// <summary>
     /// Casts a <see cref="Shares{TNumber}"/> object to an array of <see cref="string"/>s.


### PR DESCRIPTION
This pull request removes the obsolete `OriginalSecret` and `OriginalSecretExists` properties from the `Shares` class, along with their associated constructor. It also updates the `SecretSplitter` code to use the simplified `Shares` constructor that does not require the original secret. These changes help clean up the API and remove deprecated functionality.

API cleanup and removal of obsolete properties:

* Removed the `OriginalSecret` property and its related obsolete constructor from the `Shares<TNumber>` class.
* Removed the `OriginalSecretExists` property from the `Shares<TNumber>` class.
* Updated the changelog to document the removal of `OriginalSecret` and `OriginalSecretExists` from the `Shares` class.

Refactoring and simplification:

* Updated all usages in `SecretSplitter<TNumber>` to construct `Shares<TNumber>` without passing the original secret, using only the list of shares. [[1]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L127-R127) [[2]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L173-R173) [[3]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L235-R235)
* Changed the visibility of the remaining `Shares<TNumber>` constructor from `private` to `internal` for improved accessibility within the assembly.