### PR TITLE
docs(README): expand Mono runtime crash note for rc01

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,7 +1048,7 @@ For the following instructions, please make sure that you are connected to the i
 
 If you start the unit tests on Linux or macOS, you must install the `mono-complete` package in case of the .NET Frameworks 4.7.2, 4.8 and 4.8.1.
 You can find the Mono installation instructions [here](https://www.mono-project.com/download/stable/#download-lin).
-Mono 6.8 on Linux occasionally writes diagnostic `mono_crash.*.json` files after Framework-TFM test runs; these are tracked by `.gitignore` and do not indicate test failures — the runners report green and the crash sits in runner shutdown / finalizer drain.
+Mono 6.8 on Linux occasionally writes diagnostic `mono_crash.<session>.<n>.json` files into `tests/` after Framework-TFM test runs. These are Mono runtime crash reports produced *after* assertion reporting, during runner shutdown / finalizer drain — every test still passes (the crash is post-test). The pattern is tracked by `.gitignore` so it never pollutes `git status`. CoreCLR targets (`net8.0` / `net9.0` / `net10.0`) are unaffected. Treat any such files as runner-shutdown artefacts of the Mono 6.8 host; they do not indicate a library defect.
 
 The .NET Frameworks 4.7.2, 4.8 and 4.8.1 can be found [here](https://dotnet.microsoft.com/download/dotnet-framework).
 


### PR DESCRIPTION
## Summary

The Prerequisites paragraph already mentioned that Mono 6.8 on Linux occasionally leaves `mono_crash.*.json` files after Framework-TFM test runs. This PR expands that one-liner in place — same location, single source of truth — with three additions that make the boundary explicit for rc01 consumers:

- The crash is **post-test**: assertion reporting has already completed; the fault occurs during runner shutdown / finalizer drain. Every test still passes.
- **CoreCLR targets (`net8.0` / `net9.0` / `net10.0`) are unaffected.**
- The artefact is a **Mono 6.8 host limitation**, not a library defect.

## Why this PR exists

Part of the rc01 release-prep cycle on `release-v1.0.1-rc01`. The Mono CI tolerance decision (parked since 2026-05-14 per the per-TFM-isolation audit) is closed as *documented tolerance* rather than retry-policy / debug / TFM-drop. This PR is the documentation half of that decision; the `.gitignore` half (commit `eedece1`) was already in place.

## Why `docs-` and not `fix-`

Pure README expansion, no library code touched. Branch prefix matches the project's `docs-` niche.

## Test plan

- [x] No code change — no build / test run required.
- [x] Diff is a single-line replacement at `README.md:1051` (Prerequisites section), no new headings, no structural shifts.
- [x] Wording is consistent with the existing threat-model voice from PR #302 / PR #305.