### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # The .NET build steps apply only to the C# analysis; 'actions' is a no-build
     # CodeQL language, so its matrix leg skips setup / restore / build.
     - name: Setup .NET SDKs
       if: matrix.language == 'csharp'
-      uses: actions/setup-dotnet@v5.4.0
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: |
           8.0.416
@@ -42,7 +42,7 @@ jobs:
           10.0.100
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         languages: ${{ matrix.language }}
 
@@ -55,4 +55,4 @@ jobs:
       run: dotnet build --configuration Release SecretSharingDotNet.slnx
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -29,10 +29,10 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.4.0
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: |
           8.0.416

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -18,10 +18,10 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.4.0
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: |
           8.0.416
@@ -55,7 +55,7 @@ jobs:
       run: dotnet pack --no-restore --no-build --configuration Release SecretSharingDotNet.slnx
 
     - name: NuGet login (OIDC → temp API key)
-      uses: NuGet/login@v1
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
       id: login
       with:
         user: ${{ secrets.NUGET_USER }}


### PR DESCRIPTION
## Summary

`CI-3` from the CI-workflow review — the last open CI item. Every `uses:` reference across the three workflows pointed at a **mutable Git tag** (`@v7`, `@v5.4.0`, `@v4`, `@v1`). A tag is a movable pointer: a compromised or re-pointed tag makes the next run silently execute different code with the job's secrets and `GITHUB_TOKEN` in scope — acute in `publishing.yml`, which decrypts the strong-name signing key and pushes a signed crypto package. Precedent: `tj-actions/changed-files` (CVE-2025-30066, Mar 2025). Pin each action to an **immutable full commit SHA**.

## Changes

Replace each `@tag` with `@<40-char-sha> # <version>` — **9 lines across 3 files**. Each SHA is exactly what the tag resolved to at pin time, so there is **no behavior change**:

| Action | SHA | version |
|---|---|---|
| `actions/checkout` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` | v7.0.0 |
| `actions/setup-dotnet` | `26b0ec14cb23fa6904739307f278c14f94c95bf1` | v5.4.0 |
| `github/codeql-action/{init,analyze}` | `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` | v4.37.0 |
| `NuGet/login` | `8d196754b4036150537f80ac539e15c2f1028841` | v1.2.0 |

Also closes the `NuGet/login@v1` tag-pin that CI-4 deferred to this sweep.

## Notes

- `dependabot` (`github-actions` ecosystem, already configured) understands SHA pins and keeps them current — it bumps the SHA **and** the version comment together in a PR. Automatic updates are preserved.
- `.github/dependabot.yml` unchanged. No CHANGELOG (version-neutral DevOps, consistent with the CI-1/2/5/6/7 PRs).

## Verification

- YAML parses on all three files; no `@v…` tag remains; diff is exactly 9-for-9 lines (nothing else touched).
- This PR's own CI exercises **8 of 9 pins immediately**: the `pull_request` triggers run `dotnetall.yml` + `codeql-analysis.yml` with the pinned `checkout` / `setup-dotnet` / `codeql-action`. `publishing.yml`'s `checkout` + `setup-dotnet` share the same SHAs (validated transitively); only `NuGet/login` waits for the next `v*` release.
