### PR TITLE
ci: clean CodeQL template boilerplate and add actions scanning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,21 +1,9 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "SecretSharingDotNet - CodeQL"
 
 on:
   push:
     branches: [ develop, main ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ develop, main ]
   schedule:
     - cron: '18 17 * * 4'
@@ -32,16 +20,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+        language: [ 'csharp', 'actions' ]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
 
+    # The .NET build steps apply only to the C# analysis; 'actions' is a no-build
+    # CodeQL language, so its matrix leg skips setup / restore / build.
     - name: Setup .NET SDKs
+      if: matrix.language == 'csharp'
       uses: actions/setup-dotnet@v5.4.0
       with:
         dotnet-version: |
@@ -49,37 +37,18 @@ jobs:
           9.0.307
           10.0.100
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
-  
     - name: Restore
+      if: matrix.language == 'csharp'
       run: dotnet restore SecretSharingDotNet.slnx
 
     - name: Build
+      if: matrix.language == 'csharp'
       run: dotnet build --configuration Release SecretSharingDotNet.slnx
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

`CI-7` from the CI-workflow review. Two changes to `.github/workflows/codeql-analysis.yml`:

1. **Remove stale GitHub-template boilerplate** — the header block, subset-branches comment, `# CodeQL supports [...]` + learn-more hint, custom-queries hint, the commented-out Autobuild step, and the manual-build block. All irrelevant since the workflow uses explicit `dotnet restore` + `dotnet build` steps.
2. **Add `actions` to the CodeQL language matrix** so CodeQL scans the workflow YAML itself (script injection, over-privileged tokens) — relevant for a repo whose publish pipeline decrypts a signing key and holds `NUGET_API_KEY`.

## How the matrix stays cheap

The .NET build steps (**Setup .NET**, **Restore**, **Build**) are guarded with `if: matrix.language == 'csharp'`. `actions` is a no-build CodeQL language, so its matrix leg runs only checkout → init → analyze. The `csharp` leg is unchanged (checkout → setup → init → restore → build → analyze; init still precedes the build as CodeQL requires).

## Notes

- End-to-end validation happens on this PR: the CodeQL workflow triggers on `pull_request → [develop, main]`, so both matrix legs run in the PR checks.
- The new `actions` leg may surface fresh CodeQL alerts on the workflows — that is the intent; triage separately, not a blocker for this PR.
- CI-only, non-consumer-facing — no CHANGELOG entry (consistent with the CI-1/CI-2/CI-5 PRs). Actions remain tag-pinned (`@v4`, `@v7`); SHA-pinning is tracked separately as CI-3.