### PR TITLE
test: add opt-in concurrency stress tests

### DIFF
--- a/tests/Cryptography/CryptoRandomSourceTest.cs
+++ b/tests/Cryptography/CryptoRandomSourceTest.cs
@@ -36,6 +36,9 @@ namespace SecretSharingDotNetTest.Cryptography;
 
 using SecretSharingDotNet.Cryptography;
 using System;
+#if NET8_0_OR_GREATER
+using System.Threading.Tasks;
+#endif
 using Xunit;
 
 /// <summary>
@@ -112,4 +115,35 @@ public class CryptoRandomSourceTest
             Assert.InRange(value, 1, 127);
         }
     }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Concurrency stress test: many threads drawing from the shared
+    /// <see cref="CryptoRandomSource.Instance"/> in parallel must all receive valid, in-range output
+    /// without corruption or exceptions. Validates the documented thread-safety of the stateless
+    /// singleton (it forwards to the thread-safe <see cref="SecureRandom"/>). Opt-in via the
+    /// <c>Category=Stress</c> trait.
+    /// </summary>
+    [Fact]
+    [Trait(StressTraits.CategoryKey, StressTraits.CategoryValue)]
+    public void Instance_ConcurrentDraws_StayWithinRangeWithoutError()
+    {
+        // Arrange
+        const int degreeOfParallelism = 16;
+        const int drawsPerWorker = 250;
+
+        // Act & Assert
+        Parallel.For(0, degreeOfParallelism, _ =>
+        {
+            var buffer = new byte[32];
+            for (int i = 0; i < drawsPerWorker; i++)
+            {
+                int value = CryptoRandomSource.Instance.NextInt32(1, 128);
+                Assert.InRange(value, 1, 127);
+
+                CryptoRandomSource.Instance.Fill(buffer, 0, buffer.Length);
+            }
+        });
+    }
+#endif
 }

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingConcurrencyTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingConcurrencyTest.cs
@@ -1,0 +1,110 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ShamirsSecretSharingConcurrencyTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.BigInteger;
+
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using Xunit;
+
+/// <summary>
+/// Concurrency stress tests for Shamir's Secret Sharing over the <see cref="BigInteger"/> backend.
+/// They exercise the supported concurrency contract: many threads, each using their own
+/// <see cref="SecretSplitter{TNumber}"/> and <see cref="SecretReconstructor{TNumber}"/> instances,
+/// split and reconstruct in parallel, and every round-trip must recover its own secret. This surfaces
+/// hidden shared mutable state in the split/reconstruct path (e.g. the reflection-backed
+/// <c>Calculator</c> factory or the <c>MersennePrimeProvider</c> singleton).
+/// </summary>
+/// <remarks>
+/// A shared splitter/reconstructor is deliberately NOT exercised: it mutates its security level and
+/// is documented as not thread-safe (architecture review item A7). Opt-in via the
+/// <c>Category=Stress</c> trait; gated to net8.0+ (see <see cref="StressTraits"/>).
+/// </remarks>
+public class ShamirsSecretSharingConcurrencyTest
+{
+    /// <summary>
+    /// Independent splitter/reconstructor instances used concurrently each recover their own secret.
+    /// </summary>
+    [Fact]
+    [Trait(StressTraits.CategoryKey, StressTraits.CategoryValue)]
+    public void ParallelRoundTrip_WithIndependentInstances_EachRecoversItsSecret()
+    {
+        // Arrange
+        const int degreeOfParallelism = 16;
+        const int roundTripsPerWorker = 25;
+
+        // Act & Assert
+        Parallel.For(0, degreeOfParallelism, worker =>
+        {
+            for (int iteration = 0; iteration < roundTripsPerWorker; iteration++)
+            {
+                using var secret = new Secret<BigInteger>(BuildSecret(worker, iteration));
+                using var secretSplitter = new SecretSplitter<BigInteger>();
+                using var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+                using var shares = secretSplitter.MakeShares(3, 5, secret);
+
+                var subset = shares.Take(3).ToArray();
+                using var recovered = secretReconstructor.Reconstruction(subset);
+
+                Assert.Equal(secret, recovered);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Builds a distinct, non-empty secret for the given worker/iteration so concurrent round-trips
+    /// operate on varied inputs (and varied security levels via varied length).
+    /// </summary>
+    /// <param name="worker">The parallel worker index.</param>
+    /// <param name="iteration">The per-worker iteration index.</param>
+    /// <returns>A deterministic, distinct secret byte array of length 1..12.</returns>
+    private static byte[] BuildSecret(int worker, int iteration)
+    {
+        int length = 1 + ((worker + iteration) % 12);
+        var secretBytes = new byte[length];
+        for (int j = 0; j < length; j++)
+        {
+            secretBytes[j] = (byte)((worker * 31) + (iteration * 7) + j + 1);
+        }
+
+        return secretBytes;
+    }
+}
+
+#endif

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingConcurrencyTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingConcurrencyTest.cs
@@ -1,0 +1,110 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ShamirsSecretSharingConcurrencyTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.SecureBigInteger;
+
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using SecretSharingDotNet.Math.Numerics;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+/// <summary>
+/// Concurrency stress tests for Shamir's Secret Sharing over the <see cref="SecureBigInteger"/>
+/// backend. They exercise the supported concurrency contract: many threads, each using their own
+/// <see cref="SecretSplitter{TNumber}"/> and <see cref="SecretReconstructor{TNumber}"/> instances
+/// (the latter over the constant-time <see cref="MersenneSafeGcdAlgorithm{TNumber}"/>), split and
+/// reconstruct in parallel, and every round-trip must recover its own secret.
+/// </summary>
+/// <remarks>
+/// A shared splitter/reconstructor is deliberately NOT exercised: it mutates its security level and
+/// is documented as not thread-safe (architecture review item A7). The workload is smaller than the
+/// <c>BigInteger</c> suite because <see cref="SecureBigInteger"/> arithmetic is considerably slower.
+/// Opt-in via the <c>Category=Stress</c> trait; gated to net8.0+ (see <see cref="StressTraits"/>).
+/// </remarks>
+public class ShamirsSecretSharingConcurrencyTest
+{
+    /// <summary>
+    /// Independent splitter/reconstructor instances used concurrently each recover their own secret.
+    /// </summary>
+    [Fact]
+    [Trait(StressTraits.CategoryKey, StressTraits.CategoryValue)]
+    public void ParallelRoundTrip_WithIndependentInstances_EachRecoversItsSecret()
+    {
+        // Arrange
+        const int degreeOfParallelism = 8;
+        const int roundTripsPerWorker = 5;
+
+        // Act & Assert
+        Parallel.For(0, degreeOfParallelism, worker =>
+        {
+            for (int iteration = 0; iteration < roundTripsPerWorker; iteration++)
+            {
+                using var secret = new Secret<SecureBigInteger>(BuildSecret(worker, iteration));
+                using var secretSplitter = new SecretSplitter<SecureBigInteger>();
+                using var secretReconstructor = new SecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>());
+                using var shares = secretSplitter.MakeShares(3, 5, secret);
+
+                var subset = shares.Take(3).ToArray();
+                using var recovered = secretReconstructor.Reconstruction(subset);
+
+                Assert.Equal(secret, recovered);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Builds a distinct, non-empty secret for the given worker/iteration so concurrent round-trips
+    /// operate on varied inputs (and varied security levels via varied length).
+    /// </summary>
+    /// <param name="worker">The parallel worker index.</param>
+    /// <param name="iteration">The per-worker iteration index.</param>
+    /// <returns>A deterministic, distinct secret byte array of length 1..6.</returns>
+    private static byte[] BuildSecret(int worker, int iteration)
+    {
+        int length = 1 + ((worker + iteration) % 6);
+        var secretBytes = new byte[length];
+        for (int j = 0; j < length; j++)
+        {
+            secretBytes[j] = (byte)((worker * 31) + (iteration * 7) + j + 1);
+        }
+
+        return secretBytes;
+    }
+}
+
+#endif

--- a/tests/StressTraits.cs
+++ b/tests/StressTraits.cs
@@ -1,0 +1,56 @@
+// ----------------------------------------------------------------------------
+// <copyright file="StressTraits.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest;
+
+/// <summary>
+/// xUnit trait constants for the opt-in concurrency stress tests.
+/// </summary>
+/// <remarks>
+/// Stress tests spawn multiple threads inside a single test method to exercise the library's
+/// supported concurrency contract (independent splitter/reconstructor instances used in parallel).
+/// They carry the <c>Category=Stress</c> trait so they can be run in isolation or excluded, and are
+/// gated to net8.0+ to avoid the intermittent Mono fatal-signal artefacts observed when the
+/// .NET Framework target frameworks run under concurrency. Run only the stress category explicitly
+/// with <c>--filter "Category=Stress"</c>.
+/// </remarks>
+internal static class StressTraits
+{
+    public const string CategoryKey = "Category";
+
+    public const string CategoryValue = "Stress";
+}
+
+#endif


### PR DESCRIPTION
## Summary

Adds opt-in concurrency stress tests exercising the library's supported concurrency contract, addressing the remaining stress-test gap of architecture review item **A14** (the property-based part landed in #335). After this, A14 is complete except for Stryker mutation testing in CI, which remains a separate PR.

## What's added

- **Independent-instance parallel round-trip** (mirrored across the `BigInteger` and `SecureBigInteger` backends): many threads, each using their own `SecretSplitter`/`SecretReconstructor` instances, split and reconstruct in parallel; every round-trip must recover its own secret. This surfaces hidden shared mutable state in the split/reconstruct path.
- **Shared-RNG contention** (`CryptoRandomSourceTest`): many threads drawing from the shared `CryptoRandomSource.Instance` concurrently must all receive valid, in-range output without corruption — validates the thread safety of the singleton introduced in #334 (A10).

The only shared statics on the hot path — the reflection-backed `Calculator` factory (`ReadOnlyDictionary`) and the `MersennePrimeProvider` singleton (`Lazy` + read-only) — are immutable/thread-safe, so the tests pass.

## Out of scope (by design)

A shared `SecretSplitter`/`SecretReconstructor` is deliberately not exercised: it mutates its security level and is documented as not thread-safe (architecture review item A7). This limitation is stated in the test XDoc rather than asserted.

## Trait + framework targeting

- Tests carry the `Category=Stress` trait (mirroring the existing `Category=Timing` convention) so they can be run in isolation (`--filter "Category=Stress"`) or excluded. They run in the default CI test command like the Timing self-test.
- Gated to `net8.0`/`net9.0`/`net10.0` via `#if NET8_0_OR_GREATER` to avoid the intermittent Mono fatal-signal artefacts observed when the `net4.x` target frameworks run under concurrency (consistent with #335 and the Timing harness).

## Verification

Full suite, single-threaded, all 6 test target frameworks:

| TFM group | Passed | Δ |
| --- | --- | --- |
| net8.0 / net9.0 / net10.0 | 1702 each | +3 (stress tests active) |
| net472 / net48 / net481 | 1688 each | ±0 (gated out) |

0 failed. Build: 0 errors, no warnings from the new files.

## Public API delta

None (test-only change).
