### PR TITLE
samples: route share output through pinned char buffer

### DIFF
--- a/samples/SecretSharingDotNet.Demo.Console/DemoApp.cs
+++ b/samples/SecretSharingDotNet.Demo.Console/DemoApp.cs
@@ -281,8 +281,11 @@ internal sealed class DemoApp
         Console.WriteLine($"Generated {shares.Count} shares (keep each one confidential):");
         for (int i = 0; i < shares.Count; i++)
         {
-            // Share.ToString() emits the public "INDEX-VALUE" hex serialisation; safe to print.
-            Console.WriteLine($"  [{i + 1}] {shares[i]}");
+            Console.Write($"  [{i + 1}] ");
+            // Pinned-buffer write path — no intermediate managed string; the char buffer is wiped on dispose.
+            using var charArray = shares[i].ToCharArray();
+            Console.Write(charArray.PoolArray, 0, charArray.Length);
+            Console.WriteLine();
         }
 
         Console.WriteLine();


### PR DESCRIPTION
## Summary
- The "Generated N shares" listing in `DemoApp.RunSplitStage` was the last demo path still materialising managed strings on the wire — `Share.ToString()` boxes the hex serialisation into an unpinned, GC-relocatable string before `Console.WriteLine` consumes it.
- Inconsistent with the library's *no string materialisation on wire path* policy that the rest of the demo already demonstrates (`ConsolePasswordReader` pinned input, pinned secret round-trip, pinned share reconstruction).
- Each share now goes through `Share.ToCharArray()` (default uppercase / no-prefix format, byte-for-byte identical to `ToString`) and is written directly via `Console.Write(char[], int, int)`. The pinned buffer is wiped on `using` dispose; the heap never sees the serialised share text.

## Why it's a fix, not a feature
A single Share is information-theoretically zero-leakage about the secret (classical Shamir property: fewer than k shares reveal nothing), so this is defense-in-depth against heap snapshots / swap / cross-process memory reads — not a hard requirement. The motivation is to make the demo *internally consistent* and to teach the pinned-output pattern alongside the pinned-input one.

## Test plan
- [x] `dotnet build --configuration Release samples/SecretSharingDotNet.Demo.Console` — green on net10.0
- [x] `dotnet run --no-build --configuration Release --project samples/SecretSharingDotNet.Demo.Console` — interactive demo runs end-to-end; share-listing output character-for-character identical to the previous version (uppercase hex, no `0x` prefix, `INDEX-VALUE` format)