### PR TITLE
feat: add internal IRandomSource seam for deterministic RNG in tests

### DIFF
--- a/src/Cryptography/CryptoRandomSource.cs
+++ b/src/Cryptography/CryptoRandomSource.cs
@@ -1,0 +1,69 @@
+// ----------------------------------------------------------------------------
+// <copyright file="CryptoRandomSource.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/10/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography;
+
+/// <summary>
+/// Default <see cref="IRandomSource"/> implementation. Forwards every draw to the
+/// cryptographically secure <see cref="SecureRandom"/> helper.
+/// </summary>
+/// <remarks>
+/// The type is stateless and immutable, so a single shared <see cref="Instance"/> backs every
+/// production draw throughout the library (no per-consumer allocation). Being stateless, it is
+/// safe for concurrent use — it delegates to the thread-safe
+/// <see cref="System.Security.Cryptography.RandomNumberGenerator"/> via <see cref="SecureRandom"/>.
+/// </remarks>
+internal sealed class CryptoRandomSource : IRandomSource
+{
+    /// <summary>
+    /// The shared, stateless instance used as the default random source throughout the library.
+    /// </summary>
+    internal static readonly IRandomSource Instance = new CryptoRandomSource();
+
+    /// <summary>
+    /// Prevents external instantiation; consumers use <see cref="Instance"/>.
+    /// </summary>
+    private CryptoRandomSource()
+    {
+    }
+
+    /// <inheritdoc/>
+    public void Fill(byte[] buffer, int offset, int count)
+    {
+        SecureRandom.Fill(buffer, offset, count);
+    }
+
+    /// <inheritdoc/>
+    public int NextInt32(int fromInclusive, int toExclusive)
+    {
+        return SecureRandom.NextInt32(fromInclusive, toExclusive);
+    }
+}

--- a/src/Cryptography/IRandomSource.cs
+++ b/src/Cryptography/IRandomSource.cs
@@ -1,0 +1,85 @@
+// ----------------------------------------------------------------------------
+// <copyright file="IRandomSource.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/10/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography;
+
+using System;
+
+/// <summary>
+/// Abstraction over the random primitives consumed by the secret-sharing pipeline
+/// (random secret generation, polynomial coefficients, and the termination byte).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default implementation is <see cref="CryptoRandomSource"/>, which delegates to the
+/// cryptographically secure <see cref="SecureRandom"/> helper. The seam exists so that tests
+/// can substitute a deterministic source; it is deliberately <see langword="internal"/> — a
+/// production <see cref="Secret{TNumber}"/> or
+/// <see cref="ShamirsSecretSharing.SecretSplitter{TNumber}"/> must be backed by a
+/// cryptographically secure generator, because a weak or seeded source undermines the secrecy
+/// of Shamir's scheme.
+/// </para>
+/// <para>
+/// <b>Thread safety:</b> an implementation used to back a <see cref="Secret{TNumber}"/> or
+/// <see cref="ShamirsSecretSharing.SecretSplitter{TNumber}"/> instance that is shared across
+/// threads must be safe for concurrent use. The default <see cref="CryptoRandomSource"/>
+/// satisfies this: it is stateless and delegates to the thread-safe
+/// <see cref="System.Security.Cryptography.RandomNumberGenerator"/>.
+/// </para>
+/// </remarks>
+internal interface IRandomSource
+{
+    /// <summary>
+    /// Fills <paramref name="count"/> bytes of <paramref name="buffer"/> starting at
+    /// <paramref name="offset"/> with random data.
+    /// </summary>
+    /// <param name="buffer">The destination buffer.</param>
+    /// <param name="offset">The offset into <paramref name="buffer"/> at which to start writing.</param>
+    /// <param name="count">The number of bytes to write.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="offset"/> or <paramref name="count"/> is negative, or the requested range
+    /// would extend past the end of <paramref name="buffer"/>.
+    /// </exception>
+    void Fill(byte[] buffer, int offset, int count);
+
+    /// <summary>
+    /// Returns a uniform random integer in
+    /// <c>[<paramref name="fromInclusive"/>, <paramref name="toExclusive"/>)</c>.
+    /// </summary>
+    /// <param name="fromInclusive">Inclusive lower bound of the result.</param>
+    /// <param name="toExclusive">Exclusive upper bound of the result. Must be greater than <paramref name="fromInclusive"/>.</param>
+    /// <returns>A uniformly distributed integer in the requested range.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="toExclusive"/> is not greater than <paramref name="fromInclusive"/>.
+    /// </exception>
+    int NextInt32(int fromInclusive, int toExclusive);
+}

