### PR TITLE
ci: fix .nupk -> .nupkg typo in publish cleanup glob

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -43,7 +43,7 @@ jobs:
       run: dotnet test --no-restore --no-build --configuration Release SecretSharingDotNet.slnx -- RunConfiguration.TargetPlatform=x64 RunConfiguration.MaxCpuCount=1  xUnit.AppDomain=denied xUnit.ParallelizeAssembly=false xUnit.ParallelizeTestCollections=false
 
     - name: Remove obsolete NuGet packages
-      run: rm -f src/bin/Release/SecretSharingDotNet*.nupk
+      run: rm -f src/bin/Release/SecretSharingDotNet*.nupkg
 
     - name: Prepare README.md for NuGet package
       run: |


### PR DESCRIPTION
## Summary

`CI-5` from the CI-workflow review. The **Remove obsolete NuGet packages** step in `publishing.yml` globbed `SecretSharingDotNet*.nupk` — the extension is missing the trailing `g`, so the glob matched nothing and the step was a dead no-op, contrary to its name. It never removed a pre-existing package before `dotnet pack`.

## Change

One-character fix on `.github/workflows/publishing.yml`:

```diff
-      run: rm -f src/bin/Release/SecretSharingDotNet*.nupk
+      run: rm -f src/bin/Release/SecretSharingDotNet*.nupkg
```

## Notes

- The downstream **Publish package** step already globs the correct `SecretSharingDotNet*.nupkg`, so this only restores the defensive pre-pack cleanup to what its name promises.
- Low behavioural risk: a fresh CI runner has no stale packages before `dotnet pack`, and `dotnet nuget push --skip-duplicate` further guards the push. The workflow only triggers on a `v*` tag push, so end-to-end validation happens at the next release cut.
- Verified this is the only `.nupk` occurrence in `.github/`. `dotnetall.yml` has no cleanup step and is unaffected. No CHANGELOG entry (CI-only, non-consumer-facing — consistent with the CI-1/CI-2 PRs).