### PR TITLE
fix: hash only public metadata in secret-type GetHashCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `FixedIterationSecretReconstructor<TNumber>` — a `SecretReconstructor<TNumber>` that accepts only `IFixedIterationExtendedGcdAlgorithm<TNumber>` strategies (pairing it with a variable-time GCD is a compile-time error) and whose parameterless constructor defaults to `MersenneSafeGcdAlgorithm<TNumber>`.
 - Added `IFixedIterationExtendedGcdAlgorithm<TNumber>` — marker interface tagging extended-GCD strategies whose iteration count is operand-independent (removing the iteration-count side channel of a plain extended-Euclidean GCD); `MersenneSafeGcdAlgorithm<TNumber>` implements it, `ExtendedEuclideanAlgorithm<TNumber>` does not.
 
+### Changed
+- `SecureBigInteger.GetHashCode` now hashes only public metadata (sign and limb count) instead of the full limb content, so it no longer produces a value-derived hash of secret material. `Calculator<TNumber>`, `Share<TNumber>`, and `ExtendedGcdResult<TNumber>` inherit this via delegation.
+
+### Fixed
+- `Secret<TNumber>.GetHashCode` is now consistent with by-value `Secret<TNumber>.Equals`: equal secrets produce equal hash codes. It now hashes only the public payload length; previously it was identity-based (`PinnedPoolArray<T>` does not override `GetHashCode`) while equality is by value, violating the `Equals`/`GetHashCode` contract and silently breaking `Secret<TNumber>` as a dictionary/set key.
+
 ## [1.0.1-rc01] - 2026-05-29
 
 ### Added

--- a/src/Cryptography/Secret`1.cs
+++ b/src/Cryptography/Secret`1.cs
@@ -809,7 +809,12 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
     public override int GetHashCode()
     {
         this.ThrowIfDisposed();
-        return this.secretNumber?.GetHashCode() ?? 0;
+        // Hash only the public payload length, never secret content: keeps the Equals/GetHashCode
+        // contract (equal payloads share a length) without a value-derived hash, and replaces the
+        // former identity hash that broke the contract (PinnedPoolArray does not override
+        // GetHashCode). Default / content-empty secrets (null secretNumber, or only the mark byte)
+        // hash to 0.
+        return this.secretNumber is { Length: > MarkByteCount } sn ? sn.Length - MarkByteCount : 0;
     }
 
     /// <summary>

--- a/src/Math/Numerics/SecureBigInteger.cs
+++ b/src/Math/Numerics/SecureBigInteger.cs
@@ -2370,16 +2370,14 @@ public sealed class SecureBigInteger : IDisposable, IEquatable<SecureBigInteger>
     public override int GetHashCode()
     {
         this.ThrowIfDisposed();
+        // Hash only public metadata (sign + limb count), never the secret limb content: keeps the
+        // Equals/GetHashCode contract (equal values share sign + trimmed limb count) without
+        // exposing a value-derived hash of secret material.
         int len = this.limbs.Length;
 #if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
         var hash = new HashCode();
         hash.Add(this.Sign);
         hash.Add(len);
-        for (int i = 0; i < len; i++)
-        {
-            hash.Add(this.limbs[i]);
-        }
-
         return hash.ToHashCode();
 #else
         unchecked
@@ -2387,11 +2385,6 @@ public sealed class SecureBigInteger : IDisposable, IEquatable<SecureBigInteger>
             var hash = 17;
             hash = hash * 31 + this.Sign.GetHashCode();
             hash = hash * 31 + len.GetHashCode();
-            for (int i = 0; i < len; i++)
-            {
-                hash = hash * 31 + this.limbs[i].GetHashCode();
-            }
-
             return hash;
         }
 #endif

--- a/tests/Cryptography/BigInteger/SecretTest.cs
+++ b/tests/Cryptography/BigInteger/SecretTest.cs
@@ -826,6 +826,41 @@ public class SecretTest
     }
 
     /// <summary>
