### PR TITLE
ci: bump actions/setup-dotnet from v5.2.0 to v5.3.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.2.0
+      uses: actions/setup-dotnet@v5.3.0
       with:
         dotnet-version: |
           8.0.416

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.2.0
+      uses: actions/setup-dotnet@v5.3.0
       with:
         dotnet-version: |
           8.0.416

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.2.0
+      uses: actions/setup-dotnet@v5.3.0
       with:
         dotnet-version: |
           8.0.416


### PR DESCRIPTION
## Summary

Bumps the `actions/setup-dotnet` action from `v5.2.0` to `v5.3.0` across all three workflows for a consistent action version:

- `.github/workflows/codeql-analysis.yml`
- `.github/workflows/dotnetall.yml`
- `.github/workflows/publishing.yml`

## Scope

Workflow tooling only — no source, test, or package surface impact.