### PR TITLE
Back-merge release-v1.0.1-rc01 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.1-rc01] - 2026-05-29
 
 ### Added
 - Added `SecureBigInteger` type with constant-time arithmetic primitives; timing depends only on the public operand bit-length, not on operand values.
@@ -316,7 +316,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LICENSE.md`
 - Added `README.md`
 
-[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.14.0...develop
+[1.0.1-rc01]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.14.0...v1.0.1-rc01
 [0.14.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.11.0...v0.12.0

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ A C# implementation of Shamir's Secret Sharing.
   <tbody>
       <tr>
           <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml/badge.svg" alt="SecretSharingDotNet - NuGet Publishing"/></a></td>
-          <td rowspan=8><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 0.14.0"/></a></td>
-          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v0.14.0" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-0.14.0-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=8><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 1.0.1-rc01"/></a></td>
+          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v1.0.1-rc01" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-1.0.1--rc01-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
@@ -88,10 +88,10 @@ A C# implementation of Shamir's Secret Sharing.
 
 1. Open a console and switch to the directory containing your project file.
 
-2. Use the following command to install version 0.14.0 of the SecretSharingDotNet package:
+2. Use the following command to install version 1.0.1-rc01 of the SecretSharingDotNet package:
 
     ```dotnetcli
-    dotnet add package SecretSharingDotNet -v 0.14.0 -f <FRAMEWORK>
+    dotnet add package SecretSharingDotNet -v 1.0.1-rc01 -f <FRAMEWORK>
     ```
 
 3. After the completion of the command, look at the project file to make sure that the package is successfully installed.
@@ -100,7 +100,7 @@ A C# implementation of Shamir's Secret Sharing.
 
     ```xml
     <ItemGroup>
