### PR TITLE
Remove obsolete `X` and `Y` properties from `Share` struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `Secret<TNumber> Reconstruction(Share<TNumber>[] shares)` method.
 - Removed `Secret<TNumber> Reconstruction(string[] shares)` method.
 - Removed `Secret<TNumber> Reconstruction(string shares)` method.
+- Removed `X` property from `Share` struct.
+- Removed `Y` property from `Share` struct.
 
 ## [0.14.0] - 2025-12-25
 ### Added

--- a/src/Cryptography/Share`1.cs
+++ b/src/Cryptography/Share`1.cs
@@ -66,7 +66,7 @@ public readonly record struct Share<TNumber> : IComparable<Share<TNumber>>, IFor
     /// The separator between the X and Y coordinate
     /// </summary>
     /// <remarks>Todo: Make private and configure via options in future versions.</remarks>
-    internal const char CoordinateSeparator = '-';
+    private const char CoordinateSeparator = '-';
 
     /// <summary>
     /// Separator array for <see cref="string.Split(char[])"/> method usage to avoid allocation of a new array.
@@ -84,15 +84,6 @@ public readonly record struct Share<TNumber> : IComparable<Share<TNumber>>, IFor
     public Calculator<TNumber> Index { get; }
 
     /// <summary>
-    /// Represents the `Index` of the Share structure, exposed under the alias `X`.
-    /// </summary>
-    /// <remarks>
-    /// This property is marked as obsolete. Use the `Index` property directly for clarity.
-    /// </remarks>
-    [Obsolete("Use 'Index' property instead.")]
-    public Calculator<TNumber> X => this.Index;
-
-    /// <summary>
     /// The value (Y coordinate) of this share.
     /// </summary>
     /// <remarks>
@@ -100,15 +91,6 @@ public readonly record struct Share<TNumber> : IComparable<Share<TNumber>>, IFor
     /// on the polynomial at the given index.
     /// </remarks>
     public Calculator<TNumber> Value { get; }
-
-    /// <summary>
-    /// Gets the value associated with the share.
-    /// </summary>
-    /// <remarks>
-    /// This property is marked as obsolete. Use the 'Value' property instead for accessing the share value.
-    /// </remarks>
-    [Obsolete("Use 'Value' property instead.")]
-    public Calculator<TNumber> Y => this.Value;
 
     /// <summary>
     /// Gets a value indicating whether the share index is even.


### PR DESCRIPTION
This pull request primarily removes obsolete properties from the `Share` struct and makes a minor visibility change to a constant. The main goal is to clean up the API by eliminating deprecated members and improving encapsulation.

API cleanup and deprecation removal:

* Removed the obsolete `X` and `Y` properties from the `Share` struct, which were previously aliases for `Index` and `Value`. Developers should use `Index` and `Value` directly for clarity. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR19-R20) [[2]](diffhunk://#diff-a7dc6667d89aade0da3bf288a0338aa080feb91aed7068988cbd89d99c8df690L86-L94) [[3]](diffhunk://#diff-a7dc6667d89aade0da3bf288a0338aa080feb91aed7068988cbd89d99c8df690L104-L112)

Encapsulation improvements:

* Changed the visibility of the `CoordinateSeparator` constant from `internal` to `private` in `Share<TNumber>`, restricting its access to within the class.