--- a/src/Cryptography/Secret`1.cs
+++ b/src/Cryptography/Secret`1.cs
@@ -130,12 +130,35 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
     /// Thrown when <paramref name="length"/> is negative or greater than the length of <paramref name="secretSource"/>.
     /// </exception>
 #if NET8_0_OR_GREATER
-    public Secret(ReadOnlySpan<byte> secretSource, int length)
+    public Secret(ReadOnlySpan<byte> secretSource, int length) : this(secretSource, length, CryptoRandomSource.Instance)
+    {
+    }
+#else
+    public Secret(byte[] secretSource, int length) : this(secretSource, length, CryptoRandomSource.Instance)
+    {
+    }
+#endif
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Secret{TNumber}"/> class, drawing the
+    /// termination byte from a caller-supplied <see cref="IRandomSource"/>.
+    /// </summary>
+    /// <param name="secretSource">A secret as array of type <see cref="byte"/></param>
+    /// <param name="length">Length of the secret</param>
+    /// <param name="randomSource">The random source used to draw the termination byte.</param>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// <paramref name="secretSource"/> or <paramref name="randomSource"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="length"/> is negative or greater than the length of <paramref name="secretSource"/>.
+    /// </exception>
+#if NET8_0_OR_GREATER
+    internal Secret(ReadOnlySpan<byte> secretSource, int length, IRandomSource randomSource)
     {
         if (secretSource.IsEmpty)
         {
 #else
-    public Secret(byte[] secretSource, int length)
+    internal Secret(byte[] secretSource, int length, IRandomSource randomSource)
     {
         if (secretSource == null)
         {
@@ -158,11 +181,16 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
             throw new ArgumentException(ErrorMessages.EmptyCollection, nameof(secretSource));
         }
 
+        if (randomSource is null)
+        {
+            throw new ArgumentNullException(nameof(randomSource));
+        }
+
         this.secretNumber = new PinnedPoolArray<byte>(length + 1);
         byte maxMarkByte = length == 1 ? MinMarkByte : MaxMarkByte;
-        // Termination byte uniformly distributed over [1, maxMarkByte]. SecureRandom.NextInt32
+        // Termination byte uniformly distributed over [1, maxMarkByte]. IRandomSource.NextInt32
         // performs rejection sampling internally — no `% maxMarkByte` modulo bias.
-        this.secretNumber.PoolArray[length] = (byte)SecureRandom.NextInt32(1, maxMarkByte + 1);
+        this.secretNumber.PoolArray[length] = (byte)randomSource.NextInt32(1, maxMarkByte + 1);
 #if NET8_0_OR_GREATER
         secretSource[..length].CopyTo(this.secretNumber.PoolArray);
 #else
@@ -1087,8 +1115,20 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
     /// <remarks>Use this ctor to create a random secret</remarks>
     internal static Secret<TNumberStatic> CreateRandom<TNumberStatic>(Calculator<TNumberStatic> prime)
     {
+        return CreateRandom(prime, CryptoRandomSource.Instance);
+    }
+
+    /// <summary>
+    /// Creates a random secret, drawing all random data from a caller-supplied
+    /// <see cref="IRandomSource"/>.
+    /// </summary>
+    /// <param name="prime">mersenne prime number</param>
+    /// <param name="randomSource">The random source used for the secret bytes and the termination byte.</param>
+    /// <remarks>Use this overload to create a random secret from a specific random source.</remarks>
+    internal static Secret<TNumberStatic> CreateRandom<TNumberStatic>(Calculator<TNumberStatic> prime, IRandomSource randomSource)
+    {
         using var randomSecretBytes = new PinnedPoolArray<byte>(prime.ByteCount);
-        SecureRandom.Fill(randomSecretBytes.PoolArray, 0, randomSecretBytes.Length);
+        randomSource.Fill(randomSecretBytes.PoolArray, 0, randomSecretBytes.Length);
 
         int i = randomSecretBytes.Length - 1;
         while (i > 0)
@@ -1108,13 +1148,13 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
                 // Fresh instance per call — must not alias a static singleton, because
                 // the caller's `using` would dispose the shared backing buffer and break
                 // every subsequent zero-draw return.
-                return new Secret<TNumberStatic>([0x00], 1);
+                return new Secret<TNumberStatic>([0x00], 1, randomSource);
             }
 
             randomSecretBytes.PoolArray[i--] = 0x00;
         }
 
         using var secretBytes = randomSecretBytes.Subset(0, randomSecretBytes.Length - (randomSecretBytes.Length - i));
-        return new Secret<TNumberStatic>(secretBytes.PoolArray, secretBytes.Length);
+        return new Secret<TNumberStatic>(secretBytes.PoolArray, secretBytes.Length, randomSource);
     }
 }

