### PR TITLE
Creating shares in secret sharing implementation by changing the types of the numberOfMinimumShares & numberOfShares params to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Set `FinitePoint` struct internal instead public to reduce the public API surface.
+- Set data type of `numberOfMinimumShares` and `numberOfShares` parameters from `TNumber` to `int` in `MakeShares` method.
 
 ### Removed
 - Removed `OriginalSecret` property from `Shares` class.
@@ -18,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `Secret<TNumber> Reconstruction(string shares)` method.
 - Removed `X` property from `Share` struct.
 - Removed `Y` property from `Share` struct.
+- Removed `ToInt32()` method from `BigIntCalculator` class.
+- Removed `ToInt32()` method from `Calculator` class.
 
 ## [0.14.0] - 2025-12-25
 ### Added

--- a/src/Cryptography/IMakeSharesUseCase.cs
+++ b/src/Cryptography/IMakeSharesUseCase.cs
@@ -18,7 +18,7 @@ public interface IMakeSharesUseCase<TNumber>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
     /// </exception>
-    Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel, out Secret<TNumber> generatedSecret);
+    Shares<TNumber> MakeShares(int numberOfMinimumShares, int numberOfShares, int securityLevel, out Secret<TNumber> generatedSecret);
 
     /// <summary>
     /// Generates a shamir pool using the provided <paramref name="secret"/> and returns the share points.
@@ -31,7 +31,7 @@ public interface IMakeSharesUseCase<TNumber>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> is lower than 13 or greater than 43.112.609. OR <paramref name="numberOfMinimumShares"/> is lower than 2 or greater than <paramref name="numberOfShares"/>.
     /// </exception>
-    Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret, int securityLevel);
+    Shares<TNumber> MakeShares(int numberOfMinimumShares, int numberOfShares, Secret<TNumber> secret, int securityLevel);
 
     /// <summary>
     /// Generates a shamir pool using the provided <paramref name="secret"/> and returns the share points.
@@ -41,5 +41,5 @@ public interface IMakeSharesUseCase<TNumber>
     /// <param name="secret">secret text as <see cref="Secret{TNumber}"/> or see cref="string"/></param>
     /// <returns>A <see cref="Shares{TNumber}"/> object</returns>
     /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="numberOfMinimumShares"/> is lower than 2 or greater than <paramref name="numberOfShares"/>.</exception>
-    Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret);
+    Shares<TNumber> MakeShares(int numberOfMinimumShares, int numberOfShares, Secret<TNumber> secret);
 }

--- a/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
@@ -93,7 +93,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> parameter is lower than 13 or greater than 43.112.609. OR The <paramref name="numberOfMinimumShares"/> parameter is lower than 2 or greater than <paramref name="numberOfShares"/>.
     /// </exception>
-    public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, int securityLevel, out Secret<TNumber> generatedSecret)
+    public Shares<TNumber> MakeShares(int numberOfMinimumShares, int numberOfShares, int securityLevel, out Secret<TNumber> generatedSecret)
     {
         try
         {
@@ -104,14 +104,12 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
             throw new ArgumentOutOfRangeException(nameof(securityLevel), securityLevel, e.Message);
         }
 
-        int min = ((Calculator<TNumber>)numberOfMinimumShares).ToInt32();
-        int max = ((Calculator<TNumber>)numberOfShares).ToInt32();
-        if (min < 2)
+        if (numberOfMinimumShares < 2)
         {
             throw new ArgumentOutOfRangeException(nameof(numberOfMinimumShares), numberOfMinimumShares, ErrorMessages.MinNumberOfSharesLowerThanTwo);
         }
 
-        if (min > max)
+        if (numberOfMinimumShares > numberOfShares)
         {
             throw new ArgumentOutOfRangeException(nameof(numberOfShares), numberOfShares, ErrorMessages.MaxSharesLowerThanMinShares);
         }
@@ -122,9 +120,9 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
         }
 
         generatedSecret = Secret<TNumber>.CreateRandom(this.securityLevelManager.MersennePrime);
