### PR TITLE
ci: add concurrency blocks to build and CodeQL workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '18 17 * * 4'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -15,6 +15,10 @@ on:
     paths-ignore:
     - '**.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

`CI-6` from the CI-workflow review. Neither `dotnetall.yml` (build+test) nor `codeql-analysis.yml` declared a `concurrency:` group, so rapid successive pushes to the same branch/PR spawned redundant parallel runs, wasting runner minutes. Add a standard group with `cancel-in-progress` to both:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Behaviour

- `${{ github.workflow }}` namespaces the group per workflow (the two never collide).
- Grouping by `${{ github.ref }}` keeps **push** runs (`refs/heads/*`) and **pull_request** runs (`refs/pull/*/merge`) in **separate** groups — the complementary push+PR runs introduced in CI-1 are preserved; only successive runs of the *same* ref cancel each other.
- `cancel-in-progress: true` supersedes an in-flight run with a newer one for that ref (standard CI behaviour; for CodeQL a push during the weekly scan simply yields a scan of the newer commit).

## Notes

- **`publishing.yml` is intentionally excluded**: it triggers only on unique `v*` tags (no redundancy to collapse), and cancelling an in-flight NuGet publish / signing-key run would be unsafe.
- CI-only, non-consumer-facing — no CHANGELOG entry (consistent with the CI-1/CI-2/CI-5/CI-7 PRs).