### PR TITLE
docs(CHANGELOG): re-introduce [Unreleased] placeholder on develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.0.1-rc01] - 2026-05-29
 
 ### Added
@@ -316,6 +318,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LICENSE.md`
 - Added `README.md`
 
+[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc01...develop
 [1.0.1-rc01]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.14.0...v1.0.1-rc01
 [0.14.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.12.0...v0.13.0


### PR DESCRIPTION
## Summary

After PR #310 back-merged `release-v1.0.1-rc01` into develop, the CHANGELOG carried `[1.0.1-rc01]` as its top-of-file entry — no `[Unreleased]` block above it. Without that placeholder, the first new develop-side entry has nowhere to land cleanly. This PR re-introduces the standard Keep-A-Changelog `[Unreleased]` block.

## Changes

Two-line addition in `CHANGELOG.md`:

- `## [Unreleased]` block inserted above `## [1.0.1-rc01] - 2026-05-29` at the top.
- `[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc01...develop` compare-link inserted above the `[1.0.1-rc01]` compare-link at the bottom.

## Why no empty `### Added` / `### Changed` / `### Fixed` subcategories

Verified against the `v0.14.0` tag: the project's existing pattern does not pre-create empty subcategory headings under `[Unreleased]`. They appear organically when the first matching entry is added. Pre-creating empty categories would deviate from the established style and create read-noise in the diff each time someone adds the first entry of a kind.

## Test plan

- [x] Pure docs change — no code touched, no build / test run required.
- [x] CHANGELOG diff is two single-line additions at distinct locations; no other content shifts.
- [x] `[Unreleased]` compare-link targets `develop` so a click from a v1.0.1-rc01 reader lands on the diff that's accumulating toward the next release.