--- a/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
@@ -74,6 +74,12 @@ public sealed class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     private readonly bool ownsSecurityLevelManager;
 
     /// <summary>
+    /// The random source used for the polynomial coefficients and the random secret. Defaults to
+    /// <see cref="CryptoRandomSource.Instance"/>; a deterministic source may be injected for testing.
+    /// </summary>
+    private readonly IRandomSource randomSource;
+
+    /// <summary>
     /// Disposal flag manipulated atomically via <see cref="Interlocked.Exchange(ref int, int)"/>:
     /// 0 = alive, 1 = disposed.
     /// </summary>
@@ -88,6 +94,7 @@ public sealed class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     {
         this.securityLevelManager = new SecurityLevelManager<TNumber>();
         this.ownsSecurityLevelManager = true;
+        this.randomSource = CryptoRandomSource.Instance;
     }
 
     /// <summary>
@@ -103,6 +110,24 @@ public sealed class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     {
         this.securityLevelManager = securityLevelManager ?? throw new ArgumentNullException(nameof(securityLevelManager));
         this.ownsSecurityLevelManager = false;
+        this.randomSource = CryptoRandomSource.Instance;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SecretSplitter{TNumber}"/> class using a default
+    /// <see cref="SecurityLevelManager{TNumber}"/> (owned by this instance and disposed together with
+    /// it) and a caller-supplied <see cref="IRandomSource"/>. Intended for testing with a
+    /// deterministic random source.
+    /// </summary>
+    /// <param name="randomSource">The random source used for the polynomial coefficients and the random secret.</param>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="randomSource"/> parameter is <see langword="null"/>.
+    /// </exception>
+    internal SecretSplitter(IRandomSource randomSource)
+    {
+        this.securityLevelManager = new SecurityLevelManager<TNumber>();
+        this.ownsSecurityLevelManager = true;
+        this.randomSource = randomSource ?? throw new ArgumentNullException(nameof(randomSource));
     }
 
     /// <summary>
@@ -198,7 +223,7 @@ public sealed class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
             throw new InvalidOperationException(ErrorMessages.SecurityLevelNotInitialized);
         }
 
