### PR TITLE
docs(README): expand "does not protect against" with two CT gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,21 @@ for hardened native crypto stacks.
   analysis of reconstruction must inject `MersenneSafeGcdAlgorithm<TNumber>`
   explicitly. A convenience overload routing the SecureBigInteger backend to
   `MersenneSafeGcdAlgorithm<SecureBigInteger>` by default is planned future work.
+- **Hex- and Base64-decoder input-character timing.** `Share<TNumber>`'s
+  hex-deserialisation pipeline (`DecodeHexToCalculator` → `GetHexValue`) and
+  `Secret<TNumber>`'s Base64 decode (`DecodeBase64Char`) are not constant-time on
+  input characters — both compile to branchy range-pattern switches whose
+  wall-clock time varies by which character class the input belongs to. Both
+  decoders are treated as boundary parsers: only the resulting
+  `Calculator<TNumber>` value / decoded secret bytes flow through the CT
+  primitives.
+- **Ordering of `Secret<TNumber>`.** `Secret<TNumber>.CompareTo` and the
+  relational operators (`<`, `>`, `<=`, `>=`) ultimately use
+  `PinnedPoolArray<byte>.IStructuralComparable.CompareTo`, which short-circuits
+  on the first differing byte. Wall-clock time leaks the length of the common
+  prefix between two secrets. Sorting or comparing secret material where
+  ordering timing matters is out of scope — only equality
+  (`Secret<TNumber>.Equals` over the fixed-time path) is CT.
 
 Constant-time big-integer arithmetic in pure managed .NET is non-trivial; canonical
 implementations (libsodium, BoringSSL) rely on fixed-width representation, branchless


### PR DESCRIPTION
## Summary
The README's Security & Threat Model section currently calls out only one Not-Protected item — the variable-time modular inverse on the default reconstruction path. Two further CT gaps were audited during the rc01 prep but the documentation never followed, leaving consumers with an incomplete picture of the wall-clock leakage surface. This PR closes that documentation gap.

Two new bullets in the "does not protect against" list:

- **Hex- and Base64-decoder input-character timing.** `Share<TNumber>`'s hex-deserialisation pipeline (`DecodeHexToCalculator` → `GetHexValue`) and `Secret<TNumber>`'s Base64 decode (`DecodeBase64Char`) compile to branchy range-pattern switches whose wall-clock time varies by which character class the input belongs to. Both decoders are treated as boundary parsers; only the resulting `Calculator<TNumber>` value and decoded secret bytes flow through the CT primitives.
- **Ordering of `Secret<TNumber>`.** `CompareTo` and the relational operators (`<`, `>`, `<=`, `>=`) ultimately use `PinnedPoolArray<byte>`'s structural `CompareTo`, which short-circuits on the first differing byte and therefore leaks the length of the common prefix between two secrets. Sorting or comparing secret material where ordering timing matters is out of scope; only equality (`Secret<TNumber>.Equals` over the fixed-time path) is CT.

## Scope
Doc-only — no library code touched.

Both items have planned code-level follow-ups (branchless CT decoders for the first; a CT-aware `PinnedPoolArray<byte>.CompareTo` plus `[Obsolete]` markers on `Secret<TNumber>`'s relational operators for the second). Those are out of scope for rc01 and stay parked for dedicated PR cycles — this PR closes only the documentation gap so consumers can make informed decisions today.

## Test plan
- [x] Sanity-build on net10.0 — green
- [x] README renders unchanged structure (two new bullets appended after the existing DivMod bullet, before the closing "Constant-time big-integer arithmetic…" paragraph)