### PR TITLE
Remove support for .NET Framework 4.7.1 and update project files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set data type of `numberOfMinimumShares` and `numberOfShares` parameters from `TNumber` to `int` in `MakeShares` method.
 
 ### Removed
+- Removed support for .NET Framework 4.7.1
 - Removed support for .NET Framework 4.7
 - Removed `OriginalSecret` property from `Shares` class.
 - Removed `OriginalSecretExists` property from `Shares` class.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,13 @@ A C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=8><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/dotnetall.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/dotnetall.yml/badge.svg?branch=main" alt="Build status"/></a></td>
-          <td rowspan=8><code>SecretSharingDotNet.slnx</code></td>
-          <td rowspan=8>SDK</td>
+          <td rowspan=7><a href ="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/dotnetall.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/dotnetall.yml/badge.svg?branch=main" alt="Build status"/></a></td>
+          <td rowspan=7><code>SecretSharingDotNet.slnx</code></td>
+          <td rowspan=7>SDK</td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
           <td>Standard 2.1</td>
-      </tr>
-      <tr>
-          <td>FX 4.7.1</td>
       </tr>
       <tr>
           <td>FX 4.7.2</td>
@@ -55,16 +52,13 @@ A C# implementation of Shamir's Secret Sharing.
   </thead>
   <tbody>
       <tr>
-          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml/badge.svg" alt="SecretSharingDotNet - NuGet Publishing"/></a></td>
-          <td rowspan=8><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.14.0"/></a></td>
-          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.14.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.14.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=7><a href="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml/badge.svg" alt="SecretSharingDotNet - NuGet Publishing"/></a></td>
+          <td rowspan=7><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.14.0"/></a></td>
+          <td rowspan=7><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.14.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.14.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
           <td>Standard 2.1</td>
-      </tr>
-      <tr>
-          <td>FX 4.7.1</td>
       </tr>
       <tr>
           <td>FX 4.7.2</td>
@@ -431,10 +425,10 @@ namespace Example5
 ## Prerequisites
 For the following instructions, please make sure that you are connected to the internet. If necessary, NuGet will try to restore the [xUnit](https://xunit.net/) packages.
 
-If you start the unit tests on Linux, you must install the `mono-complete` package in case of the .NET Frameworks 4.7, 4.7.1, 4.7.2, 4.8 and 4.8.1.
+If you start the unit tests on Linux, you must install the `mono-complete` package in case of the .NET Frameworks 4.7.2, 4.8 and 4.8.1.
 You can find the Mono installation instructions [here](https://www.mono-project.com/download/stable/#download-lin).
 
-The .NET Frameworks 4.7.1, 4.7.2, 4.8 and 4.8.1 can be found [here](https://dotnet.microsoft.com/download/dotnet-framework).
+The .NET Frameworks 4.7.2, 4.8 and 4.8.1 can be found [here](https://dotnet.microsoft.com/download/dotnet-framework).
 
 The .NET SDKs 8.0, 9.0 and 10.0 can be found [here](https://dotnet.microsoft.com/download/dotnet).
 

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -5,7 +5,7 @@
         <RootNamespace>SecretSharingDotNet</RootNamespace>
         <OutputType>Library</OutputType>
         <LangVersion>latest</LangVersion>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net471;net472;net48;net481;net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net48;net481;net8.0;net9.0;net10.0</TargetFrameworks>
         <AssemblyOriginatorKeyFile>SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>True</SignAssembly>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <TargetFrameworks>net471;net472;net48;net481;net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net472;net48;net481;net8.0;net9.0;net10.0</TargetFrameworks>
         <AssemblyOriginatorKeyFile>..\src\SecretSharingDotNet.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>True</SignAssembly>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
- Removed `net471` target from project and test files.
- Updated README to remove references to `.NET Framework 4.7.1`.
- Adjusted compatibility tables and prerequisites for accuracy.
- Added a corresponding CHANGELOG entry.