### PR TITLE
fix: SharesEnumerator.Current exception type + Shares.Dispose doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `Secret<TNumber>.GetHashCode` is now consistent with by-value `Secret<TNumber>.Equals`: equal secrets produce equal hash codes. It now hashes only the public payload length; previously it was identity-based (`PinnedPoolArray<T>` does not override `GetHashCode`) while equality is by value, violating the `Equals`/`GetHashCode` contract and silently breaking `Secret<TNumber>` as a dictionary/set key.
+- `SharesEnumerator<TNumber>.Current` now throws `InvalidOperationException` when accessed before the first `MoveNext` or past the end, per the `IEnumerator` contract. Previously it caught `IndexOutOfRangeException`, which the backing `ReadOnlyCollection` indexer never throws (it throws `ArgumentOutOfRangeException`), so the raw `ArgumentOutOfRangeException` surfaced instead.
 
 ## [1.0.1-rc01] - 2026-05-29
 

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -578,9 +578,9 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection, 
     /// are no-ops.
     /// </summary>
     /// <remarks>
-    /// <b>Ownership:</b> a <see cref="Shares{TNumber}"/> collection owns every share it contains.
-    /// Disposing the collection disposes all contained shares. Shares removed via
-    /// <see cref="Remove"/> are returned to the caller, who then owns disposal.
+    /// <b>Ownership:</b> a <see cref="Shares{TNumber}"/> collection owns every share it contains, and
+    /// disposing the collection disposes them all. The collection is read-only, so there is no removal
+    /// path (<see cref="Remove"/> throws) that hands an individual share's ownership back to the caller.
     /// </remarks>
     public void Dispose()
     {

--- a/src/Cryptography/SharesEnumerator.cs
+++ b/src/Cryptography/SharesEnumerator.cs
@@ -110,7 +110,7 @@ public sealed class SharesEnumerator<TNumber> : IEnumerator<Share<TNumber>>
             {
                 return this.shareList[this.position];
             }
-            catch (IndexOutOfRangeException)
+            catch (ArgumentOutOfRangeException)
             {
                 throw new InvalidOperationException();
             }

--- a/tests/Cryptography/BigInteger/SharesTest.cs
+++ b/tests/Cryptography/BigInteger/SharesTest.cs
@@ -150,6 +150,25 @@ public class SharesTest
     }
 
     /// <summary>
+    /// Regression (SE-1): <see cref="System.Collections.IEnumerator.Current"/> must throw
+    /// <see cref="InvalidOperationException"/> when accessed before the first <c>MoveNext</c>
+    /// (undefined position per the enumerator contract). Previously the getter surfaced the raw
+    /// <see cref="ArgumentOutOfRangeException"/> from the backing indexer.
+    /// </summary>
+    [Fact]
+    public void GetEnumerator_CurrentBeforeMoveNext_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var lines = TestData.GetPredefinedShares().ToPinnedSecureShareLines();
+        using var shares = Shares<BigInteger>.FromTextLines(lines);
+        var enumerator = ((IEnumerable)shares).GetEnumerator();
+        using var disposable = enumerator as IDisposable;
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => _ = enumerator.Current);
+    }
+
+    /// <summary>
     /// Tests that <see cref="Shares{TNumber}.Count"/> reports the number of shares parsed
     /// from the pre-defined predefined-shares fixture.
     /// </summary>

--- a/tests/Cryptography/SecureBigInteger/SharesTest.cs
+++ b/tests/Cryptography/SecureBigInteger/SharesTest.cs
@@ -193,6 +193,25 @@ public class SharesTest
     }
 
     /// <summary>
+    /// Regression (SE-1): <see cref="System.Collections.IEnumerator.Current"/> must throw
+    /// <see cref="InvalidOperationException"/> when accessed before the first <c>MoveNext</c>
+    /// (undefined position per the enumerator contract). Previously the getter surfaced the raw
+    /// <see cref="ArgumentOutOfRangeException"/> from the backing indexer.
+    /// </summary>
+    [Fact]
+    public void GetEnumerator_CurrentBeforeMoveNext_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var lines = TestData.GetPredefinedShares().ToPinnedSecureShareLines();
+        using var shares = Shares<SecureBigInteger>.FromTextLines(lines);
+        var enumerator = ((IEnumerable)shares).GetEnumerator();
+        using var disposable = enumerator as IDisposable;
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => _ = enumerator.Current);
+    }
+
+    /// <summary>
     /// Tests that <see cref="Shares{TNumber}.Count"/> reports the number of shares parsed
     /// from the pre-defined predefined-shares fixture.
     /// </summary>


### PR DESCRIPTION
## Summary

Two small, verified correctness nits in the `Shares` area (bundled):

- **SE-1** — `SharesEnumerator<TNumber>.Current` caught `IndexOutOfRangeException`, but the backing `ReadOnlyCollection` indexer throws `ArgumentOutOfRangeException`, so the catch was **dead code**. Accessing `Current` before the first `MoveNext` (or past the end) surfaced the raw `ArgumentOutOfRangeException` instead of the `IEnumerator` contract's `InvalidOperationException`.
- **SH-2** — the `Shares<TNumber>.Dispose` `<remarks>` claimed shares removed via `Remove` are returned to the caller, but `Remove` always throws `NotSupportedException` (the collection is read-only). Stale/misleading doc.

## Changes

- `SharesEnumerator.cs` — correct the caught type: `catch (IndexOutOfRangeException)` → `catch (ArgumentOutOfRangeException)`. The existing try/catch structure and the parameterless `InvalidOperationException` translation are preserved (minimal, surgical — no structural rewrite).
- `Shares.cs` — correct the Dispose ownership note to reflect the read-only reality (no removal path hands a share's ownership back).
- `CHANGELOG.md` — one `Fixed` entry for SE-1 (SH-2 is doc-only).

## Tests

- Added `GetEnumerator_CurrentBeforeMoveNext_ThrowsInvalidOperationException` in **both** backend hierarchies, proven **fails-before → passes-after** (before: `ArgumentOutOfRangeException`; after: `InvalidOperationException`).
- Existing enumerator tests only touch `Current` at valid positions (after `MoveNext`), so they are unaffected.

## Verification

- `dotnet build --configuration Release` — 0 errors.
- Full single-threaded suite green on all six TFMs: net8.0/9.0/10.0 → 1687 tests; net4.7.2/4.8/4.8.1 → 1680 tests; 0 failures (+2 new).