+    /// SEC-1 regression: <see cref="Secret{TNumber}.GetHashCode"/> is consistent with by-value
+    /// <see cref="Secret{TNumber}.Equals(Secret{TNumber})"/> — two distinct instances holding the
+    /// same payload produce equal hash codes (Equals/GetHashCode contract). Previously the hash was
+    /// identity-based, so equal secrets produced unequal hashes and Secret was broken as a hash key.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_EqualSecrets_ReturnSameHashCode()
+    {
+        // Arrange — two independently constructed secrets with the same payload bytes.
+        byte[] payload = { 0x01, 0x02, 0x03, 0x04 };
+        using var secretA = new Secret<BigInteger>(payload);
+        using var secretB = new Secret<BigInteger>(payload);
+
+        // Act & Assert — equal by value, therefore equal hash.
+        Assert.Equal(secretA, secretB);
+        Assert.Equal(secretA.GetHashCode(), secretB.GetHashCode());
+    }
+
+    /// <summary>
+    /// SEC-1 (metadata only): the hash reflects only the public payload length, never secret
+    /// content — two same-length secrets with different payloads produce the same hash.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_SameLengthDifferentPayload_ReturnSameHashCode()
+    {
+        // Arrange — equal payload length (4 bytes), different content.
+        using var secretA = new Secret<BigInteger>(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        using var secretB = new Secret<BigInteger>(new byte[] { 0x11, 0x22, 0x33, 0x44 });
+
+        // Act & Assert — different payloads, but the hash carries only the length.
+        Assert.NotEqual(secretA, secretB);
+        Assert.Equal(secretA.GetHashCode(), secretB.GetHashCode());
+    }
+
+    /// <summary>
     /// Regression guard for ultrareview Bug 4: <see cref="Secret{TNumber}.ToByteArray"/>
     /// on a default-value struct returns an empty <see cref="PinnedPoolArray{Byte}"/>
     /// rather than NRE-ing on the <see langword="null"/> <c>secretNumber</c>. Without

--- a/tests/Cryptography/SecureBigInteger/SecretTest.cs
+++ b/tests/Cryptography/SecureBigInteger/SecretTest.cs
@@ -854,6 +854,41 @@ public class SecretTest
     }
 
     /// <summary>
+    /// SEC-1 regression: <see cref="Secret{TNumber}.GetHashCode"/> is consistent with by-value
+    /// <see cref="Secret{TNumber}.Equals(Secret{TNumber})"/> — two distinct instances holding the
+    /// same payload produce equal hash codes (Equals/GetHashCode contract). Previously the hash was
+    /// identity-based, so equal secrets produced unequal hashes and Secret was broken as a hash key.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_EqualSecrets_ReturnSameHashCode()
+    {
+        // Arrange — two independently constructed secrets with the same payload bytes.
+        byte[] payload = { 0x01, 0x02, 0x03, 0x04 };
+        using var secretA = new Secret<SecureBigInteger>(payload);
+        using var secretB = new Secret<SecureBigInteger>(payload);
+
+        // Act & Assert — equal by value, therefore equal hash.
+        Assert.Equal(secretA, secretB);
+        Assert.Equal(secretA.GetHashCode(), secretB.GetHashCode());
+    }
+
+    /// <summary>
+    /// SEC-1 (metadata only): the hash reflects only the public payload length, never secret
+    /// content — two same-length secrets with different payloads produce the same hash.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_SameLengthDifferentPayload_ReturnSameHashCode()
+    {
+        // Arrange — equal payload length (4 bytes), different content.
+        using var secretA = new Secret<SecureBigInteger>(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        using var secretB = new Secret<SecureBigInteger>(new byte[] { 0x11, 0x22, 0x33, 0x44 });
+
+        // Act & Assert — different payloads, but the hash carries only the length.
+        Assert.NotEqual(secretA, secretB);
+        Assert.Equal(secretA.GetHashCode(), secretB.GetHashCode());
+    }
+
+    /// <summary>
     /// Regression guard for ultrareview Bug 4: <see cref="Secret{TNumber}.ToByteArray"/>
     /// on a default-value struct returns an empty <see cref="PinnedPoolArray{Byte}"/>
     /// rather than NRE-ing on the <see langword="null"/> <c>secretNumber</c>. Without

--- a/tests/Math/Numerics/SecureBigIntegerTest.cs
+++ b/tests/Math/Numerics/SecureBigIntegerTest.cs
@@ -1722,6 +1722,23 @@ public class SecureBigIntegerTests
     }
 
     /// <summary>
