### PR TITLE
test: add property-based Shamir round-trip tests via CsCheck

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="CsCheck" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingPropertyTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingPropertyTest.cs
@@ -1,0 +1,123 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ShamirsSecretSharingPropertyTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.BigInteger;
+
+using CsCheck;
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using System.Linq;
+using System.Numerics;
+using Xunit;
+
+/// <summary>
+/// Property-based round-trip tests for Shamir's Secret Sharing over the <see cref="BigInteger"/>
+/// backend. They assert the core Shamir invariant — any <c>threshold</c>-sized subset of the
+/// generated shares reconstructs the original secret — across randomly generated secrets and
+/// <c>(threshold, numberOfShares)</c> configurations, complementing the hand-authored InlineData suites.
+/// </summary>
+public class ShamirsSecretSharingPropertyTest
+{
+    /// <summary>
+    /// Inclusive upper bound for the generated secret length in bytes.
+    /// </summary>
+    private const int MaxSecretLength = 32;
+
+    /// <summary>
+    /// Inclusive upper bound for the generated number of shares.
+    /// </summary>
+    private const int MaxShares = 7;
+
+    /// <summary>
+    /// Number of generated cases per property. Executed with <c>threads: 1</c> to honour the
+    /// project-wide requirement that security-sensitive tests never run in parallel.
+    /// </summary>
+    private const int Iterations = 250;
+
+    /// <summary>
+    /// Any qualifying subset — exactly <c>threshold</c> of the <c>numberOfShares</c> generated shares —
+    /// reconstructs the original secret.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_FromAnyThresholdSubset_RecoversSecret()
+    {
+        // Arrange
+        var generator = ShamirsSecretSharingGenerators.SubsetReconstruction(MaxSecretLength, MaxShares);
+
+        // Act & Assert
+        generator.Sample((secretBytes, threshold, numberOfShares, subsetOffset) =>
+        {
+            using var secret = new Secret<BigInteger>(secretBytes);
+            using var secretSplitter = new SecretSplitter<BigInteger>();
+            using var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            using var shares = secretSplitter.MakeShares(threshold, numberOfShares, secret);
+
+            // A wrap-around window of length threshold over the (index-sorted) shares is an
+            // arbitrary qualifying subset; length ≤ numberOfShares guarantees distinct shares.
+            var subset = shares.Concat(shares).Skip(subsetOffset).Take(threshold).ToArray();
+            using var recovered = secretReconstructor.Reconstruction(subset);
+
+            Assert.Equal(secret, recovered);
+        }, iter: Iterations, threads: 1);
+    }
+
+    /// <summary>
+    /// Reconstruction from the complete, over-determined share set (all <c>numberOfShares</c> shares,
+    /// which is more than <c>threshold</c>) also recovers the original secret — extra shares beyond the
+    /// threshold must not break recovery.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_FromFullShareSet_RecoversSecret()
+    {
+        // Arrange
+        var generator = ShamirsSecretSharingGenerators.FullSetReconstruction(MaxSecretLength, MaxShares);
+
+        // Act & Assert
+        generator.Sample((secretBytes, threshold, numberOfShares) =>
+        {
+            using var secret = new Secret<BigInteger>(secretBytes);
+            using var secretSplitter = new SecretSplitter<BigInteger>();
+            using var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            using var shares = secretSplitter.MakeShares(threshold, numberOfShares, secret);
+
+            using var recovered = secretReconstructor.Reconstruction(shares);
+
+            Assert.Equal(secret, recovered);
+        }, iter: Iterations, threads: 1);
+    }
+}
+
+#endif

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingPropertyTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingPropertyTest.cs
@@ -1,0 +1,130 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ShamirsSecretSharingPropertyTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.SecureBigInteger;
+
+using CsCheck;
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using SecretSharingDotNet.Math.Numerics;
+using System.Linq;
+using Xunit;
+
+/// <summary>
+/// Property-based round-trip tests for Shamir's Secret Sharing over the <see cref="SecureBigInteger"/>
+/// backend. They assert the core Shamir invariant — any <c>threshold</c>-sized subset of the
+/// generated shares reconstructs the original secret — across randomly generated secrets and
+/// <c>(threshold, numberOfShares)</c> configurations, complementing the hand-authored InlineData suites.
+/// </summary>
+/// <remarks>
+/// The generated space (secret length, share count, iterations) is deliberately smaller than the
+/// <c>BigInteger</c> suite because <see cref="SecureBigInteger"/> arithmetic — including the
+/// constant-time <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> reconstruction path exercised here —
+/// is considerably slower.
+/// </remarks>
+public class ShamirsSecretSharingPropertyTest
+{
+    /// <summary>
+    /// Inclusive upper bound for the generated secret length in bytes.
+    /// </summary>
+    private const int MaxSecretLength = 8;
+
+    /// <summary>
+    /// Inclusive upper bound for the generated number of shares.
+    /// </summary>
+    private const int MaxShares = 5;
+
+    /// <summary>
+    /// Number of generated cases per property. Kept modest because <see cref="SecureBigInteger"/> is
+    /// slow; executed with <c>threads: 1</c> to honour the project-wide requirement that
+    /// security-sensitive tests never run in parallel.
+    /// </summary>
+    private const int Iterations = 50;
+
+    /// <summary>
+    /// Any qualifying subset — exactly <c>threshold</c> of the <c>numberOfShares</c> generated shares —
+    /// reconstructs the original secret.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_FromAnyThresholdSubset_RecoversSecret()
+    {
+        // Arrange
+        var generator = ShamirsSecretSharingGenerators.SubsetReconstruction(MaxSecretLength, MaxShares);
+
+        // Act & Assert
+        generator.Sample((secretBytes, threshold, numberOfShares, subsetOffset) =>
+        {
+            using var secret = new Secret<SecureBigInteger>(secretBytes);
+            using var secretSplitter = new SecretSplitter<SecureBigInteger>();
+            using var secretReconstructor = new SecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>());
+            using var shares = secretSplitter.MakeShares(threshold, numberOfShares, secret);
+
+            // A wrap-around window of length threshold over the (index-sorted) shares is an
+            // arbitrary qualifying subset; length ≤ numberOfShares guarantees distinct shares.
+            var subset = shares.Concat(shares).Skip(subsetOffset).Take(threshold).ToArray();
+            using var recovered = secretReconstructor.Reconstruction(subset);
+
+            Assert.Equal(secret, recovered);
+        }, iter: Iterations, threads: 1);
+    }
+
+    /// <summary>
+    /// Reconstruction from the complete, over-determined share set (all <c>numberOfShares</c> shares,
+    /// which is more than <c>threshold</c>) also recovers the original secret — extra shares beyond the
+    /// threshold must not break recovery.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_FromFullShareSet_RecoversSecret()
+    {
+        // Arrange
+        var generator = ShamirsSecretSharingGenerators.FullSetReconstruction(MaxSecretLength, MaxShares);
+
+        // Act & Assert
+        generator.Sample((secretBytes, threshold, numberOfShares) =>
+        {
+            using var secret = new Secret<SecureBigInteger>(secretBytes);
+            using var secretSplitter = new SecretSplitter<SecureBigInteger>();
+            using var secretReconstructor = new SecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>());
+            using var shares = secretSplitter.MakeShares(threshold, numberOfShares, secret);
+
+            using var recovered = secretReconstructor.Reconstruction(shares);
+
+            Assert.Equal(secret, recovered);
+        }, iter: Iterations, threads: 1);
+    }
+}
+
+#endif

