### PR TITLE
ci: use NuGet Trusted Publishing (OIDC) for package push

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write   # OIDC token for NuGet Trusted Publishing
 
 jobs:
   build:
@@ -53,5 +54,11 @@ jobs:
     - name: Create package
       run: dotnet pack --no-restore --no-build --configuration Release SecretSharingDotNet.slnx
 
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Publish package
-      run: dotnet nuget push $(find src/bin/Release -type f  -name 'SecretSharingDotNet*.nupkg' -print 2> /dev/null) -k  ${{ secrets.NUGET_API_KEY }}  -s https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push $(find src/bin/Release -type f  -name 'SecretSharingDotNet*.nupkg' -print 2> /dev/null) -k  ${{ steps.login.outputs.NUGET_API_KEY }}  -s https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary

`CI-4` from the CI-workflow review. `publishing.yml` authenticated the NuGet push with a long-lived `NUGET_API_KEY` secret. Replace it with **NuGet.org Trusted Publishing**: the job mints a short-lived GitHub OIDC token, exchanges it at nuget.org for a temporary (1-hour, single-use) API key, and pushes with that — eliminating the stored publish secret. This closes the loop `CI-2` left open (`id-token: write` was scoped to CI-4).

## Changes

- Add `id-token: write` to the workflow `permissions` block so the job can request a GitHub OIDC token.
- Add a `NuGet/login@v1` step immediately before the push, so the 1-hour key is minted seconds before it is used.
- Push with `${{ steps.login.outputs.NUGET_API_KEY }}` instead of `${{ secrets.NUGET_API_KEY }}`; `secrets.NUGET_API_KEY` is no longer referenced.

## Notes

- The Trusted Publishing **policy** (owner `shinji-san`, repo `SecretSharingDotNet`, workflow file `publishing.yml`, no environment) is configured on nuget.org.
- The `NuGet/login` `user:` input reads a `NUGET_USER` repo secret holding the nuget.org **profile name** (not the email).
- `NuGet/login@v1` stays **tag-pinned**, consistent with the other actions in this file (`actions/checkout@v7`, `actions/setup-dotnet@v5.4.0`); it will join the CI-3 SHA-pinning sweep.
- Strong-name signing (`decrypt_publisher_snk.sh`) and the `v*`-tag trigger are untouched.
- CI-only, non-consumer-facing — no CHANGELOG entry (consistent with the CI-1/2/5/6/7 PRs).

## Verification

- Workflow-YAML-only change: the .NET build/test suite does not exercise it and is not a gate here. YAML parses cleanly; `permissions` = `{contents: read, id-token: write}`; step order is `Create package` → `NuGet login` → `Publish package`.
- The OIDC exchange only runs in a real Actions job, so the end-to-end check is the **next `v*` release**: the `NuGet login` step must obtain a temp key and `dotnet nuget push` must succeed. The `NUGET_API_KEY` secret is kept as revert insurance until that release is green.