-        generatedSecret = Secret<TNumber>.CreateRandom(this.securityLevelManager.MersennePrime);
+        generatedSecret = Secret<TNumber>.CreateRandom(this.securityLevelManager.MersennePrime, this.randomSource);
         Calculator<TNumber>[] polynomial = null;
         try
         {
@@ -359,7 +384,7 @@ public sealed class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
             {
                 while (true)
                 {
-                    SecureRandom.Fill(randomBytePool.PoolArray, 0, mersennePrimeByteCount);
+                    this.randomSource.Fill(randomBytePool.PoolArray, 0, mersennePrimeByteCount);
                     using var randomValue = Calculator.Create<TNumber>(randomBytePool.PoolArray, randomBytePool.Length);
 
                     if (randomValue >= rangeBound)

--- a/tests/Cryptography/CryptoRandomSourceTest.cs
+++ b/tests/Cryptography/CryptoRandomSourceTest.cs
@@ -1,0 +1,115 @@
+// ----------------------------------------------------------------------------
+// <copyright file="CryptoRandomSourceTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/10/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+
+namespace SecretSharingDotNetTest.Cryptography;
+
+using SecretSharingDotNet.Cryptography;
+using System;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="CryptoRandomSource"/> — the default <see cref="IRandomSource"/>
+/// implementation forwarding to <see cref="SecureRandom"/>. Verifies the shared instance and
+/// that the two forwarded operations honour the <see cref="IRandomSource"/> contract.
+/// </summary>
+public class CryptoRandomSourceTest
+{
+    /// <summary>
+    /// Tests that the shared <see cref="CryptoRandomSource.Instance"/> is available (used as the
+    /// default random source throughout the library).
+    /// </summary>
+    [Fact]
+    public void Instance_IsNotNull()
+    {
+        // Act & Assert
+        Assert.NotNull(CryptoRandomSource.Instance);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CryptoRandomSource.Fill"/> forwards the argument contract of
+    /// <see cref="SecureRandom.Fill"/> — a <see langword="null"/> buffer is rejected with
+    /// <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Fill_NullBuffer_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentNullException>(() => CryptoRandomSource.Instance.Fill(null!, 0, 0));
+        Assert.Equal("buffer", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CryptoRandomSource.Fill"/> writes only within the requested
+    /// <c>[offset, offset + count)</c> window and leaves the surrounding bytes untouched.
+    /// </summary>
+    [Fact]
+    public void Fill_WritesOnlyWithinRequestedRange()
+    {
+        // Arrange — sentinel-filled buffer; fill only the middle 8 bytes.
+        var buffer = new byte[16];
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = 0xAA;
+        }
+
+        // Act
+        CryptoRandomSource.Instance.Fill(buffer, 4, 8);
+
+        // Assert — bytes outside [4, 12) are still the sentinel.
+        for (int i = 0; i < 4; i++)
+        {
+            Assert.Equal((byte)0xAA, buffer[i]);
+        }
+
+        for (int i = 12; i < buffer.Length; i++)
+        {
+            Assert.Equal((byte)0xAA, buffer[i]);
+        }
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CryptoRandomSource.NextInt32"/> returns values within the
+    /// half-open range <c>[fromInclusive, toExclusive)</c> across many draws.
+    /// </summary>
+    [Fact]
+    public void NextInt32_StaysWithinRequestedRange()
+    {
+        // Act & Assert — 1000 draws must all land in [1, 128).
+        for (int i = 0; i < 1000; i++)
+        {
+            int value = CryptoRandomSource.Instance.NextInt32(1, 128);
+            Assert.InRange(value, 1, 127);
+        }
+    }
+}

--- a/tests/Cryptography/DeterministicRandomSource.cs
+++ b/tests/Cryptography/DeterministicRandomSource.cs
@@ -1,0 +1,100 @@
+// ----------------------------------------------------------------------------
+// <copyright file="DeterministicRandomSource.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/10/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+
+namespace SecretSharingDotNetTest.Cryptography;
+
+using SecretSharingDotNet.Cryptography;
+using System;
+
+/// <summary>
+/// Deterministic <see cref="IRandomSource"/> test double backed by a seeded
+/// <see cref="Random"/>. Given the same seed it reproduces the same byte and integer stream,
+/// which makes the split output (random secret + polynomial coefficients) reproducible in tests.
+/// </summary>
+/// <remarks>
+/// This double is <b>not</b> cryptographically secure and <b>not</b> thread-safe — it exists
+/// solely to exercise the <see cref="IRandomSource"/> seam under the single-threaded test harness.
+/// Its argument guards mirror <see cref="SecureRandom"/> so it is a faithful stand-in.
+/// </remarks>
+internal sealed class DeterministicRandomSource : IRandomSource
+{
+    /// <summary>
+    /// The seeded pseudo-random generator producing the deterministic stream.
+    /// </summary>
+    private readonly Random random;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeterministicRandomSource"/> class.
+    /// </summary>
+    /// <param name="seed">Seed for the underlying <see cref="Random"/>; equal seeds yield equal streams.</param>
+    public DeterministicRandomSource(int seed)
+    {
+        this.random = new Random(seed);
+    }
+
+    /// <inheritdoc/>
+    public void Fill(byte[] buffer, int offset, int count)
+    {
+        if (buffer is null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        if (offset < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(offset));
+        }
+
+        if (count < 0 || offset + count > buffer.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        for (int i = 0; i < count; i++)
+        {
+            buffer[offset + i] = (byte)this.random.Next(0, 256);
+        }
+    }
+
+    /// <inheritdoc/>
+    public int NextInt32(int fromInclusive, int toExclusive)
+    {
+        if (toExclusive <= fromInclusive)
+        {
+            throw new ArgumentOutOfRangeException(nameof(toExclusive));
+        }
+
+        return this.random.Next(fromInclusive, toExclusive);
+    }
+}

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/SecretSplitterTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/SecretSplitterTest.cs
@@ -325,4 +325,56 @@ public class SecretSplitterTest
 
         Assert.Equal(new BigInteger[] { 1, 2, 3, 4, 5 }, actualIndices);
     }
+
+    /// <summary>
+    /// Tests that injecting a deterministic <see cref="IRandomSource"/> makes
+    /// <see cref="SecretSplitter{TNumber}.MakeShares(int, int, int, out Secret{TNumber})"/>
+    /// fully reproducible: two splitters seeded identically produce the same random secret and
+    /// the same shares. This is the capability the RNG seam unlocks — without it the split is
+    /// non-deterministic and only round-trip assertions are possible.
+    /// </summary>
+    [Fact]
+    public void MakeShares_WithDeterministicRandomSource_ProducesReproducibleSecretAndShares()
+    {
+        // Arrange — two independent splitters, identical seed.
+        using var splitterA = new SecretSplitter<BigInteger>(new DeterministicRandomSource(20260710));
+        using var splitterB = new SecretSplitter<BigInteger>(new DeterministicRandomSource(20260710));
+
+        // Act
+        using var sharesA = splitterA.MakeShares(3, 5, 31, out var secretA);
+        using var sharesB = splitterB.MakeShares(3, 5, 31, out var secretB);
+        var sharesArrayA = new Share<BigInteger>[5];
+        var sharesArrayB = new Share<BigInteger>[5];
+        sharesA.CopyTo(sharesArrayA, 0);
+        sharesB.CopyTo(sharesArrayB, 0);
+
+        // Assert — identical generated secret and identical shares.
+        Assert.Equal(secretA, secretB);
+        Assert.Equal(sharesArrayA, sharesArrayB);
+
+        secretA.Dispose();
+        secretB.Dispose();
+    }
+
+    /// <summary>
+    /// Tests that a different seed yields a different random secret — proof that the split
+    /// output is genuinely wired to the injected <see cref="IRandomSource"/> and not a constant.
+    /// </summary>
+    [Fact]
+    public void MakeShares_WithDifferentSeeds_ProducesDifferentSecret()
+    {
+        // Arrange
+        using var splitterA = new SecretSplitter<BigInteger>(new DeterministicRandomSource(1));
+        using var splitterB = new SecretSplitter<BigInteger>(new DeterministicRandomSource(2));
+
+        // Act
+        using var sharesA = splitterA.MakeShares(3, 5, 31, out var secretA);
+        using var sharesB = splitterB.MakeShares(3, 5, 31, out var secretB);
+
+        // Assert
+        Assert.NotEqual(secretA, secretB);
+
+        secretA.Dispose();
+        secretB.Dispose();
+    }
 }

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/SecretSplitterTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/SecretSplitterTest.cs
@@ -330,4 +330,57 @@ public class SecretSplitterTest
 
         Assert.Equal(6, expectedIndex);
     }
+
+    /// <summary>
+    /// Tests that injecting a deterministic <see cref="IRandomSource"/> makes
+    /// <see cref="SecretSplitter{TNumber}.MakeShares(int, int, int, out Secret{TNumber})"/>
+    /// fully reproducible: two splitters seeded identically produce the same random secret and
+    /// the same shares. This is the capability the RNG seam unlocks — without it the split is
+    /// non-deterministic and only round-trip assertions are possible. Mirror of the BigInteger-side test.
+    /// </summary>
+    [Fact]
+    public void MakeShares_WithDeterministicRandomSource_ProducesReproducibleSecretAndShares()
+    {
+        // Arrange — two independent splitters, identical seed.
+        using var splitterA = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(20260710));
+        using var splitterB = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(20260710));
+
+        // Act
+        using var sharesA = splitterA.MakeShares(3, 5, 31, out var secretA);
+        using var sharesB = splitterB.MakeShares(3, 5, 31, out var secretB);
+        var sharesArrayA = new Share<SecureBigInteger>[5];
+        var sharesArrayB = new Share<SecureBigInteger>[5];
+        sharesA.CopyTo(sharesArrayA, 0);
+        sharesB.CopyTo(sharesArrayB, 0);
+
+        // Assert — identical generated secret and identical shares.
+        Assert.Equal(secretA, secretB);
+        Assert.Equal(sharesArrayA, sharesArrayB);
+
+        secretA.Dispose();
+        secretB.Dispose();
+    }
+
+    /// <summary>
+    /// Tests that a different seed yields a different random secret — proof that the split
+    /// output is genuinely wired to the injected <see cref="IRandomSource"/> and not a constant.
+    /// Mirror of the BigInteger-side test.
+    /// </summary>
+    [Fact]
+    public void MakeShares_WithDifferentSeeds_ProducesDifferentSecret()
+    {
+        // Arrange
+        using var splitterA = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(1));
+        using var splitterB = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(2));
+
+        // Act
+        using var sharesA = splitterA.MakeShares(3, 5, 31, out var secretA);
+        using var sharesB = splitterB.MakeShares(3, 5, 31, out var secretB);
+
+        // Assert
+        Assert.NotEqual(secretA, secretB);
+
+        secretA.Dispose();
+        secretB.Dispose();
+    }
 }


