### PR TITLE
Set FinitePoint struct to internal

### DIFF
--- a/.github/secrets/decrypt_publisher_snk.sh
+++ b/.github/secrets/decrypt_publisher_snk.sh
@@ -4,3 +4,4 @@ rm -f ${CDIR}/../../src/SecretSharingDotNet.snk
 # Decrypt the file
 # --batch to prevent interactive command --yes to assume "yes" for questions
 gpg --quiet --batch --yes --decrypt --passphrase="$PUBLISHER_SNK" --output ${CDIR}/../../src/SecretSharingDotNet.snk ${CDIR}/SecretSharingDotNetPublisher.snk.gpg
+sed -i -r "s/(InternalsVisibleTo.*PublicKey=)([0-9a-f]+)(.*)/\1$PUBLISHER_PUB_KEY\3/g" ${CDIR}/../../src/Properties/AssemblyInfo.cs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Set `FinitePoint` struct internal instead public to reduce the public API surface.
+
 ### Removed
 - Removed `OriginalSecret` property from `Shares` class.
 - Removed `OriginalSecretExists` property from `Shares` class.

--- a/src/Cryptography/FinitePoint`1.cs
+++ b/src/Cryptography/FinitePoint`1.cs
@@ -34,20 +34,13 @@ namespace SecretSharingDotNet.Cryptography;
 using Math;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-#if !NET8_0_OR_GREATER
-using System.Text;
-#else
-using System.Runtime.CompilerServices;
-#endif
 
 /// <summary>
 /// Represents the support point of the polynomial
 /// </summary>
 /// <typeparam name="TNumber">Numeric data type (An integer type)</typeparam>
-[Obsolete("Use Share<TNumber> struct instead. This struct will be marked as internal in future releases.", false)]
-public readonly record struct FinitePoint<TNumber> : IComparable<FinitePoint<TNumber>>
+internal readonly record struct FinitePoint<TNumber> : IComparable<FinitePoint<TNumber>>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="FinitePoint{TNumber}"/> struct.
@@ -61,40 +54,6 @@ public readonly record struct FinitePoint<TNumber> : IComparable<FinitePoint<TNu
     {
         this.X = x ?? throw new ArgumentNullException(nameof(x));
         this.Y = Evaluate(polynomial ?? throw new ArgumentNullException(nameof(polynomial)), this.X, prime ?? throw new ArgumentNullException(nameof(prime)));
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="FinitePoint{TNumber}"/> struct.
-    /// </summary>
-    /// <param name="serialized">string representation of the <see cref="FinitePoint{TNumber}"/> struct</param>
-    /// <exception cref="T:System.ArgumentNullException"><paramref name="serialized"/> is <see langword="null"/></exception>
-#if NET8_0_OR_GREATER
-    public FinitePoint(ReadOnlySpan<char> serialized)
-#else
-    public FinitePoint(string serialized)
-#endif
-    {
-#if NET8_0_OR_GREATER
-        if (serialized.IsEmpty)
-#else
-        if (string.IsNullOrWhiteSpace(serialized))
-#endif
-        {
-            throw new ArgumentNullException(nameof(serialized));
-        }
-
-#if NET8_0_OR_GREATER
-        var xReadOnlySpan = serialized[..serialized.IndexOf(Share<TNumber>.CoordinateSeparator)];
-        var yReadOnlySpan = serialized[(serialized.IndexOf(Share<TNumber>.CoordinateSeparator) + 1)..];
-        var numberType = typeof(TNumber);
-        this.X = Calculator.Create(ToByteArray(xReadOnlySpan), numberType) as Calculator<TNumber>;
-        this.Y = Calculator.Create(ToByteArray(yReadOnlySpan), numberType) as Calculator<TNumber>;
-#else
-        string[] s = serialized.Split(Share<TNumber>.CoordinateSeparatorArray);
-        var numberType = typeof(TNumber);
-        this.X = Calculator.Create(ToByteArray(s[0]), numberType) as Calculator<TNumber>;
-        this.Y = Calculator.Create(ToByteArray(s[1]), numberType) as Calculator<TNumber>;
-#endif
     }
 
     /// <summary>
@@ -175,7 +134,14 @@ public readonly record struct FinitePoint<TNumber> : IComparable<FinitePoint<TNu
     /// Returns the string representation of the <see cref="FinitePoint{TNumber}"/> structure.
     /// </summary>
     /// <returns>The string representation of the <see cref="FinitePoint{TNumber}"/> structure.</returns>
-    public override string ToString() => string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", ToHexString(this.X.ByteRepresentation), Share<TNumber>.CoordinateSeparator.ToString(), ToHexString(this.Y.ByteRepresentation));
+    public override string ToString()
+    {
+#if DEBUG
+        return $"({this.X}, {this.Y})";
+#else
+        return "*** Secured Value ***";
+#endif
+    }
 
     /// <summary>
     /// Evaluates polynomial (coefficient tuple) at x, used to generate a shamir pool.
@@ -195,82 +161,4 @@ public readonly record struct FinitePoint<TNumber> : IComparable<FinitePoint<TNu
 
         return result;
     }
