### PR TITLE
ci: add least-privilege permissions blocks to build and publish workflows

### DIFF
--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -15,6 +15,9 @@ on:
     paths-ignore:
     - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -7,6 +7,9 @@ on:
     paths-ignore:
     - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
## Summary

Neither `dotnetall.yml` nor `publishing.yml` declared a `permissions` block, so the `GITHUB_TOKEN` ran with the repository default scope (often write). Add an explicit top-level least-privilege block to both, matching the pattern already used in `codeql-analysis.yml`.

```yaml
permissions:
  contents: read
```

## Why `contents: read` is sufficient

Both workflows only need read access:

- `dotnetall.yml` — restore/build/test/pack only reads the repo.
- `publishing.yml` — the NuGet push authenticates with the external `NUGET_API_KEY`, not the `GITHUB_TOKEN`; nothing in the workflow creates releases or comments on PRs.

OIDC trusted publishing would add `id-token: write`, but that is a separate change (out of scope here).

## Scope

Workflow only — no source, test, or package surface impact.