-      <PackageReference Include="SecretSharingDotNet" Version="0.14.0" />
+      <PackageReference Include="SecretSharingDotNet" Version="1.0.1-rc01" />
     </ItemGroup>
     ```
 ## Remove SecretSharingDotNet package 📤

--- a/README.md
+++ b/README.md
@@ -1048,7 +1048,7 @@ For the following instructions, please make sure that you are connected to the i
 
 If you start the unit tests on Linux or macOS, you must install the `mono-complete` package in case of the .NET Frameworks 4.7.2, 4.8 and 4.8.1.
 You can find the Mono installation instructions [here](https://www.mono-project.com/download/stable/#download-lin).
-Mono 6.8 on Linux occasionally writes diagnostic `mono_crash.*.json` files after Framework-TFM test runs; these are tracked by `.gitignore` and do not indicate test failures — the runners report green and the crash sits in runner shutdown / finalizer drain.
+Mono 6.8 on Linux occasionally writes diagnostic `mono_crash.<session>.<n>.json` files into `tests/` after Framework-TFM test runs. These are Mono runtime crash reports produced *after* assertion reporting, during runner shutdown / finalizer drain — every test still passes (the crash is post-test). The pattern is tracked by `.gitignore` so it never pollutes `git status`. CoreCLR targets (`net8.0` / `net9.0` / `net10.0`) are unaffected. Treat any such files as runner-shutdown artefacts of the Mono 6.8 host; they do not indicate a library defect.
 
 The .NET Frameworks 4.7.2, 4.8 and 4.8.1 can be found [here](https://dotnet.microsoft.com/download/dotnet-framework).
 

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -82,7 +82,11 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection, 
     internal Shares(IList<Share<TNumber>> shares)
     {
         _ = shares ?? throw new ArgumentNullException(nameof(shares));
-        var sortedShares = shares as Share<TNumber>[] ?? shares.ToArray();
+        // Always copy via ToArray(). The public implicit operator from
+        // Share<TNumber>[] reaches this ctor with caller-owned storage; an
+        // alias-cast to Share<TNumber>[] followed by Array.Sort would
+        // reorder the caller's array as a side effect of construction.
+        var sortedShares = shares.ToArray();
         Array.Sort(sortedShares);
         this.shareList = new Collection<Share<TNumber>>(sortedShares);
     }

--- a/src/Math/ExtendedEuclideanAlgorithm.cs
+++ b/src/Math/ExtendedEuclideanAlgorithm.cs
@@ -111,19 +111,23 @@ public sealed class ExtendedEuclideanAlgorithm<TNumber> : IExtendedGcdAlgorithm<
             var result = new ExtendedGcdResult<TNumber>(rPrev, coefficients, quotients);
 
             // Ownership of these calculators is now held by `result`. Null the locals
-            // so the catch block below does not double-dispose values the result owns.
+            // so the finally block below does not double-dispose values the result owns.
             rPrev = sPrev = tPrev = sCur = tCur = null;
             return result;
         }
-        catch
+        finally
         {
+            // sCur / sPrev / tCur / tPrev / rCur / rPrev are nulled on the success
+            // path above and non-null on a throw between their allocation and the
+            // ownership-transfer line — null-conditional disposal handles both.
+            // Mirrors the ownership-transfer cleanup pattern in
+            // MersenneSafeGcdAlgorithm.Compute.
             sCur?.Dispose();
             sPrev?.Dispose();
             tCur?.Dispose();
             tPrev?.Dispose();
             rCur?.Dispose();
             rPrev?.Dispose();
-            throw;
         }
     }
 }

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -16,8 +16,9 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("1c21b99c-2de4-4ca5-b4ce-bc95cf89369e")]
 
-[assembly: AssemblyVersion("0.14.0")]
-[assembly: AssemblyFileVersion("0.14.0")]
+[assembly: AssemblyVersion("1.0.1")]
+[assembly: AssemblyFileVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1-rc01")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -11,14 +11,14 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <PackageId>SecretSharingDotNet</PackageId>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v0.14.0/CHANGELOG.md</PackageReleaseNotes>
+        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v1.0.1-rc01/CHANGELOG.md</PackageReleaseNotes>
         <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
         <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
         <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>0.14.0</Version>
+        <Version>1.0.1-rc01</Version>
         <Authors>Sebastian Walther</Authors>
         <Company>Private Person</Company>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/tests/Cryptography/BigInteger/SharesTest.cs
+++ b/tests/Cryptography/BigInteger/SharesTest.cs
@@ -373,6 +373,43 @@ public class SharesTest
     }
 
     /// <summary>
+    /// Regression test against the <see cref="Shares{TNumber}"/> ctor sorting the
+    /// caller-owned array in place. The public implicit operator from
+    /// <see cref="Share{TNumber}"/>[] reaches the internal ctor; an alias-cast there
+    /// followed by <see cref="Array.Sort{T}(T[])"/> would reorder the caller's array
+    /// as a side effect of construction. Reported by codex on PR #308 against the
+    /// v1.0.1-rc01 release candidate. The test asserts both halves: the caller's
+    /// array keeps its original ordering, and the wrapped collection is still sorted
+    /// internally (so the defensive copy does not break the sort contract).
+    /// </summary>
+    [Fact]
+    public void ImplicitOperatorFromArray_DoesNotMutateCallerArray()
+    {
+        // Arrange — three shares laid out in reverse-of-index order so an in-place
+        // sort would visibly reorder the caller's array.
+        using var p3 = "3-300".ToPinnedSecure();
+        using var p1 = "1-100".ToPinnedSecure();
+        using var p2 = "2-200".ToPinnedSecure();
+        using var s3 = new Share<BigInteger>(p3);
+        using var s1 = new Share<BigInteger>(p1);
+        using var s2 = new Share<BigInteger>(p2);
+        var callerArray = new[] { s3, s1, s2 };
+
+        // Act — implicit operator wraps the caller-owned array.
+        using var wrapped = (Shares<BigInteger>)callerArray;
+
+        // Assert — caller's array still in [s3, s1, s2] order (defensive copy in ctor).
+        Assert.Same(s3, callerArray[0]);
+        Assert.Same(s1, callerArray[1]);
+        Assert.Same(s2, callerArray[2]);
+
+        // Assert — wrapped collection sorted ascending by index: [s1, s2, s3].
+        Assert.Same(s1, wrapped[0]);
+        Assert.Same(s2, wrapped[1]);
+        Assert.Same(s3, wrapped[2]);
+    }
+
+    /// <summary>
     /// <see cref="Shares{TNumber}.ToCharArray()"/> emits uppercase hex without prefix, one share per line,
     /// separated and terminated by <see cref="Environment.NewLine"/>, regardless of build configuration.
     /// </summary>

--- a/tests/Cryptography/SecureBigInteger/SharesTest.cs
+++ b/tests/Cryptography/SecureBigInteger/SharesTest.cs
@@ -413,6 +413,43 @@ public class SharesTest
     }
 
     /// <summary>
+    /// Regression test against the <see cref="Shares{TNumber}"/> ctor sorting the
+    /// caller-owned array in place. The public implicit operator from
+    /// <see cref="Share{TNumber}"/>[] reaches the internal ctor; an alias-cast there
+    /// followed by <see cref="Array.Sort{T}(T[])"/> would reorder the caller's array
+    /// as a side effect of construction. Reported by codex on PR #308 against the
+    /// v1.0.1-rc01 release candidate. The test asserts both halves: the caller's
+    /// array keeps its original ordering, and the wrapped collection is still sorted
+    /// internally (so the defensive copy does not break the sort contract).
+    /// </summary>
+    [Fact]
+    public void ImplicitOperatorFromArray_DoesNotMutateCallerArray()
+    {
+        // Arrange — three shares laid out in reverse-of-index order so an in-place
+        // sort would visibly reorder the caller's array.
+        using var p3 = "3-300".ToPinnedSecure();
+        using var p1 = "1-100".ToPinnedSecure();
+        using var p2 = "2-200".ToPinnedSecure();
+        using var s3 = new Share<SecureBigInteger>(p3);
+        using var s1 = new Share<SecureBigInteger>(p1);
+        using var s2 = new Share<SecureBigInteger>(p2);
+        var callerArray = new[] { s3, s1, s2 };
+
+        // Act — implicit operator wraps the caller-owned array.
+        using var wrapped = (Shares<SecureBigInteger>)callerArray;
+
+        // Assert — caller's array still in [s3, s1, s2] order (defensive copy in ctor).
+        Assert.Same(s3, callerArray[0]);
+        Assert.Same(s1, callerArray[1]);
+        Assert.Same(s2, callerArray[2]);
+
+        // Assert — wrapped collection sorted ascending by index: [s1, s2, s3].
+        Assert.Same(s1, wrapped[0]);
+        Assert.Same(s2, wrapped[1]);
+        Assert.Same(s3, wrapped[2]);
+    }
+
+    /// <summary>
     /// <see cref="Shares{TNumber}.ToCharArray()"/> emits uppercase hex without prefix, one share per line,
     /// separated and terminated by <see cref="Environment.NewLine"/>, regardless of build configuration.
     /// </summary>


### PR DESCRIPTION
## Summary

Back-merge of the `release-v1.0.1-rc01` branch into `develop`. Brings the release-prep commits plus the in-flight codex fix back so develop stays aligned with the release-branch state. Companion to PR #308 (`release-v1.0.1-rc01` → `main`).

## Commits coming over

Three commits ahead of develop, none diverging back:

- `bce06cc` (PR #306) — `docs(README): expand Mono runtime crash note for rc01`
- `11eeaa2` (PR #307) — `chore: prepare v1.0.1-rc01 release` (csproj `<Version>` + `AssemblyInfo` + CHANGELOG bracket-flip + README badges)
- `de64979` (PR #309) — `fix(Shares): copy ctor input to avoid sorting caller-owned array` (codex finding on PR #308; defensive-copy regression + mirrored test in both backend hierarchies)

## Why merge release → develop directly (instead of waiting for main → develop)

Classic git-flow back-merges through `main` after the release tag. Doing the back-merge to `develop` directly in parallel has two benefits:

1. **Develop catches the codex fix immediately**, without waiting for the `release → main` merge of PR #308. Any in-flight feature branches off `develop` pick up the corrected `Shares<TNumber>` ctor on their next rebase.
2. **The back-merge content is identical** either way (these three commits), so the eventual `main → develop` merge after the v1.0.1-rc01 tag is a no-op for `develop` and can be reduced to a fast-forward of the tag itself.

## Consequences for develop after this merge

The version-bump and CHANGELOG bracket-flip flow into develop with this back-merge:

- `src/SecretSharingDotNet.csproj` `<Version>` will read `1.0.1-rc01` on develop.
- `src/Properties/AssemblyInfo.cs` will carry `AssemblyVersion("1.0.1")` / `AssemblyFileVersion("1.0.1")` / `AssemblyInformationalVersion("1.0.1-rc01")`.
- `CHANGELOG.md` will have `## [1.0.1-rc01] - 2026-05-29` as its top released-version block, with no `[Unreleased]` placeholder above it.
- `README.md` badges and install snippets will read `1.0.1-rc01`.

A follow-up commit on develop (separate PR) will want to re-introduce an empty `## [Unreleased]` block above `[1.0.1-rc01]` so future develop-side entries have a place to land. That is intentionally **not** part of this back-merge — keeping this PR pure ("release-branch state → develop") makes it easy to review and to revert if anything is off.

## Merge strategy

Same `--no-ff` merge-commit rule as PR #308 — preserve the granular history (PR #306 / #307 / #309 commit boundaries) for `git bisect` / audit purposes. **Do not squash, do not rebase.**

## Test plan

- [x] Local build + test suite already verified green on `release-v1.0.1-rc01` (all 6 TFMs; 1670 / 1670 on CoreCLR, 1663 / 1663 on Framework — incl. the new `ImplicitOperatorFromArray_DoesNotMutateCallerArray` regression test). Since this PR brings the same commits over without modification, no re-verification is required on develop pre-merge.
- [ ] Post-merge follow-up on develop: re-introduce `## [Unreleased]` placeholder in `CHANGELOG.md` (separate PR).