### PR TITLE
A6: make BigIntCalculator + SecureBigIntCalculator internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `SecureBigInteger` type with constant-time arithmetic primitives; timing depends only on the public operand bit-length, not on operand values.
-- Added `SecureBigIntCalculator` as `Calculator<SecureBigInteger>` backend.
 - Added `MersenneSafeGcdAlgorithm<TNumber>` — Bernstein–Yang divstep modular inverse for a constant-time `SecretReconstructor.DivMod`.
 - Added `PinnedPoolArray<T>` — GC-pinned, securely-cleared buffer wrapper with fixed-time equality.
 - Added `PinnedPoolArrayList<T>` — cascade-dispose container for multiple pinned buffers.
@@ -28,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Shares<TNumber>` is now `IDisposable`; disposal cascades to every contained share.
 - `Share<TNumber>` is now a `sealed record` (was `readonly record struct`) and implements `IDisposable`. Properties `X` / `Y` renamed to `Index` / `Value`.
 - `IMakeSharesUseCase<TNumber>` and `IReconstructionUseCase<TNumber>` now extend `IDisposable`; DI registrations must use `Transient` or `Scoped` lifetimes so the container disposes them.
-- Moved `BigIntCalculator` from namespace `SecretSharingDotNet.Math` to `SecretSharingDotNet.Math.Numerics`.
+- `BigIntCalculator` and `SecureBigIntCalculator` are now `internal`. The numeric backends are reflection-discovered by `Calculator.Create<TNumber>()`; consumer code should use `Calculator<TNumber>` (abstract base) for typed access.
 - `Calculator<TNumber>.Clone` is now `abstract` (was a non-virtual default that returned `MemberwiseClone()`). Subclasses must now provide a true deep copy — `MemberwiseClone` is not safe when `TNumber` is a reference type (e.g. `SecureBigInteger`) or when the subtype carries reference-type fields.
 - `ExtendedEuclideanAlgorithm<TNumber>` is now `sealed`.
 - `SecretSplitter<TNumber>` is now `sealed`.

--- a/src/Math/Numerics/BigIntCalculator.cs
+++ b/src/Math/Numerics/BigIntCalculator.cs
@@ -45,7 +45,7 @@ using System.Threading;
 /// <summary>
 /// <see cref="Calculator"/> implementation of <see cref="System.Numerics.BigInteger"/>
 /// </summary>
-public sealed class BigIntCalculator : Calculator<BigInteger>
+internal sealed class BigIntCalculator : Calculator<BigInteger>
 {
     /// <summary>
     /// Lazily computes and gets the number of bytes allocated by the byte-array representation

--- a/src/Math/Numerics/SecureBigIntCalculator.cs
+++ b/src/Math/Numerics/SecureBigIntCalculator.cs
@@ -55,7 +55,7 @@ using System.Threading;
 /// <see cref="SecureBigInteger"/> once <see cref="Dispose(bool)"/> has run.
 /// </para>
 /// </remarks>
-public sealed class SecureBigIntCalculator : Calculator<SecureBigInteger>
+internal sealed class SecureBigIntCalculator : Calculator<SecureBigInteger>
 {
     /// <summary>
     /// Indicates whether the instance has been disposed (<c>0</c> = live, <c>1</c> = disposed).


### PR DESCRIPTION
## Summary
- First step of the A6 *Public-API-Boundary cleanup* tracked for the v1.0.1-rc01 release.
- Both `Calculator<TNumber>` backends (`BigIntCalculator`, `SecureBigIntCalculator`) move from `public` to `internal`. They have no consumer-side construction path — they are reflection-discovered by `Calculator.Create<TNumber>()` and reached from outside the assembly only via the abstract `Calculator<TNumber>` base.
- CHANGELOG `[Unreleased]`: drops the now-unreachable `Added` line for `SecureBigIntCalculator` and replaces the obsolete namespace-move `Changed` entry with the visibility switch.

## Why before rc01
At the rc API freeze, every `public` type becomes semver-bound. The two backends are pure implementation detail of the strategy-pattern dispatch in `Calculator.cs`, so locking them into the public surface would burden v1.x with a refactor barrier for no consumer benefit.

## Implementation notes
- `Assembly.GetTypes()` in `Calculator.GetDerivedNumberTypes` already returns internal types — reflection discovery is unaffected.
- `Type.GetConstructors()` default `BindingFlags` find public ctors regardless of declaring-type visibility, so the `Expression.Lambda(...).Compile()` path keeps working.
- Verified on legacy .NET Framework targets (Mono 6.8 on Linux CI) — `Expression.Compile` against an internal type with a public ctor binds without `MethodAccessException`.

## Test plan
- [x] Build all 6 TFMs (`net8.0`/`net9.0`/`net10.0` + `net4.7.2`/`net4.8`/`net4.8.1`) — green
- [x] Full test suite all 6 TFMs — 9986 tests total, 0 failures
  - net10.0 / net9.0 / net8.0: 1668 each
  - net4.7.2 / net4.8 / net4.8.1: 1661 each
- [x] `samples/SecretSharingDotNet.Demo.Console` builds and runs end-to-end against the modified library