### PR TITLE
Remove obsolete methods for `MakeShares` and `Reconstruction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Removed `OriginalSecret` property from `Shares` class.
 - Removed `OriginalSecretExists` property from `Shares` class.
+- Removed `MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel)` method.
+- Removed `Secret<TNumber> Reconstruction(FinitePoint<TNumber>[] shares)` method.
+- Removed `Secret<TNumber> Reconstruction(Share<TNumber>[] shares)` method.
+- Removed `Secret<TNumber> Reconstruction(string[] shares)` method.
+- Removed `Secret<TNumber> Reconstruction(string shares)` method.
 
 ## [0.14.0] - 2025-12-25
 ### Added

--- a/README.md
+++ b/README.md
@@ -420,8 +420,14 @@ namespace Example5
       Console.WriteLine((BigInteger)recoveredSecret2);
 
       //// Output should be 52199147989510990914370102003412153
-      var recoveredSecret3 = combiner.Reconstruction(share1, share2, share3);
+      Share<BigInteger>[] shareArray = [share1, share2, share3];
+      var recoveredSecret3 = combiner.Reconstruction(shareArray);
       Console.WriteLine((BigInteger)recoveredSecret3);
+
+      //// Output should be 52199147989510990914370102003412153
+      Shares<BigInteger> shares3 = shareArray;
+      var recoveredSecret4 = combiner.Reconstruction(shares3);
+      Console.WriteLine((BigInteger)recoveredSecret4);
     }
   }
 }

--- a/src/Cryptography/IMakeSharesUseCase.cs
+++ b/src/Cryptography/IMakeSharesUseCase.cs
@@ -1,7 +1,5 @@
 namespace SecretSharingDotNet.Cryptography;
 
-using System;
-
 /// <summary>
 /// Interface for the Shamir's Secret Sharing algorithm implementation for creating shared secrets. 
 /// </summary>
@@ -9,33 +7,21 @@ using System;
 public interface IMakeSharesUseCase<TNumber>
 {
     /// <summary>
-    /// Generates a random shamir pool, returns the random secret and the share points.
+    /// Generates a random shamir pool and returns the share points.
+    /// The generated random secret is provided via the <paramref name="generatedSecret"/> out parameter.
     /// </summary>
     /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>
     /// <param name="securityLevel">Security level (in number of bits). The minimum is 13.</param>
+    /// <param name="generatedSecret">output parameter returning the generated secret as <see cref="Secret{TNumber}"/></param>
     /// <returns>A <see cref="Shares{TNumber}"/> object</returns>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
     /// </exception>
-    [Obsolete("Use MakeShares with out parameter secret instead", false)]
-    Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel);
+    Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel, out Secret<TNumber> generatedSecret);
 
     /// <summary>
-    /// Generates a random shamir pool, returns the random secret and the share points.
-    /// </summary>
-    /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
-    /// <param name="numberOfShares">Maximum number of shared secrets</param>
-    /// <param name="securityLevel">Security level (in number of bits). The minimum is 13.</param>
-    /// <param name="secret">output parameter returning the generated secret as <see cref="Secret{TNumber}"/></param>
-    /// <returns>A <see cref="Shares{TNumber}"/> object</returns>
-    /// <exception cref="T:System.ArgumentOutOfRangeException">
-    /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
-    /// </exception>
-    Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel, out Secret<TNumber> secret);
-
-    /// <summary>
-    /// Generates a random shamir pool, returns the specified <paramref name="secret"/> and the share points.
+    /// Generates a shamir pool using the provided <paramref name="secret"/> and returns the share points.
     /// </summary>
     /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>
@@ -48,7 +34,7 @@ public interface IMakeSharesUseCase<TNumber>
     Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret, int securityLevel);
 
     /// <summary>
-    /// Generates a random shamir pool, returns the specified <paramref name="secret"/> and the share points.
+    /// Generates a shamir pool using the provided <paramref name="secret"/> and returns the share points.
     /// </summary>
     /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>

--- a/src/Cryptography/IReconstructionUseCase.cs
+++ b/src/Cryptography/IReconstructionUseCase.cs
@@ -1,7 +1,5 @@
 namespace SecretSharingDotNet.Cryptography;
 
-using System;
-
 /// <summary>
 /// Interface for the Shamir's Secret Sharing algorithm implementation for reconstructing the secret.
 /// </summary>
@@ -11,43 +9,7 @@ public interface IReconstructionUseCase<TNumber>
     /// <summary>
     /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
     /// </summary>
-    /// <param name="shares">Shares represented by <see cref="string"/> and separated by newline.</param>
-    /// <returns>Re-constructed secret</returns>
-    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
-    Secret<TNumber> Reconstruction(string shares);
-
-    /// <summary>
-    /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
-    /// </summary>
-    /// <param name="shares">Shares represented by <see cref="string"/> array.</param>
-    /// <returns>Re-constructed secret</returns>
-    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
-    Secret<TNumber> Reconstruction(string[] shares);
-
-    /// <summary>
-    /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
-    /// </summary>
     /// <param name="shares">For details <see cref="Shares{TNumber}"/></param>
     /// <returns>Re-constructed secret</returns>
     Secret<TNumber> Reconstruction(Shares<TNumber> shares);
-
-    /// <summary>
-    /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
-    /// </summary>
-    /// <param name="shares">Two or more shares</param>
-    /// <returns>Re-constructed secret</returns>
-    /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/>.</exception>
-    /// <exception cref="T:System.ArgumentOutOfRangeException">The length of <paramref name="shares"/> is lower than 2.</exception>
-    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
-    Secret<TNumber> Reconstruction(Share<TNumber>[] shares);
-
-    /// <summary>
-    /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
-    /// </summary>
-    /// <param name="shares">Two or more shares represented by a set of <see cref="FinitePoint{TNumber}"/></param>
-    /// <returns>Re-constructed secret</returns>
-    /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/>.</exception>
-    /// <exception cref="T:System.ArgumentOutOfRangeException">The length of <paramref name="shares"/> is lower than 2.</exception>
-    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
-    Secret<TNumber> Reconstruction(FinitePoint<TNumber>[] shares);
 }

--- a/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
@@ -158,45 +158,6 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
     /// <summary>
     /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
     /// </summary>
-    /// <param name="shares">Shares represented by <see cref="string"/> and separated by newline.</param>
-    /// <returns>Re-constructed secret</returns>
-    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
-    public Secret<TNumber> Reconstruction(string shares)
-    {
-        if (string.IsNullOrWhiteSpace(shares))
-        {
-            throw new ArgumentNullException(nameof(shares));
-        }
-
-        Shares<TNumber> castShares = shares;
-        return this.Reconstruction(castShares);
-    }
-
-    /// <summary>
-    /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
-    /// </summary>
-    /// <param name="shares">Shares represented by <see cref="string"/> array.</param>
-    /// <returns>Re-constructed secret</returns>
-    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
-    public Secret<TNumber> Reconstruction(string[] shares)
-    {
-        if (shares is null)
-        {
-            throw new ArgumentNullException(nameof(shares));
-        }
-
-        if (shares.Length < 2)
-        {
-            throw new ArgumentOutOfRangeException(nameof(shares), ErrorMessages.MinNumberOfSharesLowerThanTwo);
-        }
-
-        Shares<TNumber> castShares = shares;
-        return this.Reconstruction(castShares);
-    }
-
-    /// <summary>
-    /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
-    /// </summary>
     /// <param name="shares">For details <see cref="Shares{TNumber}"/></param>
     /// <returns>Re-constructed secret</returns>
     public Secret<TNumber> Reconstruction(Shares<TNumber> shares)
@@ -220,50 +181,6 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
 
         this.securityLevelManager.AdjustSecurityLevel(maximumY);
         return this.LagrangeInterpolate(finitePoints, this.securityLevelManager.MersennePrime);
-    }
-
-    /// <summary>
-    /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
-    /// </summary>
-    /// <param name="shares">Two or more shares represented by a set of <see cref="FinitePoint{TNumber}"/></param>
-    /// <returns>Re-constructed secret</returns>
-    /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/>.</exception>
-    /// <exception cref="T:System.ArgumentOutOfRangeException">The length of <paramref name="shares"/> is lower than 2.</exception>
-    [Obsolete("Use Reconstruction(Shares<TNumber> shares) instead", false)]
-    public Secret<TNumber> Reconstruction(Share<TNumber>[] shares)
-    {
-        if (shares is null)
-        {
-            throw new ArgumentNullException(nameof(shares));
-        }
-
-        if (shares.Length < 2)
-        {
-            throw new ArgumentOutOfRangeException(nameof(shares), ErrorMessages.MinNumberOfSharesLowerThanTwo);
-        }
-
-        var finitePoints = shares.ToFinitePoints();
-        var maximumY = finitePoints.Select(point => point.Y).Max();
-        if (maximumY == null)
-        {
-            throw new ArgumentException(ErrorMessages.NoMaximumY, nameof(shares));
-        }
-
-        this.securityLevelManager.AdjustSecurityLevel(maximumY);
-        return this.LagrangeInterpolate(finitePoints, this.securityLevelManager.MersennePrime);
-    }
-
-    /// <summary>
-    /// Recovers the secret from the given <paramref name="shares"/> (points with x and y on the polynomial)
-    /// </summary>
-    /// <param name="shares">Two or more shares represented by a set of <see cref="FinitePoint{TNumber}"/></param>
-    /// <returns>Re-constructed secret</returns>
-    /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/>.</exception>
-    /// <exception cref="T:System.ArgumentOutOfRangeException">The length of <paramref name="shares"/> is lower than 2.</exception>
-    [Obsolete("Use Reconstruction(Share<TNumber>[] shares) instead", false)]
-    public Secret<TNumber> Reconstruction(FinitePoint<TNumber>[] shares)
-    {
-        return this.Reconstruction(shares.ToShares());
     }
 
     /// <summary>

--- a/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
@@ -82,17 +82,18 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     }
 
     /// <summary>
-    /// Generates a random shamir pool, returns the random secret and the share points.
+    /// Generates a random shamir pool and returns the share points.
+    /// The generated random secret is provided via the <paramref name="generatedSecret"/> out parameter.
     /// </summary>
     /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>
     /// <param name="securityLevel">Security level (in number of bits). The minimum is 13.</param>
+    /// <param name="generatedSecret">output parameter returning the generated secret as <see cref="Secret{TNumber}"/></param>
     /// <returns>A <see cref="Shares{TNumber}"/> collection containing the generated shares.</returns>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
     /// </exception>
-    [Obsolete("Use MakeShares with out parameter secret instead", false)]
-    public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel)
+    public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel, out Secret<TNumber> generatedSecret)
     {
         try
         {
@@ -120,61 +121,15 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
             throw new InvalidOperationException("Security Level is not initialized!");
         }
 
-        var secret = Secret<TNumber>.CreateRandom(this.securityLevelManager.MersennePrime);
+        generatedSecret = Secret<TNumber>.CreateRandom(this.securityLevelManager.MersennePrime);
         var polynomial = this.CreatePolynomial(min);
-        polynomial[0] = secret.ToCoefficient;
+        polynomial[0] = generatedSecret.ToCoefficient;
         var points = this.CreateFinitePoints(max, polynomial);
         return new Shares<TNumber>(points.ToShares());
     }
 
     /// <summary>
-    /// Generates a random shamir pool, returns the random secret and the share points.
-    /// </summary>
-    /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
-    /// <param name="numberOfShares">Maximum number of shared secrets</param>
-    /// <param name="securityLevel">Security level (in number of bits). The minimum is 13.</param>
-    /// <param name="secret">output parameter returning the generated secret as <see cref="Secret{TNumber}"/></param>
-    /// <returns>A <see cref="Shares{TNumber}"/> collection containing the generated shares.</returns>
-    /// <exception cref="T:System.ArgumentOutOfRangeException">
-    /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
-    /// </exception>
-    public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel, out Secret<TNumber> secret)
-    {
-        try
-        {
-            this.SecurityLevel = securityLevel;
-        }
-        catch (ArgumentOutOfRangeException e)
-        {
-            throw new ArgumentOutOfRangeException(nameof(securityLevel), securityLevel, e.Message);
-        }
-
-        int min = ((Calculator<TNumber>)numberOfMinimumShares).ToInt32();
-        int max = ((Calculator<TNumber>)numberOfShares).ToInt32();
-        if (min < 2)
-        {
-            throw new ArgumentOutOfRangeException(nameof(numberOfMinimumShares), numberOfMinimumShares, ErrorMessages.MinNumberOfSharesLowerThanTwo);
-        }
-
-        if (min > max)
-        {
-            throw new ArgumentOutOfRangeException(nameof(numberOfShares), numberOfShares, ErrorMessages.MaxSharesLowerThanMinShares);
-        }
-
-        if (this.securityLevelManager.MersennePrime == null)
-        {
-            throw new InvalidOperationException("Security Level is not initialized!");
-        }
-
-        secret = Secret<TNumber>.CreateRandom(this.securityLevelManager.MersennePrime);
-        var polynomial = this.CreatePolynomial(min);
-        polynomial[0] = secret.ToCoefficient;
-        var points = this.CreateFinitePoints(max, polynomial);
-        return new Shares<TNumber>(points.ToShares());
-    }
-
-    /// <summary>
-    /// Generates a random shamir pool, returns the specified <paramref name="secret"/> and the share points.
+    /// Generates a shamir pool using the provided <paramref name="secret"/> and returns the share points.
     /// </summary>
     /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>
@@ -200,7 +155,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     }
 
     /// <summary>
-    /// Generates a random shamir pool, returns the specified <paramref name="secret"/> and the share points.
+    /// Generates a shamir pool using the provided <paramref name="secret"/> and returns the share points.
     /// </summary>
     /// <param name="numberOfMinimumShares">Minimum number of shared secrets for reconstruction</param>
     /// <param name="numberOfShares">Maximum number of shared secrets</param>

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -65,7 +65,7 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection
     internal Shares(IList<Share<TNumber>> shares)
     {
         _ = shares ?? throw new ArgumentNullException(nameof(shares));
-        var sortedShares = shares.ToArray();
+        var sortedShares = shares as Share<TNumber>[] ?? shares.ToArray();
         Array.Sort(sortedShares);
         this.shareList = new Collection<Share<TNumber>>(sortedShares);
     }
@@ -96,13 +96,13 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection
     /// <param name="s">A <see cref="string"/> object representing two or more finite points separated by newline.</param>
     public static implicit operator Shares<TNumber>(string s)
     {
-        var points = s
+        var shares = s
             .Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries)
             .Select(line => line.Trim())
             .Where(line => !string.IsNullOrEmpty(line))
             .Select(line => new Share<TNumber>(line))
             .ToArray();
-        return new Shares<TNumber>(points);
+        return new Shares<TNumber>(shares);
     }
 
     /// <summary>
@@ -111,12 +111,12 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection
     /// <param name="s">An array of <see cref="string"/> representing two or more finite points.</param>
     public static implicit operator Shares<TNumber>(string[] s)
     {
-        var points = s
+        var shares = s
             .Select(line => line.Trim())
             .Where(line => !string.IsNullOrEmpty(line))
             .Select(line => new Share<TNumber>(line))
             .ToArray();
-        return new Shares<TNumber>(points);
+        return new Shares<TNumber>(shares);
     }
 
     /// <summary>

--- a/src/Extension/ShareExtensions.cs
+++ b/src/Extension/ShareExtensions.cs
@@ -39,7 +39,7 @@ using System.Linq;
 /// <summary>
 /// Provides extension methods for working with shares.
 /// </summary>
-public static class ShareExtensions
+internal static class ShareExtensions
 {
     /// <summary>
     /// Converts a collection of shares to an array of <see cref="FinitePoint{TNumber}"/>.


### PR DESCRIPTION
This pull request removes several obsolete methods and properties related to Shamir's Secret Sharing reconstruction and share creation, and updates the interfaces and implementations to simplify and clarify the API. The changes also update documentation and example usage to match the new method signatures, and improve internal code consistency.

The most important changes are:

### API Cleanup and Simplification

* Removed obsolete `MakeShares` and `Reconstruction` overloads from `IMakeSharesUseCase<TNumber>`, `IReconstructionUseCase<TNumber>`, and their implementations, leaving only the recommended methods that use strong types like `Shares<TNumber>` and `Secret<TNumber>`. (`src/Cryptography/IMakeSharesUseCase.cs`, `src/Cryptography/IReconstructionUseCase.cs`, `src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs`, `src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs`, `CHANGELOG.md`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R14) [[2]](diffhunk://#diff-cb6999316f426a0a7b5ce559ced9bc0e05c2037dc945df949815dca98df1eb11R15-R23) [[3]](diffhunk://#diff-41a9106d15bf2ceba5fd00a89ad13f61b68050cff5dd960fa59329bcf18269b5L3-L52) [[4]](diffhunk://#diff-5894463ebc14a22c5de96530cb77ca1609d994f91605f623fa6cd78f66a99890L158-L196) [[5]](diffhunk://#diff-5894463ebc14a22c5de96530cb77ca1609d994f91605f623fa6cd78f66a99890L225-L268) [[6]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42R90-R95) [[7]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L123-R131)

* Updated the signature of `MakeShares` to require an `out` parameter for the generated secret, improving clarity and safety. (`src/Cryptography/IMakeSharesUseCase.cs`, `src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs`) [[1]](diffhunk://#diff-cb6999316f426a0a7b5ce559ced9bc0e05c2037dc945df949815dca98df1eb11R15-R23) [[2]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42R90-R95) [[3]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L123-R131)

### Documentation and Example Updates

* Updated XML documentation comments and the `README.md` example to match the new method signatures, demonstrating correct usage with the updated API. (`src/Cryptography/IMakeSharesUseCase.cs`, `src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs`, `README.md`) [[1]](diffhunk://#diff-cb6999316f426a0a7b5ce559ced9bc0e05c2037dc945df949815dca98df1eb11R15-R23) [[2]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42R90-R95) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L423-R430)

### Internal Improvements

* Improved the construction of `Shares<TNumber>` from arrays and strings for better clarity and correctness. (`src/Cryptography/Shares.cs`) [[1]](diffhunk://#diff-19f8dd0462bf11a696988ddf5bfebf6fe429743b8eeba967ca320cef7e9858e0L68-R68) [[2]](diffhunk://#diff-19f8dd0462bf11a696988ddf5bfebf6fe429743b8eeba967ca320cef7e9858e0L99-R105) [[3]](diffhunk://#diff-19f8dd0462bf11a696988ddf5bfebf6fe429743b8eeba967ca320cef7e9858e0L114-R119)
* Changed the visibility of `ShareExtensions` from `public` to `internal` to limit its scope to within the assembly. (`src/Extension/ShareExtensions.cs`)