### PR TITLE
fix(Shares): copy ctor input to avoid sorting caller-owned array

### DIFF
--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -82,7 +82,11 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection, 
     internal Shares(IList<Share<TNumber>> shares)
     {
         _ = shares ?? throw new ArgumentNullException(nameof(shares));
-        var sortedShares = shares as Share<TNumber>[] ?? shares.ToArray();
+        // Always copy via ToArray(). The public implicit operator from
+        // Share<TNumber>[] reaches this ctor with caller-owned storage; an
+        // alias-cast to Share<TNumber>[] followed by Array.Sort would
+        // reorder the caller's array as a side effect of construction.
+        var sortedShares = shares.ToArray();
         Array.Sort(sortedShares);
         this.shareList = new Collection<Share<TNumber>>(sortedShares);
     }

--- a/tests/Cryptography/BigInteger/SharesTest.cs
+++ b/tests/Cryptography/BigInteger/SharesTest.cs
@@ -373,6 +373,43 @@ public class SharesTest
     }
 
     /// <summary>
+    /// Regression test against the <see cref="Shares{TNumber}"/> ctor sorting the
+    /// caller-owned array in place. The public implicit operator from
+    /// <see cref="Share{TNumber}"/>[] reaches the internal ctor; an alias-cast there
+    /// followed by <see cref="Array.Sort{T}(T[])"/> would reorder the caller's array
+    /// as a side effect of construction. Reported by codex on PR #308 against the
+    /// v1.0.1-rc01 release candidate. The test asserts both halves: the caller's
+    /// array keeps its original ordering, and the wrapped collection is still sorted
+    /// internally (so the defensive copy does not break the sort contract).
+    /// </summary>
+    [Fact]
+    public void ImplicitOperatorFromArray_DoesNotMutateCallerArray()
+    {
+        // Arrange — three shares laid out in reverse-of-index order so an in-place
+        // sort would visibly reorder the caller's array.
+        using var p3 = "3-300".ToPinnedSecure();
+        using var p1 = "1-100".ToPinnedSecure();
+        using var p2 = "2-200".ToPinnedSecure();
+        using var s3 = new Share<BigInteger>(p3);
+        using var s1 = new Share<BigInteger>(p1);
+        using var s2 = new Share<BigInteger>(p2);
+        var callerArray = new[] { s3, s1, s2 };
+
+        // Act — implicit operator wraps the caller-owned array.
+        using var wrapped = (Shares<BigInteger>)callerArray;
+
+        // Assert — caller's array still in [s3, s1, s2] order (defensive copy in ctor).
+        Assert.Same(s3, callerArray[0]);
+        Assert.Same(s1, callerArray[1]);
+        Assert.Same(s2, callerArray[2]);
+
+        // Assert — wrapped collection sorted ascending by index: [s1, s2, s3].
+        Assert.Same(s1, wrapped[0]);
+        Assert.Same(s2, wrapped[1]);
+        Assert.Same(s3, wrapped[2]);
+    }
+
+    /// <summary>
     /// <see cref="Shares{TNumber}.ToCharArray()"/> emits uppercase hex without prefix, one share per line,
     /// separated and terminated by <see cref="Environment.NewLine"/>, regardless of build configuration.
     /// </summary>

--- a/tests/Cryptography/SecureBigInteger/SharesTest.cs
+++ b/tests/Cryptography/SecureBigInteger/SharesTest.cs
@@ -413,6 +413,43 @@ public class SharesTest
     }
 
     /// <summary>
