### PR TITLE
fix(Euclidean): mirror MersenneSafeGcd cleanup pattern with finally

### DIFF
--- a/src/Math/ExtendedEuclideanAlgorithm.cs
+++ b/src/Math/ExtendedEuclideanAlgorithm.cs
@@ -111,19 +111,23 @@ public sealed class ExtendedEuclideanAlgorithm<TNumber> : IExtendedGcdAlgorithm<
             var result = new ExtendedGcdResult<TNumber>(rPrev, coefficients, quotients);
 
             // Ownership of these calculators is now held by `result`. Null the locals
-            // so the catch block below does not double-dispose values the result owns.
+            // so the finally block below does not double-dispose values the result owns.
             rPrev = sPrev = tPrev = sCur = tCur = null;
             return result;
         }
-        catch
+        finally
         {
+            // sCur / sPrev / tCur / tPrev / rCur / rPrev are nulled on the success
+            // path above and non-null on a throw between their allocation and the
+            // ownership-transfer line — null-conditional disposal handles both.
+            // Mirrors the ownership-transfer cleanup pattern in
+            // MersenneSafeGcdAlgorithm.Compute.
             sCur?.Dispose();
             sPrev?.Dispose();
             tCur?.Dispose();
             tPrev?.Dispose();
             rCur?.Dispose();
             rPrev?.Dispose();
-            throw;
         }
     }
 }


### PR DESCRIPTION
## Summary

Style-consistency change in `src/Math/ExtendedEuclideanAlgorithm.cs` — switches the `Compute` method's ownership-transfer cleanup from `catch + rethrow` to `try / finally`, matching the pattern already in `MersenneSafeGcdAlgorithm.Compute`. Surfaced by codex on PR #308 (review thread [`r3326723213`](https://github.com/shinji-san/SecretSharingDotNet/pull/308#discussion_r3326723213), P1 badge).

## What was actually wrong (and what wasn't)

The codex finding had two claims:

1. **"This method skips all cleanup."** Unfounded — verified by tracing the previous code path. The `catch` block at the bottom of `Compute` fired on any throw between the loop exit and the `return` statement, used null-conditional `?.Dispose()` on all six ownership-transfer locals (`sCur`, `sPrev`, `tCur`, `tPrev`, `rCur`, `rPrev`), and rethrew. The L115 `rPrev = sPrev = tPrev = sCur = tCur = null;` assignment happens only on the success path, so on a throw the catch block always saw the live (or already-null) loc als and disposed them correctly. `ExtendedGcdResult<TNumber>`'s ctor (`src/Math/ExtendedGcdResult.cs:56`) does all null-validation upfront before any field assignment, so partial-construction couldn't bypass the catch either.
2. **"Mirror the safe-GCD try/finally pattern."** Valid. `MersenneSafeGcdAlgorithm.Compute` (`src/Math/MersenneSafeGcdAlgorithm.cs:251-293`) uses `try { ...; transferLocals = null; return result; } finally { ...?.Dispose(); }`. Two sibling algorithms in the same namespace using two different exception-safety idioms is read-noise for the next maintainer.

This PR addresses #2 only. The previous form was functionally complete; the change is a style tightening, not a correctness fix.

## Diff shape

Three lines of effective change in `ExtendedEuclideanAlgorithm.cs`:

- `catch` → `finally`
- `throw;` removed (let the original exception propagate naturally)
- Inline comment expanded to mirror the `MersenneSafeGcdAlgorithm.Compute` finally-block's wording about null-after-transfer + null-conditional disposal, and to reference the sibling algorithm.

The `L113-114` ownership-transfer comment is updated from "catch block below" to "finally block below" to keep the in-code language consistent with the new structure.

## Side effect

The explicit `throw;` rethrow is removed. With `finally`, the original exception propagates without an additional IL rethrow op. Stack trace identity is preserved either way (both `throw;` and the finally-propagation use the same `endfinally` mechanism on CLR; only `throw exception;` would reset the trace).

## No CHANGELOG entry

The `catch + rethrow` form lived only in unreleased develop history (introduced during the `feature-SecureBigInteger` cycle). v0.14.0 had the naive leak-prone version with no exception handling at all; v1.0.1-rc01 with this commit ships try/finally. No consumer-visible behaviour change relative to the last released version — adding a `### Fixed` entry would mislead a v0.14.0 → v1.0.1-rc01 reader into thinking the catch-rethrow form had ever shipped.

## Test plan

- [x] Build green on all library + test TFMs (0 errors, 16 pre-existing warnings, all unrelated to this file).
- [x] Full test suite green on all 6 test TFMs:
  - `net8.0` / `net9.0` / `net10.0` — 1670 / 1670 each (unchanged from PR #309 baseline; this PR adds no new test).
  - `net4.7.2` / `net4.8` / `net4.8.1` — 1663 / 1663 each (unchanged from PR #309 baseline).

Existing coverage of `ExtendedEuclideanAlgorithm.Compute` runs through the reconstruction tests on the BigInteger backend; the try/finally form is exercised by every `Reconstruction(...)` call on every TFM.

## Effect on PR #308

PR #308 is `release-v1.0.1-rc01` → `main`. Once this PR lands on the release branch, PR #308 picks up the additional commit automatically. After that I'll reply on the codex thread with a verbatim acknowledgement of what was actually changed (and what wasn't) plus a link to this commit.