--- a/tests/Cryptography/ShamirsSecretSharing/ShamirsSecretSharingGenerators.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/ShamirsSecretSharingGenerators.cs
@@ -1,0 +1,84 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ShamirsSecretSharingGenerators.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing;
+
+using CsCheck;
+
+/// <summary>
+/// Shared CsCheck generators for the Shamir's Secret Sharing property tests. Backend-agnostic:
+/// they yield raw secret bytes together with a valid share configuration, which both the
+/// <c>BigInteger</c> and <c>SecureBigInteger</c> property suites feed into their respective
+/// <see cref="SecretSharingDotNet.Cryptography.ShamirsSecretSharing.SecretSplitter{TNumber}"/>.
+/// </summary>
+/// <remarks>
+/// The generated configurations always satisfy the Shamir constraint <c>2 ≤ threshold ≤ numberOfShares</c>.
+/// Secret length and share count are bounded by the caller so the (slow) <c>SecureBigInteger</c>
+/// backend can request a smaller space than the <c>BigInteger</c> backend.
+/// </remarks>
+internal static class ShamirsSecretSharingGenerators
+{
+    /// <summary>
+    /// Generates a random secret, a valid <c>(threshold, numberOfShares)</c> configuration and a
+    /// <c>subsetOffset</c> in <c>[0, numberOfShares - 1]</c>. The offset selects a wrap-around window
+    /// of exactly <c>threshold</c> shares, i.e. an arbitrary qualifying subset.
+    /// </summary>
+    /// <param name="maxSecretLength">Inclusive upper bound for the generated secret length in bytes.</param>
+    /// <param name="maxShares">Inclusive upper bound for the generated number of shares.</param>
+    /// <returns>A generator of <c>(Secret, Threshold, NumberOfShares, SubsetOffset)</c> tuples.</returns>
+    public static Gen<(byte[] Secret, int Threshold, int NumberOfShares, int SubsetOffset)> SubsetReconstruction(
+        int maxSecretLength, int maxShares) =>
+        Gen.Byte.Array[1, maxSecretLength].SelectMany(secret =>
+            Gen.Int[2, maxShares].SelectMany(numberOfShares =>
+                Gen.Int[2, numberOfShares].SelectMany(threshold =>
+                    Gen.Int[0, numberOfShares - 1].Select(subsetOffset =>
+                        (secret, threshold, numberOfShares, subsetOffset)))));
+
+    /// <summary>
+    /// Generates a random secret and a valid <c>(threshold, numberOfShares)</c> configuration, used to
+    /// reconstruct from the complete (possibly over-determined) share set.
+    /// </summary>
+    /// <param name="maxSecretLength">Inclusive upper bound for the generated secret length in bytes.</param>
+    /// <param name="maxShares">Inclusive upper bound for the generated number of shares.</param>
+    /// <returns>A generator of <c>(Secret, Threshold, NumberOfShares)</c> tuples.</returns>
+    public static Gen<(byte[] Secret, int Threshold, int NumberOfShares)> FullSetReconstruction(
+        int maxSecretLength, int maxShares) =>
+        Gen.Byte.Array[1, maxSecretLength].SelectMany(secret =>
+            Gen.Int[2, maxShares].SelectMany(numberOfShares =>
+                Gen.Int[2, numberOfShares].Select(threshold =>
+                    (secret, threshold, numberOfShares))));
+}
+
+#endif