-        var polynomial = this.CreatePolynomial(min);
+        var polynomial = this.CreatePolynomial(numberOfMinimumShares);
         polynomial[0] = generatedSecret.ToCoefficient;
-        var points = this.CreateFinitePoints(max, polynomial);
+        var points = this.CreateFinitePoints(numberOfShares, polynomial);
         return new Shares<TNumber>(points.ToShares());
     }
 
@@ -140,7 +138,7 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     /// <exception cref="T:System.ArgumentOutOfRangeException">
     /// The <paramref name="securityLevel"/> is lower than 13 or greater than 43.112.609. OR <paramref name="numberOfMinimumShares"/> is lower than 2 or greater than <paramref name="numberOfShares"/>.
     /// </exception>
-    public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret, int securityLevel)
+    public Shares<TNumber> MakeShares(int numberOfMinimumShares, int numberOfShares, Secret<TNumber> secret, int securityLevel)
     {
         try
         {
@@ -163,16 +161,14 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     /// <returns>A <see cref="Shares{TNumber}"/> collection containing the generated shares.</returns>
     /// <remarks>This method modifies the <see cref="SecurityLevel"/> based on the <paramref name="secret"/> length</remarks>
     /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="numberOfMinimumShares"/> is lower than 2 or greater than <paramref name="numberOfShares"/>.</exception>
-    public Shares<TNumber> MakeShares(TNumber numberOfMinimumShares, TNumber numberOfShares, Secret<TNumber> secret)
+    public Shares<TNumber> MakeShares(int numberOfMinimumShares, int numberOfShares, Secret<TNumber> secret)
     {
-        int min = ((Calculator<TNumber>)numberOfMinimumShares).ToInt32();
-        int max = ((Calculator<TNumber>)numberOfShares).ToInt32();
-        if (min < 2)
+        if (numberOfMinimumShares < 2)
         {
             throw new ArgumentOutOfRangeException(nameof(numberOfMinimumShares), numberOfMinimumShares, ErrorMessages.MinNumberOfSharesLowerThanTwo);
         }
 
-        if (min > max)
+        if (numberOfMinimumShares > numberOfShares)
         {
             throw new ArgumentOutOfRangeException(nameof(numberOfShares), numberOfShares, ErrorMessages.MaxSharesLowerThanMinShares);
         }
@@ -183,9 +179,9 @@ public class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
             this.SecurityLevel = newSecurityLevel;
         }
 
-        var polynomial = this.CreatePolynomial(min);
+        var polynomial = this.CreatePolynomial(numberOfMinimumShares);
         polynomial[0] = secret.ToCoefficient;
-        var points = this.CreateFinitePoints(max, polynomial);
+        var points = this.CreateFinitePoints(numberOfShares, polynomial);
 
         return new Shares<TNumber>(points.ToShares());
     }

--- a/src/Math/BigIntCalculator.cs
+++ b/src/Math/BigIntCalculator.cs
@@ -156,10 +156,6 @@ public sealed class BigIntCalculator : Calculator<BigInteger>
     /// <returns>This method returns <see langword="true"/> if this instance is less than or equal to the <paramref name="right"/> instance, <see langword="false"/> otherwise.</returns>
     protected override bool EqualOrLowerThan(BigInteger right) => this.Value <= right;
 
-    /// <inheritdoc />
-    /// <exception cref="T:System.OverflowException">Unable to convert the current instance of <see cref="BigIntCalculator"/> class to <see cref="Int32"/>.</exception>
-    public override int ToInt32() => (int)this.Value;
-
     /// <summary>
     /// Compares this instance to a second <see cref="Calculator{BigInteger}"/> and returns an integer that
     /// indicates whether the value of this instance is less than, equal to, or greater than the value of the specified object.

--- a/src/Math/Calculator.cs
+++ b/src/Math/Calculator.cs
@@ -86,13 +86,6 @@ public abstract class Calculator
     public abstract int Sign { get; }
 
     /// <summary>
-    /// Converts the current <see cref="Calculator{TNumber}"/> instance to a <see cref="Int32"/>.
-    /// </summary>
-    /// <returns>A value of the <see cref="Int32"/> type.</returns>
-    /// <exception cref="T:System.OverflowException">Unable to convert the current instance of <see cref="Calculator{TNumber}"/> class to <see cref="Int32"/>.</exception>
-    public abstract int ToInt32();
-
-    /// <summary>
     /// Creates a new instance derived from the <see cref="Calculator"/> class.
     /// </summary>
     /// <param name="data">byte array representation of the <paramref name="numberType"/></param>

--- a/tests/Math/BigIntCalculatorTest.cs
+++ b/tests/Math/BigIntCalculatorTest.cs
@@ -134,26 +134,6 @@ public class BigIntCalculatorTest
     }
 
     [Fact]
