### PR TITLE
remove LINQ allocations from SecretReconstructor hot path

### DIFF
--- a/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
@@ -170,9 +170,22 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
             throw new ArgumentOutOfRangeException(nameof(shares), numberOfPoints, ErrorMessages.MinNumberOfSharesLowerThanTwo);
         }
 
-        if (shares.Select(s => s.Index).Distinct().Count() != numberOfPoints)
+        // Explicit HashSet loop instead of shares.Select(s => s.Index).Distinct().Count()
+        // — avoids the SelectIterator + DistinctIterator + enumerator allocations on the
+        // unpinned managed heap. Throws on first-duplicate detection instead of after full
+        // enumeration; eager-vs-lazy throw on the public x-coordinates yields the same
+        // exception type and message, no observable difference on the success path.
+#if NET8_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        var seenIndices = new HashSet<Calculator<TNumber>>(numberOfPoints);
+#else
+        var seenIndices = new HashSet<Calculator<TNumber>>();
+#endif
+        for (int i = 0; i < numberOfPoints; i++)
         {
-            throw new ArgumentException(ErrorMessages.ShareIndicesNotDistinct, nameof(shares));
+            if (!seenIndices.Add(shares[i].Index))
+            {
+                throw new ArgumentException(ErrorMessages.ShareIndicesNotDistinct, nameof(shares));
+            }
         }
 
         using var zero = Calculator<TNumber>.Zero;
@@ -282,7 +295,25 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
         }
 
         var shareList = shares.ToArray();
-        var maximumY = shareList.Select(share => share.Value).Max();
+        // Explicit loop instead of shareList.Select(share => share.Value).Max() —
+        // avoids the SelectArrayIterator + enumerator allocations on the unpinned
+        // managed heap. Null-skip matches Enumerable.Max semantics for reference
+        // types: the maximum of all non-null values, or null if every value is null.
+        Calculator<TNumber> maximumY = null;
+        for (int i = 0; i < shareList.Length; i++)
+        {
+            var candidate = shareList[i].Value;
+            if (candidate is null)
+            {
+                continue;
+            }
+
+            if (maximumY is null || candidate > maximumY)
+            {
+                maximumY = candidate;
+            }
+        }
+
         if (maximumY is null)
         {
             throw new ArgumentException(ErrorMessages.NoMaximumY, nameof(shares));


### PR DESCRIPTION
## Summary

- `Reconstruction` (max-Y scan, `Reconstructor\`3.cs`) and `LagrangeInterpolate` (index-distinctness check) previously routed through `Select().Max()` and `Select().Distinct().Count()`. Both materialised iterator + closure objects on the unpinned managed heap per reconstruction call.
- Replaced with explicit loops. `Max()` semantics preserved (null-skip matches `Enumerable.Max` for reference types). Distinctness throw moved to first-duplicate detection — eager vs lazy throw on the public x-coordinates yields the same exception type and message; no observable difference on the success path.
- Reduces heap surface in a security-sensitive primitive. No behavioural change on the success path, no API change.

## Why fix- and not perf?

The wallclock impact is sub-1 % even on the faster `BigInteger` backend and below noise on `SecureBigInteger`, where CT arithmetic dominates. The real value is removing LINQ iterator/closure surface from a security-sensitive reconstruction path — a code-quality / defense-in-depth improvement, not a measurable perf win.

## Notes on the HashSet capacity hint

`HashSet<T>(int capacity)` is not available on `netstandard2.0` / `net4.7.2` / `net4.8` / `net4.8.1`. A `#if NET8_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER` block keeps the hint on the modern TFMs and falls back to the parameterless ctor elsewhere — matches the conditional-compilation convention already used in `SecureCharBufferExtensions.cs`.

## Test plan

- [x] Build succeeds across all 6 library TFMs (`netstandard2.0`, `netstandard2.1`, `net4.7.2`, `net4.8.1`, `net8.0`, `net9.0`, `net10.0`) plus Demo/Tests on `net4.8`.
- [x] Full test suite green on all 6 test TFMs: 1668/1668 on `net8.0`/`net9.0`/`net10.0`, 1661/1661 on `net4.7.2`/`net4.8`/`net4.8.1` (TFM-conditional Span tests).
- [x] No new compiler warnings introduced.