-
-    /// <summary>
-    /// Converts a byte collection to hexadecimal string.
-    /// </summary>
-    /// <param name="bytes"></param>
-    /// <returns>human-readable / printable string</returns>
-    /// <remarks>
-    /// Based on discussion on <see href="https://stackoverflow.com/questions/623104/byte-to-hex-string/5919521#5919521">stackoverflow</see>
-    /// </remarks>
-    [Obsolete("Will be removed in future releases.", false)]
-#if NET8_0_OR_GREATER
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
-    private static string ToHexString(IEnumerable<byte> bytes)
-    {
-#if NET8_0_OR_GREATER
-        return Convert.ToHexString(bytes as byte[] ?? bytes.ToArray());
-#else
-        byte[] byteArray = bytes as byte[] ?? bytes.ToArray();
-        var hexRepresentation = new StringBuilder(byteArray.Length * 2);
-        foreach (byte b in byteArray)
-        {
-            const string hexAlphabet = "0123456789ABCDEF";
-            hexRepresentation.Append(hexAlphabet[b >> 4]).Append(hexAlphabet[b & 0xF]);
-        }
-
-        return hexRepresentation.ToString();
-#endif
-    }
-
-    /// <summary>
-    /// Converts a hexadecimal string to a byte array.
-    /// </summary>
-    /// <param name="hexString">hexadecimal string</param>
-    /// <returns>Returns a byte array</returns>
-    [Obsolete("Will be removed in future releases.", false)]
-#if NET8_0_OR_GREATER
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static byte[] ToByteArray(ReadOnlySpan<char> hexString) => Convert.FromHexString(hexString);
-#else
-    private static byte[] ToByteArray(string hexString)
-        {
-            byte[] bytes = new byte[hexString.Length / 2];
-            var hexValues = Array.AsReadOnly([
-                0x00,
-                0x01,
-                0x02,
-                0x03,
-                0x04,
-                0x05,
-                0x06,
-                0x07,
-                0x08,
-                0x09,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x00,
-                0x0A,
-                0x0B,
-                0x0C,
-                0x0D,
-                0x0E,
-                0x0F
-            ]);
-
-            for (int i = 0, j = 0; j < hexString.Length; j += 2, i += 1)
-            {
-                const char zeroDigit = '0';
-                bytes[i] = (byte)(hexValues[char.ToUpper(hexString[j + 0], CultureInfo.InvariantCulture) - zeroDigit] << 4 | hexValues[char.ToUpper(hexString[j + 1], CultureInfo.InvariantCulture) - zeroDigit]);
-            }
-
-            return bytes;
-        }
-#endif
 }

--- a/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
@@ -197,7 +197,7 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
     /// Thrown when the <paramref name="denominator"/> is zero (its modular inverse does not exist) or
     /// when the denominator is not invertible modulo the prime (gcd does not equal 1).
     /// </exception>