### PR DESCRIPTION
## Summary

Architecture review item **A10** (testability). `SecureRandom` is an `internal static` helper, so every random draw in the split path is a static call — the split is non-deterministic and cannot be exercised with a fixed RNG in tests (only round-trip assertions are possible). This introduces an `internal IRandomSource` abstraction, injected via `internal` constructor overloads, defaulting everywhere to the cryptographic RNG. It unlocks deterministic / golden-vector tests (and is the enabling seam for property-based tests, A14).

## Design — why the seam is `internal`, not public

A publicly injectable RNG in a secret-sharing library is a footgun: a weak or seeded source silently breaks Shamir's guarantee (predictable coefficients → the secret becomes recoverable from fewer than `k` shares). The actual driver of A10 is *testability*, which the existing `InternalsVisibleTo` seam fully serves. Keeping it `internal` also avoids freezing a new type into the v1.0 public surface. Widening `internal → public` later (e.g. for a hardware/enclave RNG consumer) is a safe, additive change; committing to public now is one-way. **Public API surface is unchanged.**

## Changes

**New (both `internal`):**
- `IRandomSource` — `Fill(byte[], int, int)` + `NextInt32(int, int)`, with a thread-safety contract in the XDoc.
- `CryptoRandomSource` — stateless, thread-safe singleton (`Instance`) forwarding to `SecureRandom`.

