### PR TITLE
harden pinned-buffer allocations to dispose-on-throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SecureBigInteger.Equals` no longer calls a redundant `Array.Clear` after `new PinnedPoolArray<ulong>(…)` — the constructor already zero-clears the rented capacity.
 - `MersenneSafeGcdAlgorithm<TNumber>` threat-model XDoc tightened: only the outer divstep iteration count is operand-independent; per-iteration wall-clock varies with the limb count of the shrinking intermediate working values. The README's Security & Threat Model section is updated to match.
 - `SecureBigInteger.Pow(int)` XDoc now flags the `exponent ∈ {0, 1}` early returns as additional timing distinctions beyond the documented `O(log₂(exponent))`.
+- Hardened pinned-buffer allocations across `SecureCharBufferExtensions`, `SecureNumericBufferExtensions`, and `PinnedPoolArrayExtensions.Subset<T>` to dispose the freshly-allocated pinned buffer if the post-allocation write throws. The failure paths are unreachable in clean code, so no behavioural change in practice — defense-in-depth against partial-fill leaks if the copy/write ever does throw.
 
 ### Removed
 - Removed support for .NET Framework 4.7.1.

--- a/src/Cryptography/SecureInput/SecureCharBufferExtensions.cs
+++ b/src/Cryptography/SecureInput/SecureCharBufferExtensions.cs
@@ -65,6 +65,10 @@ public static class SecureCharBufferExtensions
     /// characters into a pinned buffer from the start — for example via
     /// <see cref="ConsolePasswordReader.ReadPassword(int, char?)"/>.
     /// </para>
+    /// <para>
+    /// If the post-allocation write throws, the pinned buffer is disposed before the
+    /// exception is rethrown — no reference to a partially-filled buffer escapes.
+    /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source"/> is <see langword="null"/>.
@@ -77,9 +81,17 @@ public static class SecureCharBufferExtensions
         }
 
         var pinned = new PinnedPoolArray<char>(source.Length);
-        if (source.Length > 0)
+        try
         {
-            source.CopyTo(0, pinned.PoolArray, 0, source.Length);
+            if (source.Length > 0)
+            {
+                source.CopyTo(0, pinned.PoolArray, 0, source.Length);
+            }
+        }
+        catch
+        {
+            pinned.Dispose();
+            throw;
         }
 
         return pinned;
@@ -99,13 +111,25 @@ public static class SecureCharBufferExtensions
     /// The pinning guarantee covers only the destination buffer. If <paramref name="source"/>
     /// is backed by an unpinned managed array or a <see cref="string"/>, the original
     /// characters remain recoverable from that backing store after this method returns.
+    /// <para>
+    /// If the post-allocation write throws, the pinned buffer is disposed before the
+    /// exception is rethrown — no reference to a partially-filled buffer escapes.
+    /// </para>
     /// </remarks>
     public static PinnedPoolArray<char> ToPinnedSecure(this ReadOnlySpan<char> source)
     {
         var pinned = new PinnedPoolArray<char>(source.Length);
-        if (source.Length > 0)
+        try
         {
-            source.CopyTo(pinned.PoolArray.AsSpan(0, source.Length));
+            if (source.Length > 0)
+            {
+                source.CopyTo(pinned.PoolArray.AsSpan(0, source.Length));
+            }
+        }
+        catch
+        {
+            pinned.Dispose();
+            throw;
         }
 
         return pinned;
@@ -128,6 +152,10 @@ public static class SecureCharBufferExtensions
     /// The pinning guarantee covers only the destination buffer — the GC may have relocated
     /// <paramref name="source"/> at any point in its lifetime, so prior unpinned residue may
     /// still exist elsewhere in process memory.
+    /// <para>
+    /// If the post-allocation write throws, the pinned buffer is disposed before the
+    /// exception is rethrown — no reference to a partially-filled buffer escapes.
+    /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source"/> is <see langword="null"/>.
@@ -140,10 +168,18 @@ public static class SecureCharBufferExtensions
         }
 
         var pinned = new PinnedPoolArray<char>(source.Length);
-        if (source.Length > 0)
+        try
         {
-            Array.Copy(source, 0, pinned.PoolArray, 0, source.Length);
-            Array.Clear(source, 0, source.Length);
+            if (source.Length > 0)
+            {
+                Array.Copy(source, 0, pinned.PoolArray, 0, source.Length);
+                Array.Clear(source, 0, source.Length);
+            }
+        }
+        catch
+        {
+            pinned.Dispose();
+            throw;
         }
 
         return pinned;

--- a/src/Cryptography/SecureInput/SecureNumericBufferExtensions.cs
+++ b/src/Cryptography/SecureInput/SecureNumericBufferExtensions.cs
@@ -68,11 +68,24 @@ public static class SecureNumericBufferExtensions
     /// than the platform-endian <see cref="BitConverter.GetBytes(int)"/>), so callers on
     /// big-endian hosts do not silently produce shares with reversed coordinates.
     /// </para>
+    /// <para>
+    /// If the post-allocation write throws, the pinned buffer is disposed before the
+    /// exception is rethrown — no reference to a partially-filled buffer escapes.
+    /// </para>
     /// </remarks>
     public static PinnedPoolArray<byte> ToPinnedSecureBytes(this int source)
     {
         var pinned = new PinnedPoolArray<byte>(sizeof(int));
-        BinaryPrimitives.WriteInt32LittleEndian(pinned.PoolArray.AsSpan(0, sizeof(int)), source);
+        try
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(pinned.PoolArray.AsSpan(0, sizeof(int)), source);
+        }
+        catch
+        {
+            pinned.Dispose();
+            throw;
+        }
+
         return pinned;
     }
 
@@ -99,11 +112,24 @@ public static class SecureNumericBufferExtensions
     /// than the platform-endian <see cref="BitConverter.GetBytes(long)"/>), so callers on
     /// big-endian hosts do not silently produce shares with reversed coordinates.
     /// </para>
+    /// <para>
+    /// If the post-allocation write throws, the pinned buffer is disposed before the
+    /// exception is rethrown — no reference to a partially-filled buffer escapes.
+    /// </para>
     /// </remarks>
     public static PinnedPoolArray<byte> ToPinnedSecureBytes(this long source)
     {
         var pinned = new PinnedPoolArray<byte>(sizeof(long));
-        BinaryPrimitives.WriteInt64LittleEndian(pinned.PoolArray.AsSpan(0, sizeof(long)), source);
+        try
+        {
+            BinaryPrimitives.WriteInt64LittleEndian(pinned.PoolArray.AsSpan(0, sizeof(long)), source);
+        }
+        catch
+        {
+            pinned.Dispose();
+            throw;
+        }
+
         return pinned;
     }
 
@@ -131,6 +157,11 @@ public static class SecureNumericBufferExtensions
     /// snapshots taken before the wipe (or of relocation residue) can still expose the
     /// secret. Prefer callers that hold the value in pinned memory from the start.
     /// </para>
+    /// <para>
+    /// If the post-allocation write throws, the pinned buffer is disposed before the
+    /// exception is rethrown — no reference to a partially-filled buffer escapes. The
+    /// intermediate unpinned byte array is wiped on both the success and failure path.
+    /// </para>
     /// </remarks>
     public static PinnedPoolArray<byte> ToPinnedSecureBytes(this BigInteger source)
     {
@@ -138,9 +169,17 @@ public static class SecureNumericBufferExtensions
         try
         {
             var pinned = new PinnedPoolArray<byte>(bytes.Length);
-            if (bytes.Length > 0)
+            try
             {
-                Array.Copy(bytes, 0, pinned.PoolArray, 0, bytes.Length);
+                if (bytes.Length > 0)
+                {
+                    Array.Copy(bytes, 0, pinned.PoolArray, 0, bytes.Length);
+                }
+            }
+            catch
+            {
+                pinned.Dispose();
+                throw;
             }
 
             return pinned;
@@ -167,6 +206,10 @@ public static class SecureNumericBufferExtensions
     /// pinning guarantee covers only the destination buffer — the GC may have relocated
     /// <paramref name="source"/> at any point in its lifetime, so prior unpinned residue may
     /// still exist elsewhere in process memory.
+    /// <para>
+    /// If the post-allocation write throws, the pinned buffer is disposed before the
+    /// exception is rethrown — no reference to a partially-filled buffer escapes.
+    /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source"/> is <see langword="null"/>.
@@ -179,10 +222,18 @@ public static class SecureNumericBufferExtensions
         }
 
         var pinned = new PinnedPoolArray<byte>(source.Length);
-        if (source.Length > 0)
+        try
         {
-            Array.Copy(source, 0, pinned.PoolArray, 0, source.Length);
-            Array.Clear(source, 0, source.Length);
+            if (source.Length > 0)
+            {
+                Array.Copy(source, 0, pinned.PoolArray, 0, source.Length);
+                Array.Clear(source, 0, source.Length);
+            }
+        }
+        catch
+        {
+            pinned.Dispose();
+            throw;
         }
 
         return pinned;

--- a/src/Extension/PinnedPoolArrayExtensions.cs
+++ b/src/Extension/PinnedPoolArrayExtensions.cs
@@ -47,6 +47,12 @@ internal static class PinnedPoolArrayExtensions
     /// <param name="index">start index</param>
     /// <param name="count">number of elements to copy to a new subset array</param>
     /// <returns>An array that contains the specified number of elements from the <paramref name="index"/> of the <paramref name="array"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// If the post-allocation write throws, the pinned buffer is disposed before the
+    /// exception is rethrown — no reference to a partially-filled buffer escapes.
+    /// </para>
+    /// </remarks>
     internal static PinnedPoolArray<TArray> Subset<TArray>(this PinnedPoolArray<TArray> array, int index, int count)
         where TArray : unmanaged
     {
@@ -73,7 +79,16 @@ internal static class PinnedPoolArrayExtensions
         }
 
         var subset = new PinnedPoolArray<TArray>(count);
-        Array.Copy(array.PoolArray, index, subset.PoolArray, 0, count);
+        try
+        {
+            Array.Copy(array.PoolArray, index, subset.PoolArray, 0, count);
+        }
+        catch
+        {
+            subset.Dispose();
+            throw;
+        }
+
         return subset;
     }
 


### PR DESCRIPTION
## Summary
Eight call sites across `SecureCharBufferExtensions`, `SecureNumericBufferExtensions`, and `PinnedPoolArrayExtensions.Subset<T>` followed the same shape: allocate a fresh `PinnedPoolArray<T>`, then copy / write into it, then return. If the post-allocation copy / write ever threw, the pinned buffer leaked — its partial-fill content stayed resident in pinned, GC-immobile memory until the finalizer ran.

Each post-allocation write is now wrapped in `try { … } catch { pinned.Dispose(); throw; }`, mirroring the existing dispose-on-throw pattern in `SecureCharBufferExtensions.ToPinnedSecureShareLines` and `ConsolePasswordReader.ReadPasswordLoop`. The XDoc `<remarks>` on each affected method is extended with the new dispose-on-throw contract (`<para>` block, consistent with `ReadPasswordLoop`'s wording).

## Call sites touched
- `SecureCharBufferExtensions.ToPinnedSecure(string)`
- `SecureCharBufferExtensions.ToPinnedSecure(ReadOnlySpan<char>)` (modern TFMs)
- `SecureCharBufferExtensions.ToPinnedSecureClearing(char[])`
- `SecureNumericBufferExtensions.ToPinnedSecureBytes(int)`
- `SecureNumericBufferExtensions.ToPinnedSecureBytes(long)`
- `SecureNumericBufferExtensions.ToPinnedSecureBytes(BigInteger)` (inner try around the existing source-clear `finally`)
- `SecureNumericBufferExtensions.ToPinnedSecureBytesClearing(byte[])`
- `PinnedPoolArrayExtensions.Subset<T>`

## Why this is defense-in-depth, not a behavioural fix
The failure paths are unreachable in clean code:
- `string.CopyTo` / `ReadOnlySpan<char>.CopyTo` into a buffer sized from `source.Length` cannot raise length-mismatch.
- `Array.Copy` between compatible element types with validated indices cannot raise `ArrayTypeMismatchException` or `IndexOutOfRangeException`.
- `BinaryPrimitives.WriteInt{32,64}LittleEndian` against a fixed `sizeof(int)` / `sizeof(long)` buffer cannot raise on the write step.

The hardening protects against partial-fill leaks if the copy ever does throw (e.g. OOM mid-write, a hypothetical malicious mutation of the source between length-read and copy).

## CT-safety
Each affected method already branched on `source.Length` — a public bit-length quantity, identical to the constructor's argument. The new `try/catch` adds a branch on the exception state, which is itself an observable public event of the caller. **No secret-derived branching is introduced.** The dispose path's timing tracks the pool-bucket capacity, which is a function of `source.Length` — also public. CT profile of every affected helper is unchanged.

## Test plan
- [x] Build on net10.0 — green (`dotnet build`)
- [x] Full test suite on net10.0 — **1668 / 1668 pass** (no failures, no skips)
- [x] No new tests added — the failure paths are practically unreachable, matching the test-coverage decision already taken for `ToPinnedSecureShareLines` and `ReadPasswordLoop`