-    private Calculator<TNumber> DivMod(
+    internal Calculator<TNumber> DivMod(
         Calculator<TNumber> numerator,
         Calculator<TNumber> denominator,
         Calculator<TNumber> prime)

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Resources;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Shamir's Secret Sharing .Net")]
@@ -20,3 +21,4 @@ using System.Runtime.InteropServices;
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]
+[assembly: InternalsVisibleTo("SecretSharingDotNetTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100257917fef6a3508bdfc3db4dd65b0b485261c2f5bff7380b7737b0d59f741d41b6086743a7957cab387fb7da8a17491dea1239b496cef97ef61cd76bc3b5f0f983d5e693083c8a0c283bb55edd6fe389abda1565c534a3537e9e087ddef8b1525520ebd5ff6f36e74baaa97522816f3a7998bbdd9392f99c0777c421634abaaa")]

--- a/tests/Cryptography/FinitePointTest.cs
+++ b/tests/Cryptography/FinitePointTest.cs
@@ -34,42 +34,79 @@
 namespace SecretSharingDotNetTest.Cryptography;
 
 using SecretSharingDotNet.Cryptography;
+using System;
+using System.Globalization;
 using System.Numerics;
 using Xunit;
 
 public class FinitePointTest
 {
-    private const string FinitePointTextRepresentation1 = "01-2929AA3E809003D578AA69B1C3E6F62C517437FEFBAD5BFBB240";
-    private const string FinitePointTextRepresentation2 = "02-665C74ED38FDFF095B2FC9319A272A75";
+    private static readonly FinitePoint<BigInteger> FinitePoint1UnderTest = new(new BigInteger(1),
+        BigInteger.Parse("2929AA3E809003D578AA69B1C3E6F62C517437FEFBAD5BFBB240", NumberStyles.HexNumber));
 
-    /// <summary>
-    /// Check <see cref="FinitePoint{TNumber}"/> to <see cref="string"/> conversion and vice vera.
-    /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-    [Theory]
-    [InlineData(FinitePointTextRepresentation1, FinitePointTextRepresentation1)]
-    [InlineData(FinitePointTextRepresentation2, FinitePointTextRepresentation2)]
-    public void ToString_FromValidFinitePoint_ReturnsCoordinatesSeparatedWithMinus(string input, string expected)
+    private static readonly FinitePoint<BigInteger> FinitePoint2UnderTest = new(new BigInteger(2),
+        BigInteger.Parse("665C74ED38FDFF095B2FC9319A272A75", NumberStyles.HexNumber));
+
+
+    [Fact]
+    public void Constructor_ValidParameters_PropertiesSetCorrectly()
     {
         // Arrange
-        var finitePointUnderTest = new FinitePoint<BigInteger>(input);
+        var x = new BigInteger(5);
+        var y = BigInteger.Parse("1234567890ABCDEF", NumberStyles.HexNumber);
 
         // Act
-        string actual = finitePointUnderTest.ToString();
+        var finitePoint = new FinitePoint<BigInteger>(x, y);
 
         // Assert
-        Assert.Equal(expected, actual);
+        Assert.Equal(x, finitePoint.X.Value);
+        Assert.Equal(y, finitePoint.Y.Value);
+    }
+
+    [Fact]
+    public void Constructor_NullX_ThrowsArgumentNullException()
+    {
+        // Arrange
+        BigInteger? x = null;
+        var y = BigInteger.Parse("1234567890ABCDEF", NumberStyles.HexNumber);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new FinitePoint<BigInteger>(x!, y));
+    }
+
+    [Fact]
+    public void Constructor_NullY_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var x = new BigInteger(5);
+        BigInteger? y = null;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new FinitePoint<BigInteger>(x, y!));
+    }
+    
+    [Fact]
+    public void ToString_ValidFinitePoint_ReturnsCorrectStringRepresentation()
+    {
+        // Arrange
+#if DEBUG
+        const string expectedString = "(BigIntCalculator(1), BigIntCalculator(66145995360161795056928953403445996185990931982120007327527488))";
+#else
+        const string expectedString = "*** Secured Value ***";
+#endif
+
+        // Act
+        string actualString = FinitePoint1UnderTest.ToString();
+
+        // Assert
+        Assert.Equal(expectedString, actualString);
     }
 
     [Fact]
     public void CompareTo_BigFinitePointToSmallFinitePoint_ReturnsOne()
     {
-        // Arrange
-        var finitePointUnder1Test = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
-        var finitePointUnder2Test = new FinitePoint<BigInteger>(FinitePointTextRepresentation2);
-
-        // Act
-        int actual = finitePointUnder1Test.CompareTo(finitePointUnder2Test);
+        // Arrange & Act
+        int actual = FinitePoint1UnderTest.CompareTo(FinitePoint2UnderTest);
 
         // Assert
         Assert.Equal(1, actual);
@@ -78,12 +115,8 @@ public class FinitePointTest
     [Fact]
     public void CompareTo_SmallFinitePointToBigFinitePoint_ReturnsMinusOne()
     {
-        // Arrange
-        var finitePointUnder1Test = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
-        var finitePointUnder2Test = new FinitePoint<BigInteger>(FinitePointTextRepresentation2);
-
-        // Act
-        int actual = finitePointUnder2Test.CompareTo(finitePointUnder1Test);
+        // Arrange & Act
+        int actual = FinitePoint2UnderTest.CompareTo(FinitePoint1UnderTest);
 
         // Assert
         Assert.Equal(-1, actual);
@@ -92,11 +125,8 @@ public class FinitePointTest
     [Fact]
     public void CompareTo_FinitePointToSameFinitePoint_ReturnsZero()
     {
-        // Arrange
-        var finitePointUnderTest = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
-
-        // Act
-        int actual = finitePointUnderTest.CompareTo(finitePointUnderTest);
+        // Arrange & Act
+        int actual = FinitePoint1UnderTest.CompareTo(FinitePoint1UnderTest);
 
         // Assert
         Assert.Equal(0, actual);
@@ -105,12 +135,8 @@ public class FinitePointTest
     [Fact]
     public void Equals_FinitePointToSameFinitePoint_ReturnsTrue()
     {
-        // Arrange
-        var finitePointUnderTest1 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
-        var finitePointUnderTest2 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
-
-        // Act
-        bool actual = finitePointUnderTest1.Equals(finitePointUnderTest2);
+        // Arrange & Act
+        bool actual = FinitePoint1UnderTest.Equals(FinitePoint1UnderTest);
 
         // Assert
         Assert.True(actual);
@@ -119,12 +145,8 @@ public class FinitePointTest
     [Fact]
     public void Equals_FinitePointToDifferentFinitePoint_ReturnsFalse()
     {
-        // Arrange
-        var finitePointUnderTest1 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
-        var finitePointUnderTest2 = new FinitePoint<BigInteger>(FinitePointTextRepresentation2);
-
-        // Act
-        bool actual = finitePointUnderTest1.Equals(finitePointUnderTest2);
+        // Arrange & Act
+        bool actual = FinitePoint1UnderTest.Equals(FinitePoint2UnderTest);
 
         // Assert
         Assert.False(actual);
@@ -133,11 +155,8 @@ public class FinitePointTest
     [Fact]
     public void Equals_FinitePointToNull_ReturnsFalse()
     {
-        // Arrange
-        var finitePointUnderTest1 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
-
-        // Act
-        bool actual = finitePointUnderTest1.Equals(null);
+        // Arrange & Act
+        bool actual = FinitePoint1UnderTest.Equals(null);
 
         // Assert
         Assert.False(actual);
@@ -147,11 +166,10 @@ public class FinitePointTest
     public void Equals_FinitePointToSameFinitePointAsObject_ReturnsTrue()
     {
         // Arrange
-        var finitePointUnderTest1 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
-        object finitePointUnderTest2 = finitePointUnderTest1;
+        object finitePointAsObject = FinitePoint1UnderTest;
 
         // Act
-        bool actual = finitePointUnderTest1.Equals(finitePointUnderTest2);
+        bool actual = FinitePoint1UnderTest.Equals(finitePointAsObject);
 
         // Assert
         Assert.True(actual);
@@ -161,11 +179,10 @@ public class FinitePointTest
     public void Equals_FinitePointToDifferentFinitePointAsObject_ReturnsFalse()
     {
         // Arrange
-        var finitePointUnderTest1 = new FinitePoint<BigInteger>(FinitePointTextRepresentation1);
-        object finitePointUnderTest2 = new FinitePoint<BigInteger>(FinitePointTextRepresentation2);
+        object finitePointAsObject = FinitePoint2UnderTest;
 
         // Act
-        bool actual = finitePointUnderTest1.Equals(finitePointUnderTest2);
+        bool actual = FinitePoint1UnderTest.Equals(finitePointAsObject);
 
         // Assert
         Assert.False(actual);

--- a/tests/Cryptography/ShamirsSecretSharing/ShamirsSecretSharingTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/ShamirsSecretSharingTest.cs
@@ -47,24 +47,15 @@ public class SecretSplitterTest
 {
     /// <summary>
     /// Checks the following condition: denominator * DivMod(numerator, denominator, prime) % prime == numerator
-    /// ToDo: Find another technical solution for this test. Code redundancy.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
     [Fact]
     public void TestDivMod()
     {
-        Calculator<BigInteger> DivMod(Calculator<BigInteger> denominator, Calculator<BigInteger> numerator,
-            Calculator<BigInteger> prime)
-        {
-            var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
-            var result = gcd.Compute(denominator, prime);
-            return numerator * result.BezoutCoefficients[0] * result.GreatestCommonDivisor;
-        }
-
+        var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
         Calculator<BigInteger> d = (BigInteger)3000;
         Calculator<BigInteger> n = (BigInteger)3000;
         Calculator<BigInteger> p = Calculator<BigInteger>.Two.Pow(127) - Calculator<BigInteger>.One;
-        Assert.Equal(n, d * DivMod(d, n, p) % p);
+        Assert.Equal(n, d * secretReconstructor.DivMod(d, n, p) % p);
     }
 
     /// <summary>

--- a/tests/Cryptography/ShareTest.cs
+++ b/tests/Cryptography/ShareTest.cs
@@ -9,6 +9,9 @@ using System.Numerics;
 
 public class ShareTest
 {
+    private const string Share1TextRepresentation = "01-2929AA3E809003D578AA69B1C3E6F62C517437FEFBAD5BFBB240";
+    private const string Share2TextRepresentation = "02-665C74ED38FDFF095B2FC9319A272A75";
+
     [Theory]
     [InlineData(5, 10)]
     [InlineData(1, 0)]
@@ -104,7 +107,8 @@ public class ShareTest
     [InlineData(11, -86, "0b-aa")]
     [InlineData(1, 1, "01-01")]
     [InlineData(1000, 4096, "e803-0010")]
-    public void ToString_WithFormatSpecifier_ShouldReturnFormattedString(BigInteger index, BigInteger value, string expected)
+    public void ToString_WithFormatSpecifier_ShouldReturnFormattedString(BigInteger index, BigInteger value,
+        string expected)
     {
         // Arrange
         var share = new Share<BigInteger>(index, value);
@@ -125,6 +129,21 @@ public class ShareTest
         // Assert
         Assert.Equal(new BigIntCalculator(11), share.Index);
         Assert.Equal(new BigIntCalculator(-86), share.Value);
+    }
+
+    [Theory]
+    [InlineData(Share1TextRepresentation, Share1TextRepresentation)]
+    [InlineData(Share2TextRepresentation, Share2TextRepresentation)]
+    public void ToString_FromValidShare_ReturnsCoordinatesSeparatedWithMinus(string input, string expected)
+    {
+        // Arrange
+        var shareUnderTest = new Share<BigInteger>(input);
+
+        // Act
+        string actual = shareUnderTest.ToString();
+
+        // Assert
+        Assert.Equal(expected, actual);
     }
 
     [Fact]


### PR DESCRIPTION
This pull request makes several important changes to the `FinitePoint` struct and related cryptography code, focusing on reducing the public API surface, improving encapsulation, and updating tests and internals for better maintainability and security. The most significant changes include making `FinitePoint` internal, removing obsolete serialization logic, updating the `ToString` method for security, and refactoring tests to match the new structure.

**API Surface and Encapsulation:**
- Changed the `FinitePoint<TNumber>` struct from `public` to `internal` to reduce the public API surface. [[1]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL37-R43)], [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R10)])
- Added `[assembly: InternalsVisibleTo("SecretSharingDotNetTest, PublicKey=...")]` to `AssemblyInfo.cs` to allow internal members to be accessed by the test project. ([[src/Properties/AssemblyInfo.csR24](diffhunk://#diff-ff8fcd0928b1ba132674b5170262b0d8c22d6e0ad6f72bfde9366f2000c0ffc2R24)])

**Security and Serialization:**
- Updated the `ToString` method of `FinitePoint` to return a secured value in release mode, only showing full details in debug builds. ([[src/Cryptography/FinitePoint`1.csL178-R144](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL178-R144)])
- Removed the obsolete serialization/deserialization constructors and helper methods from `FinitePoint`, eliminating string-based construction and hex conversion logic. [[1]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL66-L99)], [[2]](diffhunk://#diff-ea2361e31c73a1af54685e125bebd7d805135cc5083898a4bd29c7a716da601aL198-L275)])

**Testing and Internal Access:**
- Refactored `FinitePointTest` to use direct construction of `FinitePoint` instances instead of relying on string serialization/deserialization, and updated test expectations to match the new `ToString` behavior. [[1]](diffhunk://#diff-b0aa3b286f394d60c29d7a73a615d40a057cbbddff49b27348c2e1b7c66b080aR37-R113)], [[2]](diffhunk://#diff-b0aa3b286f394d60c29d7a73a615d40a057cbbddff49b27348c2e1b7c66b080aL81-R123)], [[3]](diffhunk://#diff-b0aa3b286f394d60c29d7a73a615d40a057cbbddff49b27348c2e1b7c66b080aL95-R133)], [[4]](diffhunk://#diff-b0aa3b286f394d60c29d7a73a615d40a057cbbddff49b27348c2e1b7c66b080aL108-R143)], [[5]](diffhunk://#diff-b0aa3b286f394d60c29d7a73a615d40a057cbbddff49b27348c2e1b7c66b080aL122-R153)], [[6]](diffhunk://#diff-b0aa3b286f394d60c29d7a73a615d40a057cbbddff49b27348c2e1b7c66b080aL136-R163)], [[7]](diffhunk://#diff-b0aa3b286f394d60c29d7a73a615d40a057cbbddff49b27348c2e1b7c66b080aL150-R176)], [[8]](diffhunk://#diff-b0aa3b286f394d60c29d7a73a615d40a057cbbddff49b27348c2e1b7c66b080aL164-R189)])
- Made `DivMod` in `SecretReconstructor` internal (was private) and updated its usage in tests to improve testability and reduce code redundancy. [[1]](diffhunk://#diff-5894463ebc14a22c5de96530cb77ca1609d994f91605f623fa6cd78f66a99890L200-R200)], [[2]](diffhunk://#diff-18fb6b62067cdd8fb4ec67201cb894059722856801c16befaba31ed8ee0b6965L50-R58)])

**Build and CI Improvements:**
- Added a `sed` command to the publisher SNK decryption script to update the public key in `AssemblyInfo.cs` automatically during CI. ([[.github/secrets/decrypt_publisher_snk.shR7](diffhunk://#diff-6a9f081d8359a790eccd2160a4233563857ef4dfd488d39089702db86d7ad8cdR7)])

**Documentation:**
- Updated `CHANGELOG.md` to reflect the change of `FinitePoint` to internal and the removal of obsolete properties. ([[CHANGELOG.mdR8-R10](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R10)])

These changes collectively modernize the codebase, improve security, and prepare for future maintainability by reducing exposure of internal structures and cleaning up legacy code.