### PR TITLE
ci: add pull_request trigger and fix branch glob in build workflow

### DIFF
--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -3,9 +3,15 @@ name: SecretSharingDotNet - Build and Test All .NET Versions
 on:
   push:
     branches:
-    - '*'
+    - '**'
     tags-ignore:
-    - '*'
+    - '**'
+    paths-ignore:
+    - '**.md'
+  pull_request:
+    branches:
+    - develop
+    - main
     paths-ignore:
     - '**.md'
 


### PR DESCRIPTION
## Summary

Closes two trigger gaps in `.github/workflows/dotnetall.yml` that let build+test be silently skipped.

- **Branch glob** — `push.branches` was `['*']`. The `*` glob does not match `/` segments, so `dependabot/...` and other slash-named branches never triggered build+test. Widened to `'**'` (and aligned `tags-ignore` to `'**'`).
- **No PR gate** — there was no `pull_request` trigger, so dependabot PRs and fork PRs (which cannot push to the repo) ran no build+test at all. CodeQL runs on `pull_request` but is static analysis, not a test gate. Added a `pull_request` trigger scoped to `develop` and `main`.

```yaml
on:
  push:
    branches:
    - '**'
    tags-ignore:
    - '**'
    paths-ignore:
    - '**.md'
  pull_request:
    branches:
    - develop
    - main
    paths-ignore:
    - '**.md'
```

## Why both triggers (not redundant)

The two runs check different commits:

- The **push** run checks out the branch HEAD as-is (branch state).
- The **pull_request** run checks out the simulated merge into the base (`refs/pull/N/merge`), catching "works on the branch, breaks against current develop" drift.

Forks cannot push to the repo, so `pull_request` is the only gate that covers fork contributions.

## Scope

Workflow only — no source, test, or package surface impact.