--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -39,6 +39,12 @@
         <PackageReference Include="System.Memory" />
     </ItemGroup>
 
+    <!-- CsCheck (property-based testing) targets net8.0 only; the property tests are gated behind
+         #if NET8_0_OR_GREATER, mirroring the net8+-only Timing harness. -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="CsCheck" />
+    </ItemGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\src\SecretSharingDotNet.csproj"/>
     </ItemGroup>

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -845,6 +845,12 @@
       }
     },
     "net10.0": {
+      "CsCheck": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "j1ddNwZJHtuXJo0haeDtEX/j/iDJYLlZdIvaEmb7ftxTN9p4e5/jn6hYGXH/Em6RFfDRGWaNQ17LOMR3MhYWwA=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",
@@ -1049,6 +1055,12 @@
       }
     },
     "net8.0": {
+      "CsCheck": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "j1ddNwZJHtuXJo0haeDtEX/j/iDJYLlZdIvaEmb7ftxTN9p4e5/jn6hYGXH/Em6RFfDRGWaNQ17LOMR3MhYWwA=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",
@@ -1253,6 +1265,12 @@
       }
     },
     "net9.0": {
+      "CsCheck": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "j1ddNwZJHtuXJo0haeDtEX/j/iDJYLlZdIvaEmb7ftxTN9p4e5/jn6hYGXH/Em6RFfDRGWaNQ17LOMR3MhYWwA=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",


### PR DESCRIPTION
## Summary

Adds CsCheck (4.7.0) property-based testing for the core Shamir's Secret Sharing invariant, addressing part of architecture review item **A14** (test-strategy gap: no property-based testing — hand-authored `InlineData` only). This is the first of three planned A14 follow-ups; concurrency stress tests and Stryker mutation testing in CI remain separate PRs.

## What's added

Two properties, mirrored across both numeric backends (`BigInteger` and `SecureBigInteger`):

- **Reconstruction from any threshold-sized subset recovers the secret** — a wrap-around window of `threshold` shares over randomly generated secrets and `(threshold, numberOfShares)` configurations.
- **Reconstruction from the full, over-determined share set recovers the secret** — all `numberOfShares` shares (more than `threshold`).

Both draw their inputs from a shared, backend-agnostic generator (`ShamirsSecretSharingGenerators`) that always satisfies `2 ≤ threshold ≤ numberOfShares`.

## Framework targeting

CsCheck 4.7.0 targets `net8.0`, so its package reference and the property tests are gated to `net8.0`/`net9.0`/`net10.0` via `#if NET8_0_OR_GREATER`, mirroring the existing net8+-only Timing harness. The `net4.x` target frameworks keep their existing deterministic `InlineData` coverage.

## Test-safety

- Runs single-threaded (`threads: 1`) to honour the project-wide requirement that security-sensitive tests never run in parallel.
- Disposes every generated `Secret`/`Shares` per iteration to avoid leaking pinned memory.

## Verification

Full suite, single-threaded, all 6 test target frameworks:

| TFM group | Passed | Δ |
| --- | --- | --- |
| net8.0 / net9.0 / net10.0 | 1699 each | +4 (property tests active) |
| net472 / net48 / net481 | 1688 each | ±0 (gated out; CsCheck not referenced) |

0 failed. Build: 0 errors across all 8 library target frameworks plus the test project.

## Public API delta

None (test-only change).