-    public void ToInt32_ShouldConvertCorrectly()
-    {
-        // Arrange
-        var calculator = new BigIntCalculator(new BigInteger(123));
-
-        // Act & Assert
-        Assert.Equal(123, calculator.ToInt32());
-    }
-
-    [Fact]
-    public void ToInt32_ShouldThrowOverflowException_OnLargeValue()
-    {
-        // Arrange
-        var calculator = new BigIntCalculator(BigInteger.Parse("12345678901234567890"));
-
-        // Act & Assert
-        Assert.Throws<OverflowException>(() => calculator.ToInt32());
-    }
-
-    [Fact]
     public void CompareTo_ShouldReturnCorrectComparison()
     {
         // Arrange


### PR DESCRIPTION
This pull request simplifies the API and internal logic for creating shares in the secret sharing implementation by changing the types of the `numberOfMinimumShares` and `numberOfShares` parameters from a generic numeric type (`TNumber`) to `int`. It also removes the `ToInt32()` method from the calculator classes and updates related code and documentation accordingly.

**API Changes:**

* Changed the data type of `numberOfMinimumShares` and `numberOfShares` parameters from `TNumber` to `int` in all `MakeShares` methods in both the `IMakeSharesUseCase<TNumber>` interface and the `SecretSplitter<TNumber>` class. This change simplifies the API and reduces unnecessary complexity. [[1]](diffhunk://#diff-cb6999316f426a0a7b5ce559ced9bc0e05c2037dc945df949815dca98df1eb11L21-R21) [[2]](diffhunk://#diff-cb6999316f426a0a7b5ce559ced9bc0e05c2037dc945df949815dca98df1eb11L34-R34) [[3]](diffhunk://#diff-cb6999316f426a0a7b5ce559ced9bc0e05c2037dc945df949815dca98df1eb11L44-R44) [[4]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L96-R96) [[5]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L143-R141) [[6]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L166-R171)

**Internal Logic Updates:**

* Updated the implementation of `MakeShares` methods to use the new `int` parameters directly, removing conversions that relied on the now-removed `ToInt32()` method. [[1]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L107-R112) [[2]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L125-R125) [[3]](diffhunk://#diff-7a72da301d679154630e18569edba0bb0a80a958b9efd92292fb23c270e1be42L186-R184)

**API Surface Reduction:**

* Removed the `ToInt32()` method from both `BigIntCalculator` and the base `Calculator` class, as it is no longer needed. [[1]](diffhunk://#diff-5f742e86036d3f4444439583e74a4ff4e227544ee9401dc29cdf9d8bff438e3dL159-L162) [[2]](diffhunk://#diff-893f038954efe9b257bd16f108872c2415343f6f0c6679c93e66503e901bf06aL88-L94)
* Removed corresponding tests for the `ToInt32()` method in `BigIntCalculatorTest.cs`.

**Documentation and Changelog:**

* Updated the `CHANGELOG.md` to reflect the changes to parameter types and the removal of the `ToInt32()` method. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR22-R23)