**Threaded through:**
- `Secret<TNumber>` — an internal 3-arg ctor and a `CreateRandom(prime, IRandomSource)` overload carry the source; the public ctors and factories delegate to the default.
- `SecretSplitter<TNumber>` — a `randomSource` field (defaulted in both public ctors), a new `internal SecretSplitter(IRandomSource)` ctor (owns a default manager), used in `CreatePolynomial` and the random-secret `CreateRandom` call.

**Tests:**
- `DeterministicRandomSource` test double (seeded `System.Random`).
- Mirrored reproducibility + seed-sensitivity split tests on both the `BigInteger` and `SecureBigInteger` backends.
- `CryptoRandomSource` contract tests.

## Thread safety

No new shared mutable state. The default `CryptoRandomSource` is stateless and delegates to the thread-safe `RandomNumberGenerator`, so the shared singleton is safe across threads — identical concurrency behaviour to the previous static `SecureRandom`. A custom injected source is only as thread-safe as its implementation; the `System.Random`-backed test double is not thread-safe but runs only under the single-threaded test harness.

## Verification

- Build: **0 errors** across all 8 TFMs (full solution); no new warnings.
- Tests single-threaded across 6 TFMs: **1695 / 1688 passed, 0 failed**.
- Determinism proven end-to-end: same seed → byte-identical shares and secret; different seed → different secret.
- No public-API regression: all new types/ctors are `internal`; public constructor signatures unchanged.
- No CHANGELOG entry — internal-only, zero public-surface delta.