+    /// Regression test against the <see cref="Shares{TNumber}"/> ctor sorting the
+    /// caller-owned array in place. The public implicit operator from
+    /// <see cref="Share{TNumber}"/>[] reaches the internal ctor; an alias-cast there
+    /// followed by <see cref="Array.Sort{T}(T[])"/> would reorder the caller's array
+    /// as a side effect of construction. Reported by codex on PR #308 against the
+    /// v1.0.1-rc01 release candidate. The test asserts both halves: the caller's
+    /// array keeps its original ordering, and the wrapped collection is still sorted
+    /// internally (so the defensive copy does not break the sort contract).
+    /// </summary>
+    [Fact]
+    public void ImplicitOperatorFromArray_DoesNotMutateCallerArray()
+    {
+        // Arrange — three shares laid out in reverse-of-index order so an in-place
+        // sort would visibly reorder the caller's array.
+        using var p3 = "3-300".ToPinnedSecure();
+        using var p1 = "1-100".ToPinnedSecure();
+        using var p2 = "2-200".ToPinnedSecure();
+        using var s3 = new Share<SecureBigInteger>(p3);
+        using var s1 = new Share<SecureBigInteger>(p1);
+        using var s2 = new Share<SecureBigInteger>(p2);
+        var callerArray = new[] { s3, s1, s2 };
+
+        // Act — implicit operator wraps the caller-owned array.
+        using var wrapped = (Shares<SecureBigInteger>)callerArray;
+
+        // Assert — caller's array still in [s3, s1, s2] order (defensive copy in ctor).
+        Assert.Same(s3, callerArray[0]);
+        Assert.Same(s1, callerArray[1]);
+        Assert.Same(s2, callerArray[2]);
+
+        // Assert — wrapped collection sorted ascending by index: [s1, s2, s3].
+        Assert.Same(s1, wrapped[0]);
+        Assert.Same(s2, wrapped[1]);
+        Assert.Same(s3, wrapped[2]);
+    }
+
+    /// <summary>
     /// <see cref="Shares{TNumber}.ToCharArray()"/> emits uppercase hex without prefix, one share per line,
     /// separated and terminated by <see cref="Environment.NewLine"/>, regardless of build configuration.
     /// </summary>


### PR DESCRIPTION
## Summary

Regression fix for an in-place sort of caller-owned arrays in the `Shares<TNumber>(IList<Share<TNumber>>)` ctor, reported by codex on PR #308 (review comment [`r3326138878`](https://github.com/shinji-san/SecretSharingDotNet/pull/308#discussion_r3326138878)).

## The bug

`src/Cryptography/Shares.cs:85` previously read:

```csharp
var sortedShares = shares as Share<TNumber>[] ?? shares.ToArray();
Array.Sort(sortedShares);
```

The alias-cast `shares as Share<TNumber>[]` succeeded whenever the caller already held a `Share<TNumber>[]`, leaving `sortedShares` pointing at the **same backing storage** as the caller. The subsequent `Array.Sort` then reordered the caller's array as a side effect of construction.

The public surface that exposed this is the implicit operator:

```csharp
public static implicit operator Shares<TNumber>(Share<TNumber>[] shares) => new Shares<TNumber>(shares);
```

Any caller writing `Shares<TNumber> wrapped = mine;` would find `mine` sorted afterwards — a silent state mutation of caller-owned storage.

## The fix

Restored unconditional `shares.ToArray()` (which is what the v0.14.0 implementation did) plus a multi-line comment at the call site explaining *why* the seeming optimisation cannot be reintroduced. The `.ToArray()` cost is sub-microsecond on the small share counts the ctor sees (single-digit to low double-digit N) — the correctness gain dominates.

## Regression test

Added `ImplicitOperatorFromArray_DoesNotMutateCallerArray` mirrored in both backend test hierarchies (`tests/Cryptography/BigInteger/SharesTest.cs` and `tests/Cryptography/SecureBigInteger/SharesTest.cs`).

The test:
1. Builds three shares in **reverse-of-index** order (`[s3, s1, s2]`), so an in-place sort would visibly reorder the caller's array.
2. Wraps them through the public implicit operator.
3. Asserts both halves: the caller's array stays in `[s3, s1, s2]`, and the wrapped collection is sorted ascending to `[s1, s2, s3]` — so the defensive copy does not break the sort contract.

## No CHANGELOG entry

The regression lived only in unreleased develop history. v0.14.0 used `shares.ToArray()` unconditionally; v1.0.1-rc01 with this fix ships the same defensive-copy behaviour. There is no consumer-visible change relative to the last released version, so the `### Fixed` section in `[1.0.1-rc01]` would be misleading.

## Effect on PR #308

PR #308 is `release-v1.0.1-rc01` → `main`. Once this PR lands on the release branch, PR #308 picks up the additional commit automatically — no separate action needed on #308 beyond closing the codex thread as resolved.

## Test plan

- [x] `dotnet build --configuration Release` green on all library and test TFMs (0 errors, 8 pre-existing SourceLink warnings on the incremental build).
- [x] Full test suite green on all 6 test TFMs:
  - `net8.0` / `net9.0` / `net10.0` — 1670 / 1670 each (+2 vs. baseline 1668: the new regression test mirrored across both backend hierarchies).
  - `net4.7.2` / `net4.8` / `net4.8.1` — 1663 / 1663 each (+2 vs. baseline 1661).