### PR TITLE
ci: add Stryker.NET mutation testing workflow

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.16.0",
+      "commands": [
+        "dotnet-stryker"
+      ]
+    }
+  }
+}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,53 @@
+name: SecretSharingDotNet - Mutation Testing
+
+# Stryker.NET mutation testing. Report-only (never fails the build) and scoped to
+# the algorithm core; establishes a baseline mutation score. Runs on demand and
+# weekly rather than per-PR because a mutation run re-executes the test suite once
+# per mutant. Pinned to net10.0 (the net4.x targets crash under Mono on Linux).
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Sunday 03:30 UTC — offset from the CodeQL Thursday run.
+    - cron: '30 3 * * 0'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    name: Stryker.NET
+    runs-on: ubuntu-22.04
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    # Only the net10.0 SDK is installed: Stryker is pinned to target-framework
+    # net10.0, so no net8.0/net9.0 test host is ever built or run here (unlike the
+    # build/test workflows, which exercise every .NET target framework).
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+      with:
+        dotnet-version: 10.0.100
+
+    - name: Restore
+      run: dotnet restore SecretSharingDotNet.slnx
+
+    - name: Restore .NET tools
+      run: dotnet tool restore
+
+    - name: Run Stryker.NET mutation testing
+      working-directory: tests
+      run: dotnet stryker
+
+    - name: Upload mutation report
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: mutation-report
+        path: tests/StrykerOutput/**/reports/
+        if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@
 # test executables crash under Mono on non-Windows hosts. Diagnostic
 # artefacts, not test failures (the tests themselves still pass).
 mono_crash.*.json
+
+# Ignore Stryker.NET mutation-testing output — per-run HTML/JSON reports and
+# logs written under tests/ by the mutation.yml workflow and local runs.
+StrykerOutput/

--- a/tests/stryker-config.json
+++ b/tests/stryker-config.json
@@ -1,0 +1,30 @@
+{
+  "stryker-config": {
+    "target-framework": "net10.0",
+    "test-case-filter": "Category!=Timing&Category!=Stress",
+    "coverage-analysis": "perTest",
+    "mutation-level": "Standard",
+    "reporters": [
+      "html",
+      "json",
+      "cleartext"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    },
+    "mutate": [
+      "!**/SecureBigInteger.cs",
+      "!**/SecureBigIntCalculator.cs",
+      "!**/PinnedPoolArray`1.cs",
+      "!**/PinnedPoolArrayList.cs",
+      "!**/CountedEqualityComparer`1.cs",
+      "!**/ICountedEqualityComparer`1.cs",
+      "!**/SecureRandom.cs",
+      "!**/CryptoRandomSource.cs",
+      "!**/ErrorMessages.Designer.cs",
+      "!**/AssemblyInfo.cs"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds Stryker.NET mutation testing to measure how effectively the test suite pins behaviour — the final part of architecture review item **A14**, after the property-based tests (#335) and concurrency stress tests (#336). With this, A14 is complete.

Mutation testing mutates the source (e.g. flips `<` to `<=`, drops a statement) and re-runs the tests; a surviving mutant is a change no test catches — a test-quality gap, which matters most in a crypto library.

## What's added

- **`.github/workflows/mutation.yml`** — a dedicated workflow that runs Stryker on demand (`workflow_dispatch`) and weekly (`schedule`), never per pull request, because a mutation run re-executes the test suite once per mutant.
- **`tests/stryker-config.json`** — the Stryker configuration.
- **`.config/dotnet-tools.json`** — a tool manifest pinning `dotnet-stryker` 4.16.0 (restored via `dotnet tool restore`).
- **`.gitignore`** — ignores Stryker's `StrykerOutput/`.

## Report-only baseline

The run never fails the build (`thresholds.break: 0`) and uploads an HTML/JSON report as an artifact. This first PR establishes a baseline; setting a real score threshold (`break`/`low`/`high`) is left to a data-driven follow-up once the first CI run produces the baseline number. Trigger the workflow manually after merge to generate it.

## Scope and constraints

- **net10.0 only.** The .NET Framework targets crash under Mono on Linux, so the run is pinned to net10.0; only the net10.0 SDK is installed since no other test host is built.
- **Algorithm core.** The `SecureBigInteger` arithmetic backend, the low-level pinned-memory plumbing (`PinnedPoolArray` / `SecureArray`), and the RNG are excluded from this first pass — mutant-dense and slow to test. Widening the `mutate` scope later is a one-line change.
- **Timing + Stress traits excluded** from the mutation run (slow and non-deterministic) via `test-case-filter`.
- Workflow actions are pinned to commit SHAs, consistent with the existing workflows.

## Verification

Stryker runs end-to-end locally: build → 3070 mutants generated → the `mutate` filter removes the excluded files → **1235 core mutants tested**, with the Timing/Stress suites filtered out (1616 of the net10.0 tests run, down from 1702). The numeric baseline score is produced by the first CI run (report-only + artifact), by design.

## Public API delta

None (CI and tooling only).