+    /// Security property (SB-1): <c>GetHashCode</c> does not depend on secret value content. Two
+    /// distinct values that share the same sign and limb count produce the same hash, so the hash
+    /// carries only public metadata (sign, bit-length bucket), never value bits.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_DifferentValuesSameLimbCount_ReturnsSameHashCode()
+    {
+        // Arrange — two distinct single-limb positive values (same sign, same limb count).
+        using var operandA = new SecureBigInteger(42);
+        using var operandB = new SecureBigInteger(99);
+
+        // Act & Assert — distinct values, but the hash reflects only sign + limb count.
+        Assert.NotEqual(operandA, operandB);
+        Assert.Equal(operandA.GetHashCode(), operandB.GetHashCode());
+    }
+
+    /// <summary>
     /// Tests the <see cref="IComparable{T}"/> convention that a non-null instance
     /// compared to <see langword="null"/> returns <c>1</c>.
     /// </summary>


### PR DESCRIPTION
## Summary

The 2026-06-10 security review found two `GetHashCode` defects on the secret-bearing types:

- **Value-derived hash of secret material** — `SecureBigInteger.GetHashCode` hashed the full secret limb *content*, so a `GetHashCode()` value (Dictionary/HashSet key, log line) carried bits correlated with the secret. Atypical for a security-conscious type (BCL `SecureString` exposes no value-hash). Propagated through `Calculator<TNumber>`, `Share<TNumber>`, and `ExtendedGcdResult<TNumber>`, which delegate to it.
- **Broken Equals/GetHashCode contract on `Secret<TNumber>`** — `Secret.GetHashCode` was identity-based (`PinnedPoolArray<T>` does not override `GetHashCode`) while `Secret.Equals` is by value, so equal secrets produced *unequal* hash codes and `Secret<TNumber>` was silently broken as a hash-collection key.

Both are fixed by the same principle: **hash only public metadata, never secret value content.**

## Changes

- `SecureBigInteger.GetHashCode` — hash **sign + limb count** only (drop the per-limb loop in both the `HashCode` and legacy branches). Transitively fixes `Calculator` / `Share` / `ExtendedGcdResult` on the `SecureBigInteger` backend. *(CHANGELOG: Changed.)*
- `Secret<TNumber>.GetHashCode` — hash the **public payload length** (`SecretByteSize` minus the mark byte; `0` for the default/empty secret) instead of the `secretNumber` identity hash. *(CHANGELOG: Fixed.)*

Sign, limb count, and payload length are already public (the threat model treats bit-length as observable; serialized share/secret sizes reveal it), so the hash leaks nothing new, while equal values/secrets still share that metadata and hash equal — the `Equals`/`GetHashCode` contract holds. Distribution is intentionally weak for same-security-level field elements (they share a limb count) — acceptable: these are equal-value/secret-content types, not high-performance hash keys.

## Tests

Added, and proven fails-before → passes-after:
- `SecureBigIntegerTest` — two distinct values with the same sign and limb count hash equal (documents that the hash carries no value content).
- `SecretTest` (both backend hierarchies) — equal-payload secrets hash equal (the contract regression), and same-length different-payload secrets hash equal (metadata-only).

All existing GetHashCode tests (zero-equality, same-value-equality, disposed-throws, default-secret-no-throw) are preserved; no test asserted distinct→distinct hashes.

## Verification

- `dotnet build --configuration Release` — 0 errors.
- Full single-threaded suite green on all six TFMs: net8.0/9.0/10.0 → 1685 tests; net4.7.2/4.8/4.8.1 → 1678 tests; 0 failures. (+5 new tests.)
