### PR TITLE
Release v1.0.1-rc02

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.16.0",
+      "commands": [
+        "dotnet-stryker"
+      ]
+    }
+  }
+}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Setup .NET SDKs
       uses: actions/setup-dotnet@v5.3.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.2.0
+      uses: actions/setup-dotnet@v5.3.0
       with:
         dotnet-version: |
           8.0.416

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # The .NET build steps apply only to the C# analysis; 'actions' is a no-build
     # CodeQL language, so its matrix leg skips setup / restore / build.
     - name: Setup .NET SDKs
       if: matrix.language == 'csharp'
-      uses: actions/setup-dotnet@v5.4.0
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: |
           8.0.416
@@ -42,7 +42,7 @@ jobs:
           10.0.100
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         languages: ${{ matrix.language }}
 
@@ -55,4 +55,4 @@ jobs:
       run: dotnet build --configuration Release SecretSharingDotNet.slnx
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,21 +1,9 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "SecretSharingDotNet - CodeQL"
 
 on:
   push:
     branches: [ develop, main ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ develop, main ]
   schedule:
     - cron: '18 17 * * 4'
@@ -32,16 +20,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+        language: [ 'csharp', 'actions' ]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
 
+    # The .NET build steps apply only to the C# analysis; 'actions' is a no-build
+    # CodeQL language, so its matrix leg skips setup / restore / build.
     - name: Setup .NET SDKs
+      if: matrix.language == 'csharp'
       uses: actions/setup-dotnet@v5.4.0
       with:
         dotnet-version: |
@@ -49,37 +37,18 @@ jobs:
           9.0.307
           10.0.100
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
-  
     - name: Restore
+      if: matrix.language == 'csharp'
       run: dotnet restore SecretSharingDotNet.slnx
 
     - name: Build
+      if: matrix.language == 'csharp'
       run: dotnet build --configuration Release SecretSharingDotNet.slnx
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.3.0
+      uses: actions/setup-dotnet@v5.4.0
       with:
         dotnet-version: |
           8.0.416

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '18 17 * * 4'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Setup .NET SDKs
       uses: actions/setup-dotnet@v5.3.0

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -29,10 +29,10 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.4.0
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: |
           8.0.416

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -3,9 +3,15 @@ name: SecretSharingDotNet - Build and Test All .NET Versions
 on:
   push:
     branches:
-    - '*'
+    - '**'
     tags-ignore:
-    - '*'
+    - '**'
+    paths-ignore:
+    - '**.md'
+  pull_request:
+    branches:
+    - develop
+    - main
     paths-ignore:
     - '**.md'
 

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -15,6 +15,10 @@ on:
     paths-ignore:
     - '**.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -15,6 +15,9 @@ on:
     paths-ignore:
     - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.2.0
+      uses: actions/setup-dotnet@v5.3.0
       with:
         dotnet-version: |
           8.0.416

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.3.0
+      uses: actions/setup-dotnet@v5.4.0
       with:
         dotnet-version: |
           8.0.416

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,53 @@
+name: SecretSharingDotNet - Mutation Testing
+
+# Stryker.NET mutation testing. Report-only (never fails the build) and scoped to
+# the algorithm core; establishes a baseline mutation score. Runs on demand and
+# weekly rather than per-PR because a mutation run re-executes the test suite once
+# per mutant. Pinned to net10.0 (the net4.x targets crash under Mono on Linux).
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Sunday 03:30 UTC — offset from the CodeQL Thursday run.
+    - cron: '30 3 * * 0'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    name: Stryker.NET
+    runs-on: ubuntu-22.04
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    # Only the net10.0 SDK is installed: Stryker is pinned to target-framework
+    # net10.0, so no net8.0/net9.0 test host is ever built or run here (unlike the
+    # build/test workflows, which exercise every .NET target framework).
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+      with:
+        dotnet-version: 10.0.100
+
+    - name: Restore
+      run: dotnet restore SecretSharingDotNet.slnx
+
+    - name: Restore .NET tools
+      run: dotnet tool restore
+
+    - name: Run Stryker.NET mutation testing
+      working-directory: tests
+      run: dotnet stryker
+
+    - name: Upload mutation report
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: mutation-report
+        path: tests/StrykerOutput/**/reports/
+        if-no-files-found: warn

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -7,6 +7,9 @@ on:
     paths-ignore:
     - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.3.0
+      uses: actions/setup-dotnet@v5.4.0
       with:
         dotnet-version: |
           8.0.416

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write   # OIDC token for NuGet Trusted Publishing
 
 jobs:
   build:
@@ -53,5 +54,11 @@ jobs:
     - name: Create package
       run: dotnet pack --no-restore --no-build --configuration Release SecretSharingDotNet.slnx
 
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Publish package
-      run: dotnet nuget push $(find src/bin/Release -type f  -name 'SecretSharingDotNet*.nupkg' -print 2> /dev/null) -k  ${{ secrets.NUGET_API_KEY }}  -s https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push $(find src/bin/Release -type f  -name 'SecretSharingDotNet*.nupkg' -print 2> /dev/null) -k  ${{ steps.login.outputs.NUGET_API_KEY }}  -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.2.0
+      uses: actions/setup-dotnet@v5.3.0
       with:
         dotnet-version: |
           8.0.416

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -43,7 +43,7 @@ jobs:
       run: dotnet test --no-restore --no-build --configuration Release SecretSharingDotNet.slnx -- RunConfiguration.TargetPlatform=x64 RunConfiguration.MaxCpuCount=1  xUnit.AppDomain=denied xUnit.ParallelizeAssembly=false xUnit.ParallelizeTestCollections=false
 
     - name: Remove obsolete NuGet packages
-      run: rm -f src/bin/Release/SecretSharingDotNet*.nupk
+      run: rm -f src/bin/Release/SecretSharingDotNet*.nupkg
 
     - name: Prepare README.md for NuGet package
       run: |

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Setup .NET SDKs
       uses: actions/setup-dotnet@v5.3.0

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -18,10 +18,10 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@v5.4.0
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: |
           8.0.416
@@ -55,7 +55,7 @@ jobs:
       run: dotnet pack --no-restore --no-build --configuration Release SecretSharingDotNet.slnx
 
     - name: NuGet login (OIDC → temp API key)
-      uses: NuGet/login@v1
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
       id: login
       with:
         user: ${{ secrets.NUGET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@
 # test executables crash under Mono on non-Windows hosts. Diagnostic
 # artefacts, not test failures (the tests themselves still pass).
 mono_crash.*.json
+
+# Ignore Stryker.NET mutation-testing output — per-run HTML/JSON reports and
+# logs written under tests/ by the mutation.yml workflow and local runs.
+StrykerOutput/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.0.1-rc01] - 2026-05-29
 
 ### Added
@@ -316,6 +318,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LICENSE.md`
 - Added `README.md`
 
+[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc01...develop
 [1.0.1-rc01]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.14.0...v1.0.1-rc01
 [0.14.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.12.0...v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added `ConstantTimeSecretReconstructor<TNumber>` — a constant-time-by-construction `SecretReconstructor<TNumber>` that accepts only `IConstantTimeExtendedGcdAlgorithm<TNumber>` strategies (pairing it with a variable-time GCD is a compile-time error) and whose parameterless constructor defaults to `MersenneSafeGcdAlgorithm<TNumber>`.
-- Added `IConstantTimeExtendedGcdAlgorithm<TNumber>` — marker interface tagging extended-GCD strategies whose modular-inverse timing depends only on public quantities; `MersenneSafeGcdAlgorithm<TNumber>` implements it, `ExtendedEuclideanAlgorithm<TNumber>` does not.
+- Added `ConstantTimeSecretReconstructor<TNumber>` — a `SecretReconstructor<TNumber>` that accepts only `IConstantTimeExtendedGcdAlgorithm<TNumber>` strategies (pairing it with a variable-time GCD is a compile-time error) and whose parameterless constructor defaults to `MersenneSafeGcdAlgorithm<TNumber>`.
+- Added `IConstantTimeExtendedGcdAlgorithm<TNumber>` — marker interface tagging extended-GCD strategies whose iteration count is operand-independent (removing the iteration-count side channel of a plain extended-Euclidean GCD); `MersenneSafeGcdAlgorithm<TNumber>` implements it, `ExtendedEuclideanAlgorithm<TNumber>` does not.
 
 ## [1.0.1-rc01] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `Secret<TNumber>.GetHashCode` is now consistent with by-value `Secret<TNumber>.Equals`: equal secrets produce equal hash codes. It now hashes only the public payload length; previously it was identity-based (`PinnedPoolArray<T>` does not override `GetHashCode`) while equality is by value, violating the `Equals`/`GetHashCode` contract and silently breaking `Secret<TNumber>` as a dictionary/set key.
+- `SharesEnumerator<TNumber>.Current` now throws `InvalidOperationException` when accessed before the first `MoveNext` or past the end, per the `IEnumerator` contract. Previously it caught `IndexOutOfRangeException`, which the backing `ReadOnlyCollection` indexer never throws (it throws `ArgumentOutOfRangeException`), so the raw `ArgumentOutOfRangeException` surfaced instead.
 
 ## [1.0.1-rc01] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `ConstantTimeSecretReconstructor<TNumber>` — a constant-time-by-construction `SecretReconstructor<TNumber>` that accepts only `IConstantTimeExtendedGcdAlgorithm<TNumber>` strategies (pairing it with a variable-time GCD is a compile-time error) and whose parameterless constructor defaults to `MersenneSafeGcdAlgorithm<TNumber>`.
+- Added `IConstantTimeExtendedGcdAlgorithm<TNumber>` — marker interface tagging extended-GCD strategies whose modular-inverse timing depends only on public quantities; `MersenneSafeGcdAlgorithm<TNumber>` implements it, `ExtendedEuclideanAlgorithm<TNumber>` does not.
+
 ## [1.0.1-rc01] - 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added `ConstantTimeSecretReconstructor<TNumber>` — a `SecretReconstructor<TNumber>` that accepts only `IConstantTimeExtendedGcdAlgorithm<TNumber>` strategies (pairing it with a variable-time GCD is a compile-time error) and whose parameterless constructor defaults to `MersenneSafeGcdAlgorithm<TNumber>`.
-- Added `IConstantTimeExtendedGcdAlgorithm<TNumber>` — marker interface tagging extended-GCD strategies whose iteration count is operand-independent (removing the iteration-count side channel of a plain extended-Euclidean GCD); `MersenneSafeGcdAlgorithm<TNumber>` implements it, `ExtendedEuclideanAlgorithm<TNumber>` does not.
+- Added `FixedIterationSecretReconstructor<TNumber>` — a `SecretReconstructor<TNumber>` that accepts only `IFixedIterationExtendedGcdAlgorithm<TNumber>` strategies (pairing it with a variable-time GCD is a compile-time error) and whose parameterless constructor defaults to `MersenneSafeGcdAlgorithm<TNumber>`.
+- Added `IFixedIterationExtendedGcdAlgorithm<TNumber>` — marker interface tagging extended-GCD strategies whose iteration count is operand-independent (removing the iteration-count side channel of a plain extended-Euclidean GCD); `MersenneSafeGcdAlgorithm<TNumber>` implements it, `ExtendedEuclideanAlgorithm<TNumber>` does not.
 
 ## [1.0.1-rc01] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `FixedIterationSecretReconstructor<TNumber>` — a `SecretReconstructor<TNumber>` that accepts only `IFixedIterationExtendedGcdAlgorithm<TNumber>` strategies (pairing it with a variable-time GCD is a compile-time error) and whose parameterless constructor defaults to `MersenneSafeGcdAlgorithm<TNumber>`.
 - Added `IFixedIterationExtendedGcdAlgorithm<TNumber>` — marker interface tagging extended-GCD strategies whose iteration count is operand-independent (removing the iteration-count side channel of a plain extended-Euclidean GCD); `MersenneSafeGcdAlgorithm<TNumber>` implements it, `ExtendedEuclideanAlgorithm<TNumber>` does not.
 
+### Changed
+- `SecureBigInteger.GetHashCode` now hashes only public metadata (sign and limb count) instead of the full limb content, so it no longer produces a value-derived hash of secret material. `Calculator<TNumber>`, `Share<TNumber>`, and `ExtendedGcdResult<TNumber>` inherit this via delegation.
+
+### Fixed
+- `Secret<TNumber>.GetHashCode` is now consistent with by-value `Secret<TNumber>.Equals`: equal secrets produce equal hash codes. It now hashes only the public payload length; previously it was identity-based (`PinnedPoolArray<T>` does not override `GetHashCode`) while equality is by value, violating the `Equals`/`GetHashCode` contract and silently breaking `Secret<TNumber>` as a dictionary/set key.
+
 ## [1.0.1-rc01] - 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1-rc02] - 2026-07-12
+
 ### Added
 - Added `FixedIterationSecretReconstructor<TNumber>` — a `SecretReconstructor<TNumber>` that accepts only `IFixedIterationExtendedGcdAlgorithm<TNumber>` strategies (pairing it with a variable-time GCD is a compile-time error) and whose parameterless constructor defaults to `MersenneSafeGcdAlgorithm<TNumber>`.
 - Added `IFixedIterationExtendedGcdAlgorithm<TNumber>` — marker interface tagging extended-GCD strategies whose iteration count is operand-independent (removing the iteration-count side channel of a plain extended-Euclidean GCD); `MersenneSafeGcdAlgorithm<TNumber>` implements it, `ExtendedEuclideanAlgorithm<TNumber>` does not.
@@ -329,7 +331,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LICENSE.md`
 - Added `README.md`
 
-[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc01...develop
+[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc02...develop
+[1.0.1-rc02]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc01...v1.0.1-rc02
 [1.0.1-rc01]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.14.0...v1.0.1-rc01
 [0.14.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.12.0...v0.13.0

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="CsCheck" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,11 +5,11 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.7.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,10 +6,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.6.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ A C# implementation of Shamir's Secret Sharing.
 > The text-secret encoding is UTF-8 (introduced in v0.14.0).
 
 > [!TIP]
-> A runnable end-to-end example lives in [`samples/SecretSharingDotNet.Demo.Console`](./samples/SecretSharingDotNet.Demo.Console). It wires the `SecureBigInteger` backend with `MersenneSafeGcdAlgorithm` through `Microsoft.Extensions.DependencyInjection`, reads the secret via `ConsolePasswordReader` (no `string` materialisation), splits it, and reconstructs it from a user-selected K-of-N subset of the generated shares.
+> A runnable end-to-end example lives in [`samples/SecretSharingDotNet.Demo.Console`](./samples/SecretSharingDotNet.Demo.Console). It wires the `SecureBigInteger` backend via `ConstantTimeSecretReconstructor` (constant-time `MersenneSafeGcdAlgorithm` inverse) through `Microsoft.Extensions.DependencyInjection`, reads the secret via `ConsolePasswordReader` (no `string` materialisation), splits it, and reconstructs it from a user-selected K-of-N subset of the generated shares.
 
 ## Basics
 Use the function `MakeShares` to generate the shares, based on a random or pre-defined secret.
@@ -147,12 +147,22 @@ Afterwards, use the function `Reconstruction` to reconstruct the original secret
 
 The library is generic in the numeric backend: `BigInteger` (used in the examples below) or `SecureBigInteger` (pinned-memory storage with constant-time arithmetic — see the Security & Threat Model section). Both `IMakeSharesUseCase<TNumber>` and `IReconstructionUseCase<TNumber>` implement `IDisposable`; wrap them in `using` so pinned, security-sensitive buffers are released deterministically.
 
+### Choosing a backend and reconstructor
+
+| Backend | Reconstructor + GCD strategy | Pinned memory | Constant-time arithmetic | Constant-time modular inverse | Choose when |
+|---|---|:---:|:---:|:---:|---|
+| `BigInteger` | `SecretReconstructor` + `ExtendedEuclideanAlgorithm` | no | no | no | performance matters and timing side channels are out of scope |
+| `SecureBigInteger` | `ConstantTimeSecretReconstructor` (wires `MersenneSafeGcdAlgorithm`) | yes | yes | yes (best-effort) | secrets where passive timing analysis is in scope |
+
+> [!WARNING]
+> Do not pair `SecureBigInteger` with `ExtendedEuclideanAlgorithm`: you keep the pinned memory but reintroduce a variable-time modular inverse, defeating the constant-time goal. `ConstantTimeSecretReconstructor<SecureBigInteger>` accepts only constant-time GCD strategies, so this mispairing is a compile-time error rather than a silent side channel. See the Security & Threat Model section for the exact constant-time scope.
+
 The length of the shares is based on the security level. On the splitter side, you can set it three ways: pass it as the `securityLevel` parameter of the `MakeShares` overload that takes one, assign the `SecretSplitter<TNumber>.SecurityLevel` property, or inject a pre-configured `ISecurityLevelManager<TNumber>` through the constructor. The configured level is overridden when the secret size exceeds the Mersenne prime derived from it — the library auto-adjusts upward. It is not necessary to define a security level for a reconstruction: `SecretReconstructor<TNumber>.SecurityLevel` is read-only and is derived from the supplied shares on every `Reconstruction` call.
 
 The `ToString()` overrides on `Secret<TNumber>`, `Share<TNumber>`, and `Shares<TNumber>` are build-mode-sensitive: DEBUG builds return the actual content, while Release builds return the redaction sentinel `"*** Secured Value ***"` so secrets cannot accidentally leak through logs, exception messages, or other diagnostic output.
 
 ## Using the SecretSharingDotNet library with DI in a .NET project
-This guide demonstrates two parallel DI wirings: the `BigInteger` backend with `ExtendedEuclideanAlgorithm` (BCL-native, variable-time arithmetic) and the `SecureBigInteger` backend with `MersenneSafeGcdAlgorithm` (pinned-memory storage, constant-time arithmetic on public bit-length — see the Security & Threat Model section for the trade-offs). Both variants share the same import block:
+This guide demonstrates two parallel DI wirings: the `BigInteger` backend with `ExtendedEuclideanAlgorithm` (BCL-native, variable-time arithmetic) and the `SecureBigInteger` backend via `ConstantTimeSecretReconstructor`, which wires the constant-time `MersenneSafeGcdAlgorithm` (pinned-memory storage, constant-time arithmetic on public bit-length — see the Security & Threat Model section for the trade-offs). Both variants share the same import block:
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -203,15 +213,14 @@ Console.Out.Write(reconstructionChars.PoolArray, 0, reconstructionChars.Length);
 Console.WriteLine();
 ```
 
-### Variant 2 — SecureBigInteger + MersenneSafeGcdAlgorithm
+### Variant 2 — SecureBigInteger + ConstantTimeSecretReconstructor
 
-The wiring is identical except for the substituted `TNumber` and the GCD algorithm — `MersenneSafeGcdAlgorithm<SecureBigInteger>` is the constant-time alternative to `ExtendedEuclideanAlgorithm<SecureBigInteger>` (see the Security & Threat Model section).
+`ConstantTimeSecretReconstructor<SecureBigInteger>` is a drop-in `IReconstructionUseCase<SecureBigInteger>` that supplies the constant-time `MersenneSafeGcdAlgorithm` itself, so no separate GCD registration is needed. To use a different constant-time strategy, additionally register `IConstantTimeExtendedGcdAlgorithm<SecureBigInteger>` and the reconstructor picks it up (see the Security & Threat Model section).
 
 ```csharp
 var serviceCollection = new ServiceCollection();
-serviceCollection.AddSingleton<IExtendedGcdAlgorithm<SecureBigInteger>, MersenneSafeGcdAlgorithm<SecureBigInteger>>();
 serviceCollection.AddTransient<IMakeSharesUseCase<SecureBigInteger>, SecretSplitter<SecureBigInteger>>();
-serviceCollection.AddTransient<IReconstructionUseCase<SecureBigInteger>, SecretReconstructor<SecureBigInteger>>();
+serviceCollection.AddTransient<IReconstructionUseCase<SecureBigInteger>, ConstantTimeSecretReconstructor<SecureBigInteger>>();
 using var serviceProvider = serviceCollection.BuildServiceProvider();
 
 var makeSharesUseCase = serviceProvider.GetRequiredService<IMakeSharesUseCase<SecureBigInteger>>();
@@ -622,11 +631,11 @@ public class Program
 
     //// SecretSplitter and SecretReconstructor auto-adjust their security
     //// level to the secret being processed, so one pair of instances
-    //// serves all three shapes. MersenneSafeGcdAlgorithm provides a
-    //// constant-time modular inverse during Lagrange interpolation.
+    //// serves all three shapes. ConstantTimeSecretReconstructor wires the
+    //// constant-time MersenneSafeGcdAlgorithm modular inverse used during
+    //// Lagrange interpolation.
     using var splitter = new SecretSplitter<SecureBigInteger>();
-    var safegcd = new MersenneSafeGcdAlgorithm<SecureBigInteger>();
-    using var combiner = new SecretReconstructor<SecureBigInteger>(safegcd);
+    using var combiner = new ConstantTimeSecretReconstructor<SecureBigInteger>();
 
     //// (a) Text round-trip.
     using var textShares = splitter.MakeShares(3, 7, textSecret);
@@ -964,15 +973,17 @@ for hardened native crypto stacks.
   "outer-iteration-count constant-time" to "per-iteration uniform". The exponent is
   derived from the modulus passed to `Compute` at call time — the algorithm holds no
   `ISecurityLevelManager` reference, so it cannot drift from the
-  `SecretReconstructor` consuming it. To wire it in, pass a
-  `MersenneSafeGcdAlgorithm<TNumber>` instance as the GCD strategy when constructing
-  `SecretReconstructor<TNumber>`:
+  `SecretReconstructor` consuming it. The simplest way to opt in is
+  `ConstantTimeSecretReconstructor<TNumber>` — it accepts only constant-time GCD strategies
+  and defaults to `MersenneSafeGcdAlgorithm<TNumber>`, so the strategy cannot be mispaired:
 
   ```csharp
-  var gcd = new MersenneSafeGcdAlgorithm<SecureBigInteger>();
-  var combiner = new SecretReconstructor<SecureBigInteger>(gcd);
-  var recovered = combiner.Reconstruction(shares);
+  using var combiner = new ConstantTimeSecretReconstructor<SecureBigInteger>();
+  using var recovered = combiner.Reconstruction(shares);
   ```
+
+  To pin a specific constant-time strategy, pass it to the same type:
+  `new ConstantTimeSecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>())`.
 
 **Public-input dependence (treated as public, not secret):**
 
@@ -985,13 +996,14 @@ for hardened native crypto stacks.
 
 **`SecureBigInteger` does *not* protect against:**
 
-- **Variable-time modular inverse on the default reconstruction path.** When
-  `SecretReconstructor` is constructed with the customary
-  `ExtendedEuclideanAlgorithm<TNumber>` GCD strategy, its iteration count is
-  variable on the operand values. Consumers whose threat model includes timing
-  analysis of reconstruction must inject `MersenneSafeGcdAlgorithm<TNumber>`
-  explicitly. A convenience overload routing the SecureBigInteger backend to
-  `MersenneSafeGcdAlgorithm<SecureBigInteger>` by default is planned future work.
+- **Variable-time modular inverse when a variable-time GCD is chosen.** The base
+  `SecretReconstructor<TNumber>` requires an explicit GCD strategy; pairing it with
+  `ExtendedEuclideanAlgorithm<TNumber>` yields an iteration count that is variable on the
+  operand values. This is a deliberate opt-out, not a default — use
+  `ConstantTimeSecretReconstructor<TNumber>` (which accepts only constant-time strategies and
+  defaults to `MersenneSafeGcdAlgorithm<TNumber>`) for reconstruction whose timing does not
+  depend on secret operands. The variable-time pairing remains available for the `BigInteger`
+  backend and other cases where constant time is not a goal.
 - **Hex- and Base64-decoder input-character timing.** `Share<TNumber>`'s
   hex-deserialisation pipeline (`DecodeHexToCalculator` → `GetHexValue`) and
   `Secret<TNumber>`'s Base64 decode (`DecodeBase64Char`) are not constant-time on

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The library is generic in the numeric backend: `BigInteger` (used in the example
 | `BigInteger` | `SecretReconstructor` + `ExtendedEuclideanAlgorithm` | no | no | no | performance matters and timing side channels are out of scope |
 | `SecureBigInteger` | `FixedIterationSecretReconstructor` (wires `MersenneSafeGcdAlgorithm`) | yes | yes | yes | secrets where passive timing analysis is in scope |
 
-† Both constant-time properties are best-effort against passive timing analysis — managed .NET cannot guarantee constant time (see the Security & Threat Model section). *Constant-time arithmetic* covers the core primitives (add / subtract / multiply / square / divide / remainder) on the public bit length; it does not cover `Pow` (variable-time on its exponent), ordering (`CompareTo`), or the hex / Base64 decoders. *Fixed-iteration inverse* means the GCD iteration count is independent of secret operands, which removes the iteration-count side channel of a plain extended-Euclidean GCD; it is not per-operation constant-time (`MersenneSafeGcdAlgorithm`'s per-iteration timing is not uniform). Together these two properties **reduce but do not eliminate** reconstruction timing side channels — they do not make the whole reconstruction constant-time.
+† Both constant-time properties are best-effort against passive timing analysis — managed .NET cannot guarantee constant time (see the Security & Threat Model section). *Constant-time arithmetic* covers the core primitives (add / subtract / multiply / square / divide / remainder) on the public bit length; it does not cover `Pow` (variable-time on its exponent), ordering (`CompareTo`), or the hex / Base64 decoders. *Fixed-iteration inverse* means that at a fixed security level the GCD iteration count depends only on that (public) level, not on the secret operand values — removing the iteration-count side channel of a plain extended-Euclidean GCD. Reconstruction auto-selects the level from the shares' maximum value, so the iteration count still reflects the selected level (which the share sizes already reveal); it is not per-operation constant-time (`MersenneSafeGcdAlgorithm`'s per-iteration timing is not uniform). Together these two properties **reduce but do not eliminate** reconstruction timing side channels — they do not make the whole reconstruction constant-time.
 
 > [!WARNING]
 > Do not pair `SecureBigInteger` with `ExtendedEuclideanAlgorithm`: you keep the pinned memory but reintroduce an operand-value-dependent iteration count — the side channel `FixedIterationSecretReconstructor` removes. `FixedIterationSecretReconstructor<SecureBigInteger>` accepts only fixed-iteration GCD strategies, so this mispairing is a compile-time error rather than a silent side channel. See the Security & Threat Model section for the exact scope.
@@ -986,6 +986,12 @@ for hardened native crypto stacks.
 
   To pin a specific fixed-iteration strategy, pass it to the same type:
   `new FixedIterationSecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>())`.
+
+  Scope: the fixed iteration count is relative to the security level. `Reconstruction` auto-selects
+  that level from the shares (via `AdjustSecurityLevel` on the maximum share value), so the iteration
+  count reflects the selected level — which the share sizes already reveal. What this removes versus
+  `ExtendedEuclideanAlgorithm` is the operand-value dependence *within* a level, not the
+  level-selection dependence (observable only to a pure-timing attacker with no share access).
 
 **Public-input dependence (treated as public, not secret):**
 

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ The library is generic in the numeric backend: `BigInteger` (used in the example
 
 ### Choosing a backend and reconstructor
 
-| Backend | Reconstructor + GCD strategy | Pinned memory | Constant-time arithmetic | Fixed-iteration inverse | Choose when |
+| Backend | Reconstructor + GCD strategy | Pinned memory | Constant-time arithmetic † | Fixed-iteration inverse † | Choose when |
 |---|---|:---:|:---:|:---:|---|
 | `BigInteger` | `SecretReconstructor` + `ExtendedEuclideanAlgorithm` | no | no | no | performance matters and timing side channels are out of scope |
 | `SecureBigInteger` | `FixedIterationSecretReconstructor` (wires `MersenneSafeGcdAlgorithm`) | yes | yes | yes | secrets where passive timing analysis is in scope |
 
-Fixed-iteration inverse means the GCD iteration count is independent of secret operands, which removes the iteration-count side channel of a plain extended-Euclidean GCD. It is not per-operation constant-time — `MersenneSafeGcdAlgorithm`'s per-iteration timing is not uniform on managed backends. See the Security & Threat Model section for the exact scope.
+† Both constant-time properties are best-effort against passive timing analysis — managed .NET cannot guarantee constant time (see the Security & Threat Model section). *Constant-time arithmetic* covers the core primitives (add / subtract / multiply / square / divide / remainder) on the public bit length; it does not cover `Pow` (variable-time on its exponent), ordering (`CompareTo`), or the hex / Base64 decoders. *Fixed-iteration inverse* means the GCD iteration count is independent of secret operands, which removes the iteration-count side channel of a plain extended-Euclidean GCD; it is not per-operation constant-time (`MersenneSafeGcdAlgorithm`'s per-iteration timing is not uniform). Together these two properties **reduce but do not eliminate** reconstruction timing side channels — they do not make the whole reconstruction constant-time.
 
 > [!WARNING]
 > Do not pair `SecureBigInteger` with `ExtendedEuclideanAlgorithm`: you keep the pinned memory but reintroduce an operand-value-dependent iteration count — the side channel `FixedIterationSecretReconstructor` removes. `FixedIterationSecretReconstructor<SecureBigInteger>` accepts only fixed-iteration GCD strategies, so this mispairing is a compile-time error rather than a silent side channel. See the Security & Threat Model section for the exact scope.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ A C# implementation of Shamir's Secret Sharing.
   <tbody>
       <tr>
           <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml/badge.svg" alt="SecretSharingDotNet - NuGet Publishing"/></a></td>
-          <td rowspan=8><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 1.0.1-rc01"/></a></td>
-          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v1.0.1-rc01" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-1.0.1--rc01-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=8><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 1.0.1-rc02"/></a></td>
+          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v1.0.1-rc02" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-1.0.1--rc02-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
@@ -88,10 +88,10 @@ A C# implementation of Shamir's Secret Sharing.
 
 1. Open a console and switch to the directory containing your project file.
 
-2. Use the following command to install version 1.0.1-rc01 of the SecretSharingDotNet package:
+2. Use the following command to install version 1.0.1-rc02 of the SecretSharingDotNet package:
 
     ```dotnetcli
-    dotnet add package SecretSharingDotNet -v 1.0.1-rc01 -f <FRAMEWORK>
+    dotnet add package SecretSharingDotNet -v 1.0.1-rc02 -f <FRAMEWORK>
     ```
 
 3. After the completion of the command, look at the project file to make sure that the package is successfully installed.
@@ -100,7 +100,7 @@ A C# implementation of Shamir's Secret Sharing.
 
     ```xml
     <ItemGroup>
-      <PackageReference Include="SecretSharingDotNet" Version="1.0.1-rc01" />
+      <PackageReference Include="SecretSharingDotNet" Version="1.0.1-rc02" />
     </ItemGroup>
     ```
 ## Remove SecretSharingDotNet package 📤
@@ -119,7 +119,7 @@ A C# implementation of Shamir's Secret Sharing.
 
 # Usage 🔧
 > [!IMPORTANT]
-> Breaking changes in v1.0.1-rc01 (major version bump from v0.14.0). Highlights for migrating consumers — see [`CHANGELOG.md`](./CHANGELOG.md) for the full list.
+> Breaking changes in v1.0.1-rc02 (major version bump from v0.14.0). Highlights for migrating consumers — see [`CHANGELOG.md`](./CHANGELOG.md) for the full list.
 >
 > - **Text I/O is pinned-buffer-only.** The `string`-based entry points are gone. Wrap a `string` in `.ToPinnedSecure()` and use the pinned factories: `Secret<TNumber>.FromText(PinnedPoolArray<char>)`, `new Share<TNumber>(PinnedPoolArray<char>)`, `Shares<TNumber>.FromText(...)`, `Shares<TNumber>.FromTextLines(...)`. Read back via the matching `ToCharArray()` methods on `Secret`, `Share`, and `Shares`.
 > - **`Reconstruction(string)` and `Reconstruction(string[])` removed.** Build a `Shares<TNumber>` through one of the pinned factories above and pass that.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ The library is generic in the numeric backend: `BigInteger` (used in the example
 | Backend | Reconstructor + GCD strategy | Pinned memory | Constant-time arithmetic | Constant-time modular inverse | Choose when |
 |---|---|:---:|:---:|:---:|---|
 | `BigInteger` | `SecretReconstructor` + `ExtendedEuclideanAlgorithm` | no | no | no | performance matters and timing side channels are out of scope |
-| `SecureBigInteger` | `ConstantTimeSecretReconstructor` (wires `MersenneSafeGcdAlgorithm`) | yes | yes | yes (best-effort) | secrets where passive timing analysis is in scope |
+| `SecureBigInteger` | `ConstantTimeSecretReconstructor` (wires `MersenneSafeGcdAlgorithm`) | yes | yes | iteration-count (best-effort) | secrets where passive timing analysis is in scope |
+
+Constant-time modular inverse is best-effort: `MersenneSafeGcdAlgorithm` fixes the GCD iteration count on public parameters, but per-iteration timing is not yet uniform on managed backends. See the Security & Threat Model section for the exact scope.
 
 > [!WARNING]
 > Do not pair `SecureBigInteger` with `ExtendedEuclideanAlgorithm`: you keep the pinned memory but reintroduce a variable-time modular inverse, defeating the constant-time goal. `ConstantTimeSecretReconstructor<SecureBigInteger>` accepts only constant-time GCD strategies, so this mispairing is a compile-time error rather than a silent side channel. See the Security & Threat Model section for the exact constant-time scope.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ A C# implementation of Shamir's Secret Sharing.
 > The text-secret encoding is UTF-8 (introduced in v0.14.0).
 
 > [!TIP]
-> A runnable end-to-end example lives in [`samples/SecretSharingDotNet.Demo.Console`](./samples/SecretSharingDotNet.Demo.Console). It wires the `SecureBigInteger` backend via `ConstantTimeSecretReconstructor` (constant-time `MersenneSafeGcdAlgorithm` inverse) through `Microsoft.Extensions.DependencyInjection`, reads the secret via `ConsolePasswordReader` (no `string` materialisation), splits it, and reconstructs it from a user-selected K-of-N subset of the generated shares.
+> A runnable end-to-end example lives in [`samples/SecretSharingDotNet.Demo.Console`](./samples/SecretSharingDotNet.Demo.Console). It wires the `SecureBigInteger` backend via `FixedIterationSecretReconstructor` (fixed-iteration `MersenneSafeGcdAlgorithm` inverse) through `Microsoft.Extensions.DependencyInjection`, reads the secret via `ConsolePasswordReader` (no `string` materialisation), splits it, and reconstructs it from a user-selected K-of-N subset of the generated shares.
 
 ## Basics
 Use the function `MakeShares` to generate the shares, based on a random or pre-defined secret.
@@ -149,22 +149,22 @@ The library is generic in the numeric backend: `BigInteger` (used in the example
 
 ### Choosing a backend and reconstructor
 
-| Backend | Reconstructor + GCD strategy | Pinned memory | Constant-time arithmetic | Constant-time modular inverse | Choose when |
+| Backend | Reconstructor + GCD strategy | Pinned memory | Constant-time arithmetic | Fixed-iteration inverse | Choose when |
 |---|---|:---:|:---:|:---:|---|
 | `BigInteger` | `SecretReconstructor` + `ExtendedEuclideanAlgorithm` | no | no | no | performance matters and timing side channels are out of scope |
-| `SecureBigInteger` | `ConstantTimeSecretReconstructor` (wires `MersenneSafeGcdAlgorithm`) | yes | yes | iteration-count (best-effort) | secrets where passive timing analysis is in scope |
+| `SecureBigInteger` | `FixedIterationSecretReconstructor` (wires `MersenneSafeGcdAlgorithm`) | yes | yes | yes | secrets where passive timing analysis is in scope |
 
-Constant-time modular inverse is best-effort: `MersenneSafeGcdAlgorithm` fixes the GCD iteration count on public parameters, but per-iteration timing is not yet uniform on managed backends. See the Security & Threat Model section for the exact scope.
+Fixed-iteration inverse means the GCD iteration count is independent of secret operands, which removes the iteration-count side channel of a plain extended-Euclidean GCD. It is not per-operation constant-time — `MersenneSafeGcdAlgorithm`'s per-iteration timing is not uniform on managed backends. See the Security & Threat Model section for the exact scope.
 
 > [!WARNING]
-> Do not pair `SecureBigInteger` with `ExtendedEuclideanAlgorithm`: you keep the pinned memory but reintroduce a variable-time modular inverse, defeating the constant-time goal. `ConstantTimeSecretReconstructor<SecureBigInteger>` accepts only constant-time GCD strategies, so this mispairing is a compile-time error rather than a silent side channel. See the Security & Threat Model section for the exact constant-time scope.
+> Do not pair `SecureBigInteger` with `ExtendedEuclideanAlgorithm`: you keep the pinned memory but reintroduce an operand-value-dependent iteration count — the side channel `FixedIterationSecretReconstructor` removes. `FixedIterationSecretReconstructor<SecureBigInteger>` accepts only fixed-iteration GCD strategies, so this mispairing is a compile-time error rather than a silent side channel. See the Security & Threat Model section for the exact scope.
 
 The length of the shares is based on the security level. On the splitter side, you can set it three ways: pass it as the `securityLevel` parameter of the `MakeShares` overload that takes one, assign the `SecretSplitter<TNumber>.SecurityLevel` property, or inject a pre-configured `ISecurityLevelManager<TNumber>` through the constructor. The configured level is overridden when the secret size exceeds the Mersenne prime derived from it — the library auto-adjusts upward. It is not necessary to define a security level for a reconstruction: `SecretReconstructor<TNumber>.SecurityLevel` is read-only and is derived from the supplied shares on every `Reconstruction` call.
 
 The `ToString()` overrides on `Secret<TNumber>`, `Share<TNumber>`, and `Shares<TNumber>` are build-mode-sensitive: DEBUG builds return the actual content, while Release builds return the redaction sentinel `"*** Secured Value ***"` so secrets cannot accidentally leak through logs, exception messages, or other diagnostic output.
 
 ## Using the SecretSharingDotNet library with DI in a .NET project
-This guide demonstrates two parallel DI wirings: the `BigInteger` backend with `ExtendedEuclideanAlgorithm` (BCL-native, variable-time arithmetic) and the `SecureBigInteger` backend via `ConstantTimeSecretReconstructor`, which wires the constant-time `MersenneSafeGcdAlgorithm` (pinned-memory storage, constant-time arithmetic on public bit-length — see the Security & Threat Model section for the trade-offs). Both variants share the same import block:
+This guide demonstrates two parallel DI wirings: the `BigInteger` backend with `ExtendedEuclideanAlgorithm` (BCL-native, variable-time arithmetic) and the `SecureBigInteger` backend via `FixedIterationSecretReconstructor`, which wires the constant-time `MersenneSafeGcdAlgorithm` (pinned-memory storage, constant-time arithmetic on public bit-length — see the Security & Threat Model section for the trade-offs). Both variants share the same import block:
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -215,14 +215,14 @@ Console.Out.Write(reconstructionChars.PoolArray, 0, reconstructionChars.Length);
 Console.WriteLine();
 ```
 
-### Variant 2 — SecureBigInteger + ConstantTimeSecretReconstructor
+### Variant 2 — SecureBigInteger + FixedIterationSecretReconstructor
 
-`ConstantTimeSecretReconstructor<SecureBigInteger>` is a drop-in `IReconstructionUseCase<SecureBigInteger>` that supplies the constant-time `MersenneSafeGcdAlgorithm` itself, so no separate GCD registration is needed. To use a different constant-time strategy, additionally register `IConstantTimeExtendedGcdAlgorithm<SecureBigInteger>` and the reconstructor picks it up (see the Security & Threat Model section).
+`FixedIterationSecretReconstructor<SecureBigInteger>` is a drop-in `IReconstructionUseCase<SecureBigInteger>` that supplies the fixed-iteration `MersenneSafeGcdAlgorithm` itself, so no separate GCD registration is needed. To use a different fixed-iteration strategy, additionally register `IFixedIterationExtendedGcdAlgorithm<SecureBigInteger>` and the reconstructor picks it up (see the Security & Threat Model section).
 
 ```csharp
 var serviceCollection = new ServiceCollection();
 serviceCollection.AddTransient<IMakeSharesUseCase<SecureBigInteger>, SecretSplitter<SecureBigInteger>>();
-serviceCollection.AddTransient<IReconstructionUseCase<SecureBigInteger>, ConstantTimeSecretReconstructor<SecureBigInteger>>();
+serviceCollection.AddTransient<IReconstructionUseCase<SecureBigInteger>, FixedIterationSecretReconstructor<SecureBigInteger>>();
 using var serviceProvider = serviceCollection.BuildServiceProvider();
 
 var makeSharesUseCase = serviceProvider.GetRequiredService<IMakeSharesUseCase<SecureBigInteger>>();
@@ -244,7 +244,7 @@ Console.WriteLine();
 Both use-case interfaces extend `IDisposable` and — under the `SecureBigInteger` backend — own pinned, security-sensitive buffers. Note that the use-case instances are not wrapped in `using` after `GetRequiredService`: the container owns the lifetime of services it resolves and disposes every tracked `IDisposable` transient when the `ServiceProvider` itself is disposed (here via `using var`). Disposing them explicitly at the call site would double-dispose against the container's cascade. In long-running hosts (ASP.NET, worker services) the root provider lives for the application's lifetime, so tracked transients accumulate until process exit — wrap each unit of work in a `using var scope = serviceProvider.CreateScope();` block (or register the use-cases as `AddScoped`) so the container disposes the resolved instances at scope end. The results of the calls (`secret`, `shares`, `reconstruction`, and the `ToCharArray` outputs) are caller-owned and remain wrapped in `using`.
 
 ## Random secret 🎲
-Create a random secret in conjunction with the generation of shares. The length of the generated shares and of the secret are based on the security level. Here is an example with a pre-defined security level of 127 using the `BigInteger` backend; for the constant-time `SecureBigInteger + MersenneSafeGcdAlgorithm` wiring, see the Security & Threat Model section.
+Create a random secret in conjunction with the generation of shares. The length of the generated shares and of the secret are based on the security level. Here is an example with a pre-defined security level of 127 using the `BigInteger` backend; for the `SecureBigInteger + MersenneSafeGcdAlgorithm` wiring, see the Security & Threat Model section.
 ```csharp
 using System;
 using System.Linq;
@@ -308,7 +308,7 @@ public class Program
 ```
 ## Pre-defined secret: text 📄
 Use a text as secret, which can be divided into shares. The length of the generated shares is based on the security level.
-Here is an example with auto-detected security level using the `BigInteger` backend; for the constant-time `SecureBigInteger + MersenneSafeGcdAlgorithm` wiring, see the Security & Threat Model section.
+Here is an example with auto-detected security level using the `BigInteger` backend; for the `SecureBigInteger + MersenneSafeGcdAlgorithm` wiring, see the Security & Threat Model section.
 ```csharp
 using System;
 using System.Linq;
@@ -362,7 +362,7 @@ public class Program
 
 ## Pre-defined secret: number 🔢
 Use an integer number as secret, which can be divided into shares. The length of the generated shares is based on the security level.
-Here is an example with a pre-defined security level of 521 using the `BigInteger` backend; for the constant-time `SecureBigInteger + MersenneSafeGcdAlgorithm` wiring, see the Security & Threat Model section.
+Here is an example with a pre-defined security level of 521 using the `BigInteger` backend; for the `SecureBigInteger + MersenneSafeGcdAlgorithm` wiring, see the Security & Threat Model section.
 ```csharp
 using System;
 using System.Linq;
@@ -410,7 +410,7 @@ public class Program
 ```
 ## Pre-defined secret: byte array ▦
 Use a byte array as secret, which can be divided into shares. The length of the generated shares is based on the security level.
-Here is an example with auto-detected security level using the `BigInteger` backend; for the constant-time `SecureBigInteger + MersenneSafeGcdAlgorithm` wiring, see the Security & Threat Model section.
+Here is an example with auto-detected security level using the `BigInteger` backend; for the `SecureBigInteger + MersenneSafeGcdAlgorithm` wiring, see the Security & Threat Model section.
 ```csharp
 using System;
 using System.Linq;
@@ -454,7 +454,7 @@ public class Program
 ```
 
 ## Secret 🔐
-The `Secret<TNumber>` type is the unified envelope for the secrets that flow through `SecretSplitter` and `SecretReconstructor`. The four sub-examples below cover every public construction, inspection, and serialisation path on the `BigInteger` backend, plus a constant-time round-trip on the `SecureBigInteger` backend. Sub-examples 5a–5c share the same payload — UTF-8 text `"Hello World!!"` — so each path can be traced end-to-end with the same expected output.
+The `Secret<TNumber>` type is the unified envelope for the secrets that flow through `SecretSplitter` and `SecretReconstructor`. The four sub-examples below cover every public construction, inspection, and serialisation path on the `BigInteger` backend, plus a fixed-iteration round-trip on the `SecureBigInteger` backend. Sub-examples 5a–5c share the same payload — UTF-8 text `"Hello World!!"` — so each path can be traced end-to-end with the same expected output.
 
 ### Secret<T> — construct
 ```csharp
@@ -600,7 +600,7 @@ public class Program
 }
 ```
 
-### Secret<SecureBigInteger> — text, number, bytes + constant-time round-trip
+### Secret<SecureBigInteger> — text, number, bytes + fixed-iteration round-trip
 ```csharp
 using System;
 
@@ -618,7 +618,7 @@ public class Program
   {
     //// Three Secret<SecureBigInteger> instances — one per input shape.
     //// Each one is split through SecretSplitter<SecureBigInteger> and
-    //// reconstructed via the constant-time MersenneSafeGcdAlgorithm path.
+    //// reconstructed via the fixed-iteration MersenneSafeGcdAlgorithm path.
 
     //// (a) Text — pinned UTF-8 chars in, Secret<SecureBigInteger> out.
     using var pinnedText = "Hello World!!".ToPinnedSecure();
@@ -633,11 +633,11 @@ public class Program
 
     //// SecretSplitter and SecretReconstructor auto-adjust their security
     //// level to the secret being processed, so one pair of instances
-    //// serves all three shapes. ConstantTimeSecretReconstructor wires the
-    //// constant-time MersenneSafeGcdAlgorithm modular inverse used during
+    //// serves all three shapes. FixedIterationSecretReconstructor wires the
+    //// fixed-iteration MersenneSafeGcdAlgorithm modular inverse used during
     //// Lagrange interpolation.
     using var splitter = new SecretSplitter<SecureBigInteger>();
-    using var combiner = new ConstantTimeSecretReconstructor<SecureBigInteger>();
+    using var combiner = new FixedIterationSecretReconstructor<SecureBigInteger>();
 
     //// (a) Text round-trip.
     using var textShares = splitter.MakeShares(3, 7, textSecret);
@@ -812,7 +812,7 @@ public class Program
     using var shares = Shares<BigInteger>.FromText(pinnedBlob);
 
     //// Reconstruct via the variable-time ExtendedEuclideanAlgorithm; for the
-    //// constant-time path with SecureBigInteger + MersenneSafeGcdAlgorithm,
+    //// fixed-iteration path with SecureBigInteger + MersenneSafeGcdAlgorithm,
     //// see the Security & Threat Model section.
     var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
     using var combiner = new SecretReconstructor<BigInteger>(gcd);
@@ -907,7 +907,7 @@ public class Program
     using var shares = Shares<BigInteger>.FromTextLines(pinnedLines);
 
     //// Reconstruct via the variable-time ExtendedEuclideanAlgorithm; for the
-    //// constant-time path with SecureBigInteger and MersenneSafeGcdAlgorithm,
+    //// fixed-iteration path with SecureBigInteger and MersenneSafeGcdAlgorithm,
     //// see the Security & Threat Model section.
     var gcd = new ExtendedEuclideanAlgorithm<BigInteger>();
     using var combiner = new SecretReconstructor<BigInteger>(gcd);
@@ -976,16 +976,16 @@ for hardened native crypto stacks.
   derived from the modulus passed to `Compute` at call time — the algorithm holds no
   `ISecurityLevelManager` reference, so it cannot drift from the
   `SecretReconstructor` consuming it. The simplest way to opt in is
-  `ConstantTimeSecretReconstructor<TNumber>` — it accepts only constant-time GCD strategies
+  `FixedIterationSecretReconstructor<TNumber>` — it accepts only fixed-iteration GCD strategies
   and defaults to `MersenneSafeGcdAlgorithm<TNumber>`, so the strategy cannot be mispaired:
 
   ```csharp
-  using var combiner = new ConstantTimeSecretReconstructor<SecureBigInteger>();
+  using var combiner = new FixedIterationSecretReconstructor<SecureBigInteger>();
   using var recovered = combiner.Reconstruction(shares);
   ```
 
-  To pin a specific constant-time strategy, pass it to the same type:
-  `new ConstantTimeSecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>())`.
+  To pin a specific fixed-iteration strategy, pass it to the same type:
+  `new FixedIterationSecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>())`.
 
 **Public-input dependence (treated as public, not secret):**
 
@@ -1002,7 +1002,7 @@ for hardened native crypto stacks.
   `SecretReconstructor<TNumber>` requires an explicit GCD strategy; pairing it with
   `ExtendedEuclideanAlgorithm<TNumber>` yields an iteration count that is variable on the
   operand values. This is a deliberate opt-out, not a default — use
-  `ConstantTimeSecretReconstructor<TNumber>` (which accepts only constant-time strategies and
+  `FixedIterationSecretReconstructor<TNumber>` (which accepts only fixed-iteration strategies and
   defaults to `MersenneSafeGcdAlgorithm<TNumber>`) for reconstruction whose timing does not
   depend on secret operands. The variable-time pairing remains available for the `BigInteger`
   backend and other cases where constant time is not a goal.

--- a/samples/SecretSharingDotNet.Demo.Console/DemoApp.cs
+++ b/samples/SecretSharingDotNet.Demo.Console/DemoApp.cs
@@ -41,8 +41,9 @@ using Math.Numerics;
 
 /// <summary>
 /// Interactive demonstration of Shamir's Secret Sharing with the
-/// <see cref="SecureBigInteger"/> backend, a constant-time
-/// <c>MersenneSafeGcdAlgorithm</c> inverse, and
+/// <see cref="SecureBigInteger"/> backend, constant-time reconstruction via
+/// <c>ConstantTimeSecretReconstructor</c> (which wires the constant-time
+/// <c>MersenneSafeGcdAlgorithm</c> inverse), and
 /// <see cref="ConsolePasswordReader"/> input that never materialises the
 /// secret as a <see cref="string"/>. The use cases are injected via
 /// <c>Microsoft.Extensions.DependencyInjection</c>; see

--- a/samples/SecretSharingDotNet.Demo.Console/DemoApp.cs
+++ b/samples/SecretSharingDotNet.Demo.Console/DemoApp.cs
@@ -41,8 +41,8 @@ using Math.Numerics;
 
 /// <summary>
 /// Interactive demonstration of Shamir's Secret Sharing with the
-/// <see cref="SecureBigInteger"/> backend, constant-time reconstruction via
-/// <c>ConstantTimeSecretReconstructor</c> (which wires the constant-time
+/// <see cref="SecureBigInteger"/> backend, fixed-iteration reconstruction via
+/// <c>FixedIterationSecretReconstructor</c> (which wires the fixed-iteration
 /// <c>MersenneSafeGcdAlgorithm</c> inverse), and
 /// <see cref="ConsolePasswordReader"/> input that never materialises the
 /// secret as a <see cref="string"/>. The use cases are injected via
@@ -175,7 +175,7 @@ internal sealed class DemoApp
     {
         Console.WriteLine("=== SecretSharingDotNet Demo ===");
         Console.WriteLine("Backend : SecureBigInteger (pinned, zeroised on dispose)");
-        Console.WriteLine("GCD     : MersenneSafeGcdAlgorithm (constant-time inverse)");
+        Console.WriteLine("GCD     : MersenneSafeGcdAlgorithm (fixed-iteration inverse)");
         Console.WriteLine("Input   : ConsolePasswordReader (no string materialisation)");
         Console.WriteLine("Wiring  : Microsoft.Extensions.DependencyInjection");
         Console.WriteLine();

--- a/samples/SecretSharingDotNet.Demo.Console/Program.cs
+++ b/samples/SecretSharingDotNet.Demo.Console/Program.cs
@@ -34,7 +34,6 @@ namespace SecretSharingDotNet.Demo.Console;
 using Microsoft.Extensions.DependencyInjection;
 using Cryptography;
 using Cryptography.ShamirsSecretSharing;
-using Math;
 using Math.Numerics;
 
 /// <summary>
@@ -61,10 +60,11 @@ internal static class Program
     }
 
     /// <summary>
-    /// Configures and builds the DI container for the demo. Registers the constant-time
-    /// GCD as a singleton (stateless), the two Shamir use cases as scoped (they own
-    /// disposable state and are released on scope dispose), and <see cref="DemoApp"/> as
-    /// scoped. <see cref="ServiceProviderOptions.ValidateOnBuild"/> and
+    /// Configures and builds the DI container for the demo. Registers the two Shamir use
+    /// cases as scoped (they own disposable state and are released on scope dispose) — the
+    /// reconstructor is the constant-time <see cref="ConstantTimeSecretReconstructor{TNumber}"/>
+    /// — and <see cref="DemoApp"/> as scoped.
+    /// <see cref="ServiceProviderOptions.ValidateOnBuild"/> and
     /// <see cref="ServiceProviderOptions.ValidateScopes"/> are enabled so that wiring
     /// mistakes fail fast at startup rather than mid-run.
     /// </summary>
@@ -75,16 +75,14 @@ internal static class Program
     {
         var services = new ServiceCollection();
 
-        // Stateless constant-time GCD. Registered as singleton:
-        // MersenneSafeGcdAlgorithm is the constant-time inverse path required for the
-        // security-conscious SecureBigInteger backend; the default ExtendedEuclideanAlgorithm
-        // is variable-time on operand values.
-        services.AddSingleton<IExtendedGcdAlgorithm<SecureBigInteger>, MersenneSafeGcdAlgorithm<SecureBigInteger>>();
-
-        // SecretSplitter and SecretReconstructor own internal disposables (SecurityLevelManager).
-        // Registered as scoped, so the DI scope tracks and disposes them deterministically.
+        // SecretSplitter and ConstantTimeSecretReconstructor own internal disposables
+        // (SecurityLevelManager). Registered as scoped, so the DI scope tracks and disposes
+        // them deterministically. ConstantTimeSecretReconstructor supplies the constant-time
+        // MersenneSafeGcdAlgorithm inverse itself — the inverse path required for the
+        // security-conscious SecureBigInteger backend — so no separate GCD registration is
+        // needed; the base ExtendedEuclideanAlgorithm would be variable-time on operand values.
         services.AddScoped<IMakeSharesUseCase<SecureBigInteger>, SecretSplitter<SecureBigInteger>>();
-        services.AddScoped<IReconstructionUseCase<SecureBigInteger>, SecretReconstructor<SecureBigInteger>>();
+        services.AddScoped<IReconstructionUseCase<SecureBigInteger>, ConstantTimeSecretReconstructor<SecureBigInteger>>();
 
         services.AddScoped<DemoApp>();
 

--- a/samples/SecretSharingDotNet.Demo.Console/Program.cs
+++ b/samples/SecretSharingDotNet.Demo.Console/Program.cs
@@ -62,7 +62,7 @@ internal static class Program
     /// <summary>
     /// Configures and builds the DI container for the demo. Registers the two Shamir use
     /// cases as scoped (they own disposable state and are released on scope dispose) — the
-    /// reconstructor is the constant-time <see cref="ConstantTimeSecretReconstructor{TNumber}"/>
+    /// reconstructor is the <see cref="FixedIterationSecretReconstructor{TNumber}"/>
     /// — and <see cref="DemoApp"/> as scoped.
     /// <see cref="ServiceProviderOptions.ValidateOnBuild"/> and
     /// <see cref="ServiceProviderOptions.ValidateScopes"/> are enabled so that wiring
@@ -75,14 +75,14 @@ internal static class Program
     {
         var services = new ServiceCollection();
 
-        // SecretSplitter and ConstantTimeSecretReconstructor own internal disposables
+        // SecretSplitter and FixedIterationSecretReconstructor own internal disposables
         // (SecurityLevelManager). Registered as scoped, so the DI scope tracks and disposes
-        // them deterministically. ConstantTimeSecretReconstructor supplies the constant-time
+        // them deterministically. FixedIterationSecretReconstructor supplies the fixed-iteration
         // MersenneSafeGcdAlgorithm inverse itself — the inverse path required for the
         // security-conscious SecureBigInteger backend — so no separate GCD registration is
         // needed; the base ExtendedEuclideanAlgorithm would be variable-time on operand values.
         services.AddScoped<IMakeSharesUseCase<SecureBigInteger>, SecretSplitter<SecureBigInteger>>();
-        services.AddScoped<IReconstructionUseCase<SecureBigInteger>, ConstantTimeSecretReconstructor<SecureBigInteger>>();
+        services.AddScoped<IReconstructionUseCase<SecureBigInteger>, FixedIterationSecretReconstructor<SecureBigInteger>>();
 
         services.AddScoped<DemoApp>();
 

--- a/samples/SecretSharingDotNet.Demo.Console/packages.lock.json
+++ b/samples/SecretSharingDotNet.Demo.Console/packages.lock.json
@@ -4,17 +4,17 @@
     "net10.0": {
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "daf62xHIrq8pnE709hgaZZN9tSam9TGGepWe1+bE6V3GEuVwJiMs6ib+38lfMCyAJAHiX0vapxBhsuMSV7U+cg==",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
       },
       "secretsharingdotnet": {
         "type": "Project"

--- a/src/Cryptography/CryptoRandomSource.cs
+++ b/src/Cryptography/CryptoRandomSource.cs
@@ -1,0 +1,69 @@
+// ----------------------------------------------------------------------------
+// <copyright file="CryptoRandomSource.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/10/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography;
+
+/// <summary>
+/// Default <see cref="IRandomSource"/> implementation. Forwards every draw to the
+/// cryptographically secure <see cref="SecureRandom"/> helper.
+/// </summary>
+/// <remarks>
+/// The type is stateless and immutable, so a single shared <see cref="Instance"/> backs every
+/// production draw throughout the library (no per-consumer allocation). Being stateless, it is
+/// safe for concurrent use — it delegates to the thread-safe
+/// <see cref="System.Security.Cryptography.RandomNumberGenerator"/> via <see cref="SecureRandom"/>.
+/// </remarks>
+internal sealed class CryptoRandomSource : IRandomSource
+{
+    /// <summary>
+    /// The shared, stateless instance used as the default random source throughout the library.
+    /// </summary>
+    internal static readonly IRandomSource Instance = new CryptoRandomSource();
+
+    /// <summary>
+    /// Prevents external instantiation; consumers use <see cref="Instance"/>.
+    /// </summary>
+    private CryptoRandomSource()
+    {
+    }
+
+    /// <inheritdoc/>
+    public void Fill(byte[] buffer, int offset, int count)
+    {
+        SecureRandom.Fill(buffer, offset, count);
+    }
+
+    /// <inheritdoc/>
+    public int NextInt32(int fromInclusive, int toExclusive)
+    {
+        return SecureRandom.NextInt32(fromInclusive, toExclusive);
+    }
+}

--- a/src/Cryptography/IRandomSource.cs
+++ b/src/Cryptography/IRandomSource.cs
@@ -1,0 +1,85 @@
+// ----------------------------------------------------------------------------
+// <copyright file="IRandomSource.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/10/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography;
+
+using System;
+
+/// <summary>
+/// Abstraction over the random primitives consumed by the secret-sharing pipeline
+/// (random secret generation, polynomial coefficients, and the termination byte).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default implementation is <see cref="CryptoRandomSource"/>, which delegates to the
+/// cryptographically secure <see cref="SecureRandom"/> helper. The seam exists so that tests
+/// can substitute a deterministic source; it is deliberately <see langword="internal"/> — a
+/// production <see cref="Secret{TNumber}"/> or
+/// <see cref="ShamirsSecretSharing.SecretSplitter{TNumber}"/> must be backed by a
+/// cryptographically secure generator, because a weak or seeded source undermines the secrecy
+/// of Shamir's scheme.
+/// </para>
+/// <para>
+/// <b>Thread safety:</b> an implementation used to back a <see cref="Secret{TNumber}"/> or
+/// <see cref="ShamirsSecretSharing.SecretSplitter{TNumber}"/> instance that is shared across
+/// threads must be safe for concurrent use. The default <see cref="CryptoRandomSource"/>
+/// satisfies this: it is stateless and delegates to the thread-safe
+/// <see cref="System.Security.Cryptography.RandomNumberGenerator"/>.
+/// </para>
+/// </remarks>
+internal interface IRandomSource
+{
+    /// <summary>
+    /// Fills <paramref name="count"/> bytes of <paramref name="buffer"/> starting at
+    /// <paramref name="offset"/> with random data.
+    /// </summary>
+    /// <param name="buffer">The destination buffer.</param>
+    /// <param name="offset">The offset into <paramref name="buffer"/> at which to start writing.</param>
+    /// <param name="count">The number of bytes to write.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="offset"/> or <paramref name="count"/> is negative, or the requested range
+    /// would extend past the end of <paramref name="buffer"/>.
+    /// </exception>
+    void Fill(byte[] buffer, int offset, int count);
+
+    /// <summary>
+    /// Returns a uniform random integer in
+    /// <c>[<paramref name="fromInclusive"/>, <paramref name="toExclusive"/>)</c>.
+    /// </summary>
+    /// <param name="fromInclusive">Inclusive lower bound of the result.</param>
+    /// <param name="toExclusive">Exclusive upper bound of the result. Must be greater than <paramref name="fromInclusive"/>.</param>
+    /// <returns>A uniformly distributed integer in the requested range.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="toExclusive"/> is not greater than <paramref name="fromInclusive"/>.
+    /// </exception>
+    int NextInt32(int fromInclusive, int toExclusive);
+}

--- a/src/Cryptography/Secret`1.cs
+++ b/src/Cryptography/Secret`1.cs
@@ -809,7 +809,12 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
     public override int GetHashCode()
     {
         this.ThrowIfDisposed();
-        return this.secretNumber?.GetHashCode() ?? 0;
+        // Hash only the public payload length, never secret content: keeps the Equals/GetHashCode
+        // contract (equal payloads share a length) without a value-derived hash, and replaces the
+        // former identity hash that broke the contract (PinnedPoolArray does not override
+        // GetHashCode). Default / content-empty secrets (null secretNumber, or only the mark byte)
+        // hash to 0.
+        return this.secretNumber is { Length: > MarkByteCount } sn ? sn.Length - MarkByteCount : 0;
     }
 
     /// <summary>

--- a/src/Cryptography/Secret`1.cs
+++ b/src/Cryptography/Secret`1.cs
@@ -130,12 +130,35 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
     /// Thrown when <paramref name="length"/> is negative or greater than the length of <paramref name="secretSource"/>.
     /// </exception>
 #if NET8_0_OR_GREATER
-    public Secret(ReadOnlySpan<byte> secretSource, int length)
+    public Secret(ReadOnlySpan<byte> secretSource, int length) : this(secretSource, length, CryptoRandomSource.Instance)
+    {
+    }
+#else
+    public Secret(byte[] secretSource, int length) : this(secretSource, length, CryptoRandomSource.Instance)
+    {
+    }
+#endif
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Secret{TNumber}"/> class, drawing the
+    /// termination byte from a caller-supplied <see cref="IRandomSource"/>.
+    /// </summary>
+    /// <param name="secretSource">A secret as array of type <see cref="byte"/></param>
+    /// <param name="length">Length of the secret</param>
+    /// <param name="randomSource">The random source used to draw the termination byte.</param>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// <paramref name="secretSource"/> or <paramref name="randomSource"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="length"/> is negative or greater than the length of <paramref name="secretSource"/>.
+    /// </exception>
+#if NET8_0_OR_GREATER
+    internal Secret(ReadOnlySpan<byte> secretSource, int length, IRandomSource randomSource)
     {
         if (secretSource.IsEmpty)
         {
 #else
-    public Secret(byte[] secretSource, int length)
+    internal Secret(byte[] secretSource, int length, IRandomSource randomSource)
     {
         if (secretSource == null)
         {
@@ -158,11 +181,16 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
             throw new ArgumentException(ErrorMessages.EmptyCollection, nameof(secretSource));
         }
 
+        if (randomSource is null)
+        {
+            throw new ArgumentNullException(nameof(randomSource));
+        }
+
         this.secretNumber = new PinnedPoolArray<byte>(length + 1);
         byte maxMarkByte = length == 1 ? MinMarkByte : MaxMarkByte;
-        // Termination byte uniformly distributed over [1, maxMarkByte]. SecureRandom.NextInt32
+        // Termination byte uniformly distributed over [1, maxMarkByte]. IRandomSource.NextInt32
         // performs rejection sampling internally — no `% maxMarkByte` modulo bias.
-        this.secretNumber.PoolArray[length] = (byte)SecureRandom.NextInt32(1, maxMarkByte + 1);
+        this.secretNumber.PoolArray[length] = (byte)randomSource.NextInt32(1, maxMarkByte + 1);
 #if NET8_0_OR_GREATER
         secretSource[..length].CopyTo(this.secretNumber.PoolArray);
 #else
@@ -1087,8 +1115,20 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
     /// <remarks>Use this ctor to create a random secret</remarks>
     internal static Secret<TNumberStatic> CreateRandom<TNumberStatic>(Calculator<TNumberStatic> prime)
     {
+        return CreateRandom(prime, CryptoRandomSource.Instance);
+    }
+
+    /// <summary>
+    /// Creates a random secret, drawing all random data from a caller-supplied
+    /// <see cref="IRandomSource"/>.
+    /// </summary>
+    /// <param name="prime">mersenne prime number</param>
+    /// <param name="randomSource">The random source used for the secret bytes and the termination byte.</param>
+    /// <remarks>Use this overload to create a random secret from a specific random source.</remarks>
+    internal static Secret<TNumberStatic> CreateRandom<TNumberStatic>(Calculator<TNumberStatic> prime, IRandomSource randomSource)
+    {
         using var randomSecretBytes = new PinnedPoolArray<byte>(prime.ByteCount);
-        SecureRandom.Fill(randomSecretBytes.PoolArray, 0, randomSecretBytes.Length);
+        randomSource.Fill(randomSecretBytes.PoolArray, 0, randomSecretBytes.Length);
 
         int i = randomSecretBytes.Length - 1;
         while (i > 0)
@@ -1108,13 +1148,13 @@ public readonly struct Secret<TNumber> : IEquatable<Secret<TNumber>>, IComparabl
                 // Fresh instance per call — must not alias a static singleton, because
                 // the caller's `using` would dispose the shared backing buffer and break
                 // every subsequent zero-draw return.
-                return new Secret<TNumberStatic>([0x00], 1);
+                return new Secret<TNumberStatic>([0x00], 1, randomSource);
             }
 
             randomSecretBytes.PoolArray[i--] = 0x00;
         }
 
         using var secretBytes = randomSecretBytes.Subset(0, randomSecretBytes.Length - (randomSecretBytes.Length - i));
-        return new Secret<TNumberStatic>(secretBytes.PoolArray, secretBytes.Length);
+        return new Secret<TNumberStatic>(secretBytes.PoolArray, secretBytes.Length, randomSource);
     }
 }

--- a/src/Cryptography/ShamirsSecretSharing/ConstantTimeSecretReconstructor`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/ConstantTimeSecretReconstructor`1.cs
@@ -1,0 +1,121 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ConstantTimeSecretReconstructor`1.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/04/2026 12:00:00 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+
+using Math;
+
+/// <summary>
+/// A <see cref="SecretReconstructor{TNumber}"/> that is constant-time by construction: it
+/// accepts only constant-time extended-GCD strategies
+/// (<see cref="IConstantTimeExtendedGcdAlgorithm{TNumber}"/>), so it cannot be paired with
+/// a variable-time modular inverse by mistake.
+/// </summary>
+/// <typeparam name="TNumber">
+/// The mathematical type used in the secret reconstruction process.
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// Supplying a variable-time strategy such as <see cref="ExtendedEuclideanAlgorithm{TNumber}"/>
+/// is a compile-time error here, because it does not carry the
+/// <see cref="IConstantTimeExtendedGcdAlgorithm{TNumber}"/> marker. Consumers that need a
+/// variable-time strategy (for example the <c>BigInteger</c> backend, where constant time is
+/// not a goal) use the base <see cref="SecretReconstructor{TNumber}"/> directly.
+/// </para>
+/// <para>
+/// The parameterless constructor wires the library's recommended constant-time default,
+/// <see cref="MersenneSafeGcdAlgorithm{TNumber}"/>. That default may change in a future
+/// <b>major</b> version; pass an explicit strategy if you need the choice pinned across
+/// upgrades.
+/// </para>
+/// <para>
+/// The constant-time guarantee is scoped and best-effort. It is only meaningful when the
+/// underlying <see cref="Math.Calculator{TNumber}"/> arithmetic is itself constant-time
+/// (the <c>SecureBigInteger</c> backend); on a variable-time backend this type is
+/// constant-time in shape only. Even on <c>SecureBigInteger</c>,
+/// <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> guarantees a constant <em>outer</em>
+/// iteration count on the public Mersenne exponent, not per-iteration uniform timing — see
+/// the Security &amp; Threat Model section of the README and the strategy's own documentation
+/// for the exact scope.
+/// </para>
+/// </remarks>
+public sealed class ConstantTimeSecretReconstructor<TNumber> : SecretReconstructor<TNumber>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConstantTimeSecretReconstructor{TNumber}"/>
+    /// class using the recommended constant-time modular-inverse strategy
+    /// (<see cref="MersenneSafeGcdAlgorithm{TNumber}"/>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The recommended default may change in a future major version. Use one of the
+    /// strategy-supplying constructors to pin the choice.
+    /// </para>
+    /// <para>
+    /// This is the only constructor that creates its own GCD strategy rather than receiving
+    /// one. That is safe today because no <see cref="IConstantTimeExtendedGcdAlgorithm{TNumber}"/>
+    /// implementation is <see cref="System.IDisposable"/>, and the base reconstructor disposes
+    /// only the security-level manager, never the GCD strategy. Should a future constant-time
+    /// strategy hold disposable state, GCD ownership would need to be tracked on the base
+    /// <see cref="SecretReconstructor{TNumber}"/>, since this internally created instance has
+    /// no other owner.
+    /// </para>
+    /// </remarks>
+    public ConstantTimeSecretReconstructor() : base(new MersenneSafeGcdAlgorithm<TNumber>()) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConstantTimeSecretReconstructor{TNumber}"/>
+    /// class with a caller-supplied constant-time extended-GCD strategy.
+    /// </summary>
+    /// <param name="constantTimeGcd">A constant-time extended greatest common divisor algorithm.</param>
+    /// <exception cref="System.ArgumentNullException">
+    /// The <paramref name="constantTimeGcd"/> parameter is <see langword="null"/>.
+    /// </exception>
+    public ConstantTimeSecretReconstructor(IConstantTimeExtendedGcdAlgorithm<TNumber> constantTimeGcd)
+        : base(constantTimeGcd) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConstantTimeSecretReconstructor{TNumber}"/>
+    /// class with a caller-supplied constant-time extended-GCD strategy and a caller-supplied
+    /// <see cref="ISecurityLevelManager{TNumber}"/>. Ownership of the manager remains with the
+    /// caller; this instance will not dispose it.
+    /// </summary>
+    /// <param name="constantTimeGcd">A constant-time extended greatest common divisor algorithm.</param>
+    /// <param name="securityLevelManager">Manages security level configuration.</param>
+    /// <exception cref="System.ArgumentNullException">
+    /// The <paramref name="constantTimeGcd"/> or <paramref name="securityLevelManager"/> parameter
+    /// is <see langword="null"/>.
+    /// </exception>
+    public ConstantTimeSecretReconstructor(
+        IConstantTimeExtendedGcdAlgorithm<TNumber> constantTimeGcd,
+        ISecurityLevelManager<TNumber> securityLevelManager)
+        : base(constantTimeGcd, securityLevelManager) { }
+}

--- a/src/Cryptography/ShamirsSecretSharing/FixedIterationSecretReconstructor`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/FixedIterationSecretReconstructor`1.cs
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// <copyright file="ConstantTimeSecretReconstructor`1.cs" company="Private">
+// <copyright file="FixedIterationSecretReconstructor`1.cs" company="Private">
 // Copyright (c) 2026 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
@@ -34,10 +34,12 @@ namespace SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
 using Math;
 
 /// <summary>
-/// A <see cref="SecretReconstructor{TNumber}"/> that is constant-time by construction: it
-/// accepts only constant-time extended-GCD strategies
-/// (<see cref="IConstantTimeExtendedGcdAlgorithm{TNumber}"/>), so it cannot be paired with
-/// a variable-time modular inverse by mistake.
+/// A <see cref="SecretReconstructor{TNumber}"/> that accepts only fixed-iteration
+/// extended-GCD strategies (<see cref="IFixedIterationExtendedGcdAlgorithm{TNumber}"/>) —
+/// strategies whose iteration count does not vary with secret operand values. Pairing it
+/// with a variable-time strategy is a compile-time error, so the operand-value-dependent
+/// iteration-count side channel of a plain extended-Euclidean GCD cannot be reintroduced
+/// by mistake.
 /// </summary>
 /// <typeparam name="TNumber">
 /// The mathematical type used in the secret reconstruction process.
@@ -46,32 +48,31 @@ using Math;
 /// <para>
 /// Supplying a variable-time strategy such as <see cref="ExtendedEuclideanAlgorithm{TNumber}"/>
 /// is a compile-time error here, because it does not carry the
-/// <see cref="IConstantTimeExtendedGcdAlgorithm{TNumber}"/> marker. Consumers that need a
-/// variable-time strategy (for example the <c>BigInteger</c> backend, where constant time is
-/// not a goal) use the base <see cref="SecretReconstructor{TNumber}"/> directly.
+/// <see cref="IFixedIterationExtendedGcdAlgorithm{TNumber}"/> marker. Consumers that need a
+/// variable-time strategy (for example the <c>BigInteger</c> backend, where timing side
+/// channels are not a goal) use the base <see cref="SecretReconstructor{TNumber}"/> directly.
 /// </para>
 /// <para>
-/// The parameterless constructor wires the library's recommended constant-time default,
+/// The parameterless constructor wires the library's recommended fixed-iteration default,
 /// <see cref="MersenneSafeGcdAlgorithm{TNumber}"/>. That default may change in a future
 /// <b>major</b> version; pass an explicit strategy if you need the choice pinned across
 /// upgrades.
 /// </para>
 /// <para>
-/// The constant-time guarantee is scoped and best-effort. It is only meaningful when the
-/// underlying <see cref="Math.Calculator{TNumber}"/> arithmetic is itself constant-time
-/// (the <c>SecureBigInteger</c> backend); on a variable-time backend this type is
-/// constant-time in shape only. Even on <c>SecureBigInteger</c>,
-/// <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> guarantees a constant <em>outer</em>
-/// iteration count on the public Mersenne exponent, not per-iteration uniform timing — see
-/// the Security &amp; Threat Model section of the README and the strategy's own documentation
-/// for the exact scope.
+/// The guarantee is scoped: the GCD iteration count is fixed on public parameters, which
+/// removes the iteration-count side channel of a plain extended-Euclidean GCD. It is
+/// <b>not</b> a per-operation constant-time guarantee — even on the <c>SecureBigInteger</c>
+/// backend, <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> is constant in its <em>outer</em>
+/// iteration count but its per-iteration timing is not uniform, and full constant-time in
+/// managed .NET is best-effort regardless. See the Security &amp; Threat Model section of the
+/// README and the strategy's own documentation for the exact scope.
 /// </para>
 /// </remarks>
-public sealed class ConstantTimeSecretReconstructor<TNumber> : SecretReconstructor<TNumber>
+public sealed class FixedIterationSecretReconstructor<TNumber> : SecretReconstructor<TNumber>
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ConstantTimeSecretReconstructor{TNumber}"/>
-    /// class using the recommended constant-time modular-inverse strategy
+    /// Initializes a new instance of the <see cref="FixedIterationSecretReconstructor{TNumber}"/>
+    /// class using the recommended fixed-iteration modular-inverse strategy
     /// (<see cref="MersenneSafeGcdAlgorithm{TNumber}"/>).
     /// </summary>
     /// <remarks>
@@ -81,41 +82,41 @@ public sealed class ConstantTimeSecretReconstructor<TNumber> : SecretReconstruct
     /// </para>
     /// <para>
     /// This is the only constructor that creates its own GCD strategy rather than receiving
-    /// one. That is safe today because no <see cref="IConstantTimeExtendedGcdAlgorithm{TNumber}"/>
+    /// one. That is safe today because no <see cref="IFixedIterationExtendedGcdAlgorithm{TNumber}"/>
     /// implementation is <see cref="System.IDisposable"/>, and the base reconstructor disposes
-    /// only the security-level manager, never the GCD strategy. Should a future constant-time
+    /// only the security-level manager, never the GCD strategy. Should a future fixed-iteration
     /// strategy hold disposable state, GCD ownership would need to be tracked on the base
     /// <see cref="SecretReconstructor{TNumber}"/>, since this internally created instance has
     /// no other owner.
     /// </para>
     /// </remarks>
-    public ConstantTimeSecretReconstructor() : base(new MersenneSafeGcdAlgorithm<TNumber>()) { }
+    public FixedIterationSecretReconstructor() : base(new MersenneSafeGcdAlgorithm<TNumber>()) { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ConstantTimeSecretReconstructor{TNumber}"/>
-    /// class with a caller-supplied constant-time extended-GCD strategy.
+    /// Initializes a new instance of the <see cref="FixedIterationSecretReconstructor{TNumber}"/>
+    /// class with a caller-supplied fixed-iteration extended-GCD strategy.
     /// </summary>
-    /// <param name="constantTimeGcd">A constant-time extended greatest common divisor algorithm.</param>
+    /// <param name="fixedIterationGcd">A fixed-iteration extended greatest common divisor algorithm.</param>
     /// <exception cref="System.ArgumentNullException">
-    /// The <paramref name="constantTimeGcd"/> parameter is <see langword="null"/>.
+    /// The <paramref name="fixedIterationGcd"/> parameter is <see langword="null"/>.
     /// </exception>
-    public ConstantTimeSecretReconstructor(IConstantTimeExtendedGcdAlgorithm<TNumber> constantTimeGcd)
-        : base(constantTimeGcd) { }
+    public FixedIterationSecretReconstructor(IFixedIterationExtendedGcdAlgorithm<TNumber> fixedIterationGcd)
+        : base(fixedIterationGcd) { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ConstantTimeSecretReconstructor{TNumber}"/>
-    /// class with a caller-supplied constant-time extended-GCD strategy and a caller-supplied
+    /// Initializes a new instance of the <see cref="FixedIterationSecretReconstructor{TNumber}"/>
+    /// class with a caller-supplied fixed-iteration extended-GCD strategy and a caller-supplied
     /// <see cref="ISecurityLevelManager{TNumber}"/>. Ownership of the manager remains with the
     /// caller; this instance will not dispose it.
     /// </summary>
-    /// <param name="constantTimeGcd">A constant-time extended greatest common divisor algorithm.</param>
+    /// <param name="fixedIterationGcd">A fixed-iteration extended greatest common divisor algorithm.</param>
     /// <param name="securityLevelManager">Manages security level configuration.</param>
     /// <exception cref="System.ArgumentNullException">
-    /// The <paramref name="constantTimeGcd"/> or <paramref name="securityLevelManager"/> parameter
+    /// The <paramref name="fixedIterationGcd"/> or <paramref name="securityLevelManager"/> parameter
     /// is <see langword="null"/>.
     /// </exception>
-    public ConstantTimeSecretReconstructor(
-        IConstantTimeExtendedGcdAlgorithm<TNumber> constantTimeGcd,
+    public FixedIterationSecretReconstructor(
+        IFixedIterationExtendedGcdAlgorithm<TNumber> fixedIterationGcd,
         ISecurityLevelManager<TNumber> securityLevelManager)
-        : base(constantTimeGcd, securityLevelManager) { }
+        : base(fixedIterationGcd, securityLevelManager) { }
 }

--- a/src/Cryptography/ShamirsSecretSharing/FixedIterationSecretReconstructor`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/FixedIterationSecretReconstructor`1.cs
@@ -59,13 +59,25 @@ using Math;
 /// upgrades.
 /// </para>
 /// <para>
-/// The guarantee is scoped: the GCD iteration count is fixed on public parameters, which
-/// removes the iteration-count side channel of a plain extended-Euclidean GCD. It is
-/// <b>not</b> a per-operation constant-time guarantee — even on the <c>SecureBigInteger</c>
-/// backend, <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> is constant in its <em>outer</em>
-/// iteration count but its per-iteration timing is not uniform, and full constant-time in
-/// managed .NET is best-effort regardless. See the Security &amp; Threat Model section of the
-/// README and the strategy's own documentation for the exact scope.
+/// The guarantee is scoped and relative to a fixed security level: for a given Mersenne
+/// modulus, the GCD iteration count depends only on that (public) modulus, not on the secret
+/// operand values — which removes the operand-value-dependent iteration-count side channel of
+/// a plain extended-Euclidean GCD. It is <b>not</b> a per-operation constant-time guarantee —
+/// even on the <c>SecureBigInteger</c> backend, <see cref="MersenneSafeGcdAlgorithm{TNumber}"/>
+/// is constant in its <em>outer</em> iteration count but its per-iteration timing is not
+/// uniform, and full constant-time in managed .NET is best-effort regardless.
+/// </para>
+/// <para>
+/// The security level is not pinned by this type: the base reconstructor's <c>Reconstruction</c>
+/// selects it from the shares — it calls <see cref="ISecurityLevelManager{TNumber}"/>'s
+/// <c>AdjustSecurityLevel</c> with the maximum share value — so across reconstructions of
+/// different secrets the chosen modulus, and therefore the iteration count, reflects that
+/// level. The level is already revealed by the share sizes, so this leaks nothing to anyone
+/// who holds or has seen the shares; only a pure-timing observer with no share access could
+/// infer the (coarse, usually deployment-fixed) level from it. What this type removes is the
+/// operand-value dependence <em>within</em> a level; the level-selection dependence is
+/// inherent to <c>Reconstruction</c>. See the Security &amp; Threat Model section of the README
+/// and the strategy's own documentation for the exact scope.
 /// </para>
 /// </remarks>
 public sealed class FixedIterationSecretReconstructor<TNumber> : SecretReconstructor<TNumber>

--- a/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretSplitter`1.cs
@@ -74,6 +74,12 @@ public sealed class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     private readonly bool ownsSecurityLevelManager;
 
     /// <summary>
+    /// The random source used for the polynomial coefficients and the random secret. Defaults to
+    /// <see cref="CryptoRandomSource.Instance"/>; a deterministic source may be injected for testing.
+    /// </summary>
+    private readonly IRandomSource randomSource;
+
+    /// <summary>
     /// Disposal flag manipulated atomically via <see cref="Interlocked.Exchange(ref int, int)"/>:
     /// 0 = alive, 1 = disposed.
     /// </summary>
@@ -88,6 +94,7 @@ public sealed class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     {
         this.securityLevelManager = new SecurityLevelManager<TNumber>();
         this.ownsSecurityLevelManager = true;
+        this.randomSource = CryptoRandomSource.Instance;
     }
 
     /// <summary>
@@ -103,6 +110,24 @@ public sealed class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
     {
         this.securityLevelManager = securityLevelManager ?? throw new ArgumentNullException(nameof(securityLevelManager));
         this.ownsSecurityLevelManager = false;
+        this.randomSource = CryptoRandomSource.Instance;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SecretSplitter{TNumber}"/> class using a default
+    /// <see cref="SecurityLevelManager{TNumber}"/> (owned by this instance and disposed together with
+    /// it) and a caller-supplied <see cref="IRandomSource"/>. Intended for testing with a
+    /// deterministic random source.
+    /// </summary>
+    /// <param name="randomSource">The random source used for the polynomial coefficients and the random secret.</param>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="randomSource"/> parameter is <see langword="null"/>.
+    /// </exception>
+    internal SecretSplitter(IRandomSource randomSource)
+    {
+        this.securityLevelManager = new SecurityLevelManager<TNumber>();
+        this.ownsSecurityLevelManager = true;
+        this.randomSource = randomSource ?? throw new ArgumentNullException(nameof(randomSource));
     }
 
     /// <summary>
@@ -198,7 +223,7 @@ public sealed class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
             throw new InvalidOperationException(ErrorMessages.SecurityLevelNotInitialized);
         }
 
-        generatedSecret = Secret<TNumber>.CreateRandom(this.securityLevelManager.MersennePrime);
+        generatedSecret = Secret<TNumber>.CreateRandom(this.securityLevelManager.MersennePrime, this.randomSource);
         Calculator<TNumber>[] polynomial = null;
         try
         {
@@ -359,7 +384,7 @@ public sealed class SecretSplitter<TNumber> : IMakeSharesUseCase<TNumber>
             {
                 while (true)
                 {
-                    SecureRandom.Fill(randomBytePool.PoolArray, 0, mersennePrimeByteCount);
+                    this.randomSource.Fill(randomBytePool.PoolArray, 0, mersennePrimeByteCount);
                     using var randomValue = Calculator.Create<TNumber>(randomBytePool.PoolArray, randomBytePool.Length);
 
                     if (randomValue >= rangeBound)

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -578,9 +578,9 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection, 
     /// are no-ops.
     /// </summary>
     /// <remarks>
-    /// <b>Ownership:</b> a <see cref="Shares{TNumber}"/> collection owns every share it contains.
-    /// Disposing the collection disposes all contained shares. Shares removed via
-    /// <see cref="Remove"/> are returned to the caller, who then owns disposal.
+    /// <b>Ownership:</b> a <see cref="Shares{TNumber}"/> collection owns every share it contains, and
+    /// disposing the collection disposes them all. The collection is read-only, so there is no removal
+    /// path (<see cref="Remove"/> throws) that hands an individual share's ownership back to the caller.
     /// </remarks>
     public void Dispose()
     {

--- a/src/Cryptography/SharesEnumerator.cs
+++ b/src/Cryptography/SharesEnumerator.cs
@@ -110,7 +110,7 @@ public sealed class SharesEnumerator<TNumber> : IEnumerator<Share<TNumber>>
             {
                 return this.shareList[this.position];
             }
-            catch (IndexOutOfRangeException)
+            catch (ArgumentOutOfRangeException)
             {
                 throw new InvalidOperationException();
             }

--- a/src/Math/IConstantTimeExtendedGcdAlgorithm`1.cs
+++ b/src/Math/IConstantTimeExtendedGcdAlgorithm`1.cs
@@ -1,0 +1,62 @@
+// ----------------------------------------------------------------------------
+// <copyright file="IConstantTimeExtendedGcdAlgorithm`1.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/04/2026 12:00:00 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Math;
+
+/// <summary>
+/// Capability marker for extended-GCD strategies whose modular-inverse timing depends
+/// only on public quantities (operand bit length, configured Mersenne exponent) and not
+/// on secret operand values.
+/// </summary>
+/// <typeparam name="TNumber">Numeric data type (An integer type)</typeparam>
+/// <remarks>
+/// <para>
+/// This interface adds no members over <see cref="IExtendedGcdAlgorithm{TNumber}"/>; it
+/// exists to type-tag the constant-time members of the GCD-strategy family. The tag is
+/// load-bearing rather than documentary: the constant-time reconstructor
+/// (<c>ConstantTimeSecretReconstructor&lt;TNumber&gt;</c>) accepts only implementations of
+/// this interface, so a variable-time strategy cannot be supplied to it by mistake — the
+/// mispairing becomes a compile-time error instead of a silent side-channel.
+/// </para>
+/// <para>
+/// <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> implements this marker.
+/// <see cref="ExtendedEuclideanAlgorithm{TNumber}"/> deliberately does not: its iteration
+/// count is variable on the operand values.
+/// </para>
+/// <para>
+/// The constant-time guarantee is scoped and best-effort. It is only meaningful when the
+/// underlying <see cref="Calculator{TNumber}"/> arithmetic is itself constant-time (the
+/// <c>SecureBigInteger</c> backend); on a variable-time backend the strategy is
+/// constant-time in shape only. See the Security &amp; Threat Model section of the README
+/// and the implementing type's own documentation for the exact scope.
+/// </para>
+/// </remarks>
+public interface IConstantTimeExtendedGcdAlgorithm<TNumber> : IExtendedGcdAlgorithm<TNumber>;

--- a/src/Math/IConstantTimeExtendedGcdAlgorithm`1.cs
+++ b/src/Math/IConstantTimeExtendedGcdAlgorithm`1.cs
@@ -32,9 +32,10 @@
 namespace SecretSharingDotNet.Math;
 
 /// <summary>
-/// Capability marker for extended-GCD strategies whose modular-inverse timing depends
-/// only on public quantities (operand bit length, configured Mersenne exponent) and not
-/// on secret operand values.
+/// Capability marker for extended-GCD strategies whose iteration count is fixed on public
+/// parameters (operand bit length, configured Mersenne exponent) and does not vary with
+/// secret operand values — removing the operand-value-dependent iteration-count side channel
+/// of a plain extended-Euclidean GCD.
 /// </summary>
 /// <typeparam name="TNumber">Numeric data type (An integer type)</typeparam>
 /// <remarks>
@@ -52,11 +53,16 @@ namespace SecretSharingDotNet.Math;
 /// count is variable on the operand values.
 /// </para>
 /// <para>
-/// The constant-time guarantee is scoped and best-effort. It is only meaningful when the
-/// underlying <see cref="Calculator{TNumber}"/> arithmetic is itself constant-time (the
-/// <c>SecureBigInteger</c> backend); on a variable-time backend the strategy is
-/// constant-time in shape only. See the Security &amp; Threat Model section of the README
-/// and the implementing type's own documentation for the exact scope.
+/// This marker asserts iteration-count / control-flow operand-independence, <b>not</b>
+/// per-operation uniform wall-clock timing: an implementation's per-iteration cost may still
+/// vary with secret operands (see the implementing type's threat-model documentation for its
+/// exact scope — for example <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> is
+/// "outer-iteration-count constant-time" but not per-iteration uniform on the
+/// <c>SecureBigInteger</c> backend). Like the rest of the library's constant-time surface it
+/// is best-effort against passive timing analysis and has not been audited against active
+/// co-located attackers, and it is only meaningful when the underlying
+/// <see cref="Calculator{TNumber}"/> arithmetic is itself constant-time (the
+/// <c>SecureBigInteger</c> backend). See the Security &amp; Threat Model section of the README.
 /// </para>
 /// </remarks>
 public interface IConstantTimeExtendedGcdAlgorithm<TNumber> : IExtendedGcdAlgorithm<TNumber>;

--- a/src/Math/IFixedIterationExtendedGcdAlgorithm`1.cs
+++ b/src/Math/IFixedIterationExtendedGcdAlgorithm`1.cs
@@ -53,10 +53,12 @@ namespace SecretSharingDotNet.Math;
 /// count is variable on the operand values.
 /// </para>
 /// <para>
-/// This marker asserts iteration-count / control-flow operand-independence, <b>not</b>
-/// per-operation uniform wall-clock timing: an implementation's per-iteration cost may still
-/// vary with secret operands (see the implementing type's threat-model documentation for its
-/// exact scope — for example <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> is
+/// This marker asserts <b>iteration-count</b> operand-independence only — the number of
+/// iterations is fixed on public parameters. It does <b>not</b> assert per-iteration
+/// control-flow or wall-clock uniformity: an implementation may still select its per-iteration
+/// branches from, and vary its per-iteration cost with, secret operands (see the implementing
+/// type's threat-model documentation for its exact scope — for example
+/// <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> is
 /// "outer-iteration-count constant-time" but not per-iteration uniform on the
 /// <c>SecureBigInteger</c> backend). Like the rest of the library's constant-time surface it
 /// is best-effort against passive timing analysis and has not been audited against active

--- a/src/Math/IFixedIterationExtendedGcdAlgorithm`1.cs
+++ b/src/Math/IFixedIterationExtendedGcdAlgorithm`1.cs
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// <copyright file="IConstantTimeExtendedGcdAlgorithm`1.cs" company="Private">
+// <copyright file="IFixedIterationExtendedGcdAlgorithm`1.cs" company="Private">
 // Copyright (c) 2026 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
@@ -41,9 +41,9 @@ namespace SecretSharingDotNet.Math;
 /// <remarks>
 /// <para>
 /// This interface adds no members over <see cref="IExtendedGcdAlgorithm{TNumber}"/>; it
-/// exists to type-tag the constant-time members of the GCD-strategy family. The tag is
-/// load-bearing rather than documentary: the constant-time reconstructor
-/// (<c>ConstantTimeSecretReconstructor&lt;TNumber&gt;</c>) accepts only implementations of
+/// exists to type-tag the fixed-iteration members of the GCD-strategy family. The tag is
+/// load-bearing rather than documentary: the fixed-iteration reconstructor
+/// (<c>FixedIterationSecretReconstructor&lt;TNumber&gt;</c>) accepts only implementations of
 /// this interface, so a variable-time strategy cannot be supplied to it by mistake — the
 /// mispairing becomes a compile-time error instead of a silent side-channel.
 /// </para>
@@ -65,4 +65,4 @@ namespace SecretSharingDotNet.Math;
 /// <c>SecureBigInteger</c> backend). See the Security &amp; Threat Model section of the README.
 /// </para>
 /// </remarks>
-public interface IConstantTimeExtendedGcdAlgorithm<TNumber> : IExtendedGcdAlgorithm<TNumber>;
+public interface IFixedIterationExtendedGcdAlgorithm<TNumber> : IExtendedGcdAlgorithm<TNumber>;

--- a/src/Math/MersenneSafeGcdAlgorithm.cs
+++ b/src/Math/MersenneSafeGcdAlgorithm.cs
@@ -158,7 +158,7 @@ using System;
 /// operator surface.
 /// </para>
 /// </remarks>
-public sealed class MersenneSafeGcdAlgorithm<TNumber> : IExtendedGcdAlgorithm<TNumber>
+public sealed class MersenneSafeGcdAlgorithm<TNumber> : IConstantTimeExtendedGcdAlgorithm<TNumber>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> class.

--- a/src/Math/MersenneSafeGcdAlgorithm.cs
+++ b/src/Math/MersenneSafeGcdAlgorithm.cs
@@ -158,7 +158,7 @@ using System;
 /// operator surface.
 /// </para>
 /// </remarks>
-public sealed class MersenneSafeGcdAlgorithm<TNumber> : IConstantTimeExtendedGcdAlgorithm<TNumber>
+public sealed class MersenneSafeGcdAlgorithm<TNumber> : IFixedIterationExtendedGcdAlgorithm<TNumber>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> class.

--- a/src/Math/Numerics/SecureBigInteger.cs
+++ b/src/Math/Numerics/SecureBigInteger.cs
@@ -2370,16 +2370,14 @@ public sealed class SecureBigInteger : IDisposable, IEquatable<SecureBigInteger>
     public override int GetHashCode()
     {
         this.ThrowIfDisposed();
+        // Hash only public metadata (sign + limb count), never the secret limb content: keeps the
+        // Equals/GetHashCode contract (equal values share sign + trimmed limb count) without
+        // exposing a value-derived hash of secret material.
         int len = this.limbs.Length;
 #if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
         var hash = new HashCode();
         hash.Add(this.Sign);
         hash.Add(len);
-        for (int i = 0; i < len; i++)
-        {
-            hash.Add(this.limbs[i]);
-        }
-
         return hash.ToHashCode();
 #else
         unchecked
@@ -2387,11 +2385,6 @@ public sealed class SecureBigInteger : IDisposable, IEquatable<SecureBigInteger>
             var hash = 17;
             hash = hash * 31 + this.Sign.GetHashCode();
             hash = hash * 31 + len.GetHashCode();
-            for (int i = 0; i < len; i++)
-            {
-                hash = hash * 31 + this.limbs[i].GetHashCode();
-            }
-
             return hash;
         }
 #endif

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -18,7 +18,7 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("1.0.1")]
 [assembly: AssemblyFileVersion("1.0.1")]
-[assembly: AssemblyInformationalVersion("1.0.1-rc01")]
+[assembly: AssemblyInformationalVersion("1.0.1-rc02")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -11,14 +11,14 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <PackageId>SecretSharingDotNet</PackageId>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v1.0.1-rc01/CHANGELOG.md</PackageReleaseNotes>
+        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v1.0.1-rc02/CHANGELOG.md</PackageReleaseNotes>
         <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
         <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
         <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>1.0.1-rc01</Version>
+        <Version>1.0.1-rc02</Version>
         <Authors>Sebastian Walther</Authors>
         <Company>Private Person</Company>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/tests/Cryptography/BigInteger/SecretTest.cs
+++ b/tests/Cryptography/BigInteger/SecretTest.cs
@@ -826,6 +826,41 @@ public class SecretTest
     }
 
     /// <summary>
+    /// SEC-1 regression: <see cref="Secret{TNumber}.GetHashCode"/> is consistent with by-value
+    /// <see cref="Secret{TNumber}.Equals(Secret{TNumber})"/> — two distinct instances holding the
+    /// same payload produce equal hash codes (Equals/GetHashCode contract). Previously the hash was
+    /// identity-based, so equal secrets produced unequal hashes and Secret was broken as a hash key.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_EqualSecrets_ReturnSameHashCode()
+    {
+        // Arrange — two independently constructed secrets with the same payload bytes.
+        byte[] payload = { 0x01, 0x02, 0x03, 0x04 };
+        using var secretA = new Secret<BigInteger>(payload);
+        using var secretB = new Secret<BigInteger>(payload);
+
+        // Act & Assert — equal by value, therefore equal hash.
+        Assert.Equal(secretA, secretB);
+        Assert.Equal(secretA.GetHashCode(), secretB.GetHashCode());
+    }
+
+    /// <summary>
+    /// SEC-1 (metadata only): the hash reflects only the public payload length, never secret
+    /// content — two same-length secrets with different payloads produce the same hash.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_SameLengthDifferentPayload_ReturnSameHashCode()
+    {
+        // Arrange — equal payload length (4 bytes), different content.
+        using var secretA = new Secret<BigInteger>(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        using var secretB = new Secret<BigInteger>(new byte[] { 0x11, 0x22, 0x33, 0x44 });
+
+        // Act & Assert — different payloads, but the hash carries only the length.
+        Assert.NotEqual(secretA, secretB);
+        Assert.Equal(secretA.GetHashCode(), secretB.GetHashCode());
+    }
+
+    /// <summary>
     /// Regression guard for ultrareview Bug 4: <see cref="Secret{TNumber}.ToByteArray"/>
     /// on a default-value struct returns an empty <see cref="PinnedPoolArray{Byte}"/>
     /// rather than NRE-ing on the <see langword="null"/> <c>secretNumber</c>. Without

--- a/tests/Cryptography/BigInteger/SharesTest.cs
+++ b/tests/Cryptography/BigInteger/SharesTest.cs
@@ -150,6 +150,25 @@ public class SharesTest
     }
 
     /// <summary>
+    /// Regression (SE-1): <see cref="System.Collections.IEnumerator.Current"/> must throw
+    /// <see cref="InvalidOperationException"/> when accessed before the first <c>MoveNext</c>
+    /// (undefined position per the enumerator contract). Previously the getter surfaced the raw
+    /// <see cref="ArgumentOutOfRangeException"/> from the backing indexer.
+    /// </summary>
+    [Fact]
+    public void GetEnumerator_CurrentBeforeMoveNext_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var lines = TestData.GetPredefinedShares().ToPinnedSecureShareLines();
+        using var shares = Shares<BigInteger>.FromTextLines(lines);
+        var enumerator = ((IEnumerable)shares).GetEnumerator();
+        using var disposable = enumerator as IDisposable;
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => _ = enumerator.Current);
+    }
+
+    /// <summary>
     /// Tests that <see cref="Shares{TNumber}.Count"/> reports the number of shares parsed
     /// from the pre-defined predefined-shares fixture.
     /// </summary>

--- a/tests/Cryptography/CryptoRandomSourceTest.cs
+++ b/tests/Cryptography/CryptoRandomSourceTest.cs
@@ -36,6 +36,9 @@ namespace SecretSharingDotNetTest.Cryptography;
 
 using SecretSharingDotNet.Cryptography;
 using System;
+#if NET8_0_OR_GREATER
+using System.Threading.Tasks;
+#endif
 using Xunit;
 
 /// <summary>
@@ -112,4 +115,35 @@ public class CryptoRandomSourceTest
             Assert.InRange(value, 1, 127);
         }
     }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Concurrency stress test: many threads drawing from the shared
+    /// <see cref="CryptoRandomSource.Instance"/> in parallel must all receive valid, in-range output
+    /// without corruption or exceptions. Validates the documented thread-safety of the stateless
+    /// singleton (it forwards to the thread-safe <see cref="SecureRandom"/>). Opt-in via the
+    /// <c>Category=Stress</c> trait.
+    /// </summary>
+    [Fact]
+    [Trait(StressTraits.CategoryKey, StressTraits.CategoryValue)]
+    public void Instance_ConcurrentDraws_StayWithinRangeWithoutError()
+    {
+        // Arrange
+        const int degreeOfParallelism = 16;
+        const int drawsPerWorker = 250;
+
+        // Act & Assert
+        Parallel.For(0, degreeOfParallelism, _ =>
+        {
+            var buffer = new byte[32];
+            for (int i = 0; i < drawsPerWorker; i++)
+            {
+                int value = CryptoRandomSource.Instance.NextInt32(1, 128);
+                Assert.InRange(value, 1, 127);
+
+                CryptoRandomSource.Instance.Fill(buffer, 0, buffer.Length);
+            }
+        });
+    }
+#endif
 }

--- a/tests/Cryptography/CryptoRandomSourceTest.cs
+++ b/tests/Cryptography/CryptoRandomSourceTest.cs
@@ -1,0 +1,115 @@
+// ----------------------------------------------------------------------------
+// <copyright file="CryptoRandomSourceTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/10/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+
+namespace SecretSharingDotNetTest.Cryptography;
+
+using SecretSharingDotNet.Cryptography;
+using System;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="CryptoRandomSource"/> — the default <see cref="IRandomSource"/>
+/// implementation forwarding to <see cref="SecureRandom"/>. Verifies the shared instance and
+/// that the two forwarded operations honour the <see cref="IRandomSource"/> contract.
+/// </summary>
+public class CryptoRandomSourceTest
+{
+    /// <summary>
+    /// Tests that the shared <see cref="CryptoRandomSource.Instance"/> is available (used as the
+    /// default random source throughout the library).
+    /// </summary>
+    [Fact]
+    public void Instance_IsNotNull()
+    {
+        // Act & Assert
+        Assert.NotNull(CryptoRandomSource.Instance);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CryptoRandomSource.Fill"/> forwards the argument contract of
+    /// <see cref="SecureRandom.Fill"/> — a <see langword="null"/> buffer is rejected with
+    /// <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Fill_NullBuffer_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentNullException>(() => CryptoRandomSource.Instance.Fill(null!, 0, 0));
+        Assert.Equal("buffer", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CryptoRandomSource.Fill"/> writes only within the requested
+    /// <c>[offset, offset + count)</c> window and leaves the surrounding bytes untouched.
+    /// </summary>
+    [Fact]
+    public void Fill_WritesOnlyWithinRequestedRange()
+    {
+        // Arrange — sentinel-filled buffer; fill only the middle 8 bytes.
+        var buffer = new byte[16];
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = 0xAA;
+        }
+
+        // Act
+        CryptoRandomSource.Instance.Fill(buffer, 4, 8);
+
+        // Assert — bytes outside [4, 12) are still the sentinel.
+        for (int i = 0; i < 4; i++)
+        {
+            Assert.Equal((byte)0xAA, buffer[i]);
+        }
+
+        for (int i = 12; i < buffer.Length; i++)
+        {
+            Assert.Equal((byte)0xAA, buffer[i]);
+        }
+    }
+
+    /// <summary>
+    /// Tests that <see cref="CryptoRandomSource.NextInt32"/> returns values within the
+    /// half-open range <c>[fromInclusive, toExclusive)</c> across many draws.
+    /// </summary>
+    [Fact]
+    public void NextInt32_StaysWithinRequestedRange()
+    {
+        // Act & Assert — 1000 draws must all land in [1, 128).
+        for (int i = 0; i < 1000; i++)
+        {
+            int value = CryptoRandomSource.Instance.NextInt32(1, 128);
+            Assert.InRange(value, 1, 127);
+        }
+    }
+}

--- a/tests/Cryptography/DeterministicRandomSource.cs
+++ b/tests/Cryptography/DeterministicRandomSource.cs
@@ -1,0 +1,100 @@
+// ----------------------------------------------------------------------------
+// <copyright file="DeterministicRandomSource.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/10/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+
+namespace SecretSharingDotNetTest.Cryptography;
+
+using SecretSharingDotNet.Cryptography;
+using System;
+
+/// <summary>
+/// Deterministic <see cref="IRandomSource"/> test double backed by a seeded
+/// <see cref="Random"/>. Given the same seed it reproduces the same byte and integer stream,
+/// which makes the split output (random secret + polynomial coefficients) reproducible in tests.
+/// </summary>
+/// <remarks>
+/// This double is <b>not</b> cryptographically secure and <b>not</b> thread-safe — it exists
+/// solely to exercise the <see cref="IRandomSource"/> seam under the single-threaded test harness.
+/// Its argument guards mirror <see cref="SecureRandom"/> so it is a faithful stand-in.
+/// </remarks>
+internal sealed class DeterministicRandomSource : IRandomSource
+{
+    /// <summary>
+    /// The seeded pseudo-random generator producing the deterministic stream.
+    /// </summary>
+    private readonly Random random;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeterministicRandomSource"/> class.
+    /// </summary>
+    /// <param name="seed">Seed for the underlying <see cref="Random"/>; equal seeds yield equal streams.</param>
+    public DeterministicRandomSource(int seed)
+    {
+        this.random = new Random(seed);
+    }
+
+    /// <inheritdoc/>
+    public void Fill(byte[] buffer, int offset, int count)
+    {
+        if (buffer is null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        if (offset < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(offset));
+        }
+
+        if (count < 0 || offset + count > buffer.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        for (int i = 0; i < count; i++)
+        {
+            buffer[offset + i] = (byte)this.random.Next(0, 256);
+        }
+    }
+
+    /// <inheritdoc/>
+    public int NextInt32(int fromInclusive, int toExclusive)
+    {
+        if (toExclusive <= fromInclusive)
+        {
+            throw new ArgumentOutOfRangeException(nameof(toExclusive));
+        }
+
+        return this.random.Next(fromInclusive, toExclusive);
+    }
+}

--- a/tests/Cryptography/SecureBigInteger/SecretTest.cs
+++ b/tests/Cryptography/SecureBigInteger/SecretTest.cs
@@ -854,6 +854,41 @@ public class SecretTest
     }
 
     /// <summary>
+    /// SEC-1 regression: <see cref="Secret{TNumber}.GetHashCode"/> is consistent with by-value
+    /// <see cref="Secret{TNumber}.Equals(Secret{TNumber})"/> — two distinct instances holding the
+    /// same payload produce equal hash codes (Equals/GetHashCode contract). Previously the hash was
+    /// identity-based, so equal secrets produced unequal hashes and Secret was broken as a hash key.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_EqualSecrets_ReturnSameHashCode()
+    {
+        // Arrange — two independently constructed secrets with the same payload bytes.
+        byte[] payload = { 0x01, 0x02, 0x03, 0x04 };
+        using var secretA = new Secret<SecureBigInteger>(payload);
+        using var secretB = new Secret<SecureBigInteger>(payload);
+
+        // Act & Assert — equal by value, therefore equal hash.
+        Assert.Equal(secretA, secretB);
+        Assert.Equal(secretA.GetHashCode(), secretB.GetHashCode());
+    }
+
+    /// <summary>
+    /// SEC-1 (metadata only): the hash reflects only the public payload length, never secret
+    /// content — two same-length secrets with different payloads produce the same hash.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_SameLengthDifferentPayload_ReturnSameHashCode()
+    {
+        // Arrange — equal payload length (4 bytes), different content.
+        using var secretA = new Secret<SecureBigInteger>(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        using var secretB = new Secret<SecureBigInteger>(new byte[] { 0x11, 0x22, 0x33, 0x44 });
+
+        // Act & Assert — different payloads, but the hash carries only the length.
+        Assert.NotEqual(secretA, secretB);
+        Assert.Equal(secretA.GetHashCode(), secretB.GetHashCode());
+    }
+
+    /// <summary>
     /// Regression guard for ultrareview Bug 4: <see cref="Secret{TNumber}.ToByteArray"/>
     /// on a default-value struct returns an empty <see cref="PinnedPoolArray{Byte}"/>
     /// rather than NRE-ing on the <see langword="null"/> <c>secretNumber</c>. Without

--- a/tests/Cryptography/SecureBigInteger/SharesTest.cs
+++ b/tests/Cryptography/SecureBigInteger/SharesTest.cs
@@ -193,6 +193,25 @@ public class SharesTest
     }
 
     /// <summary>
+    /// Regression (SE-1): <see cref="System.Collections.IEnumerator.Current"/> must throw
+    /// <see cref="InvalidOperationException"/> when accessed before the first <c>MoveNext</c>
+    /// (undefined position per the enumerator contract). Previously the getter surfaced the raw
+    /// <see cref="ArgumentOutOfRangeException"/> from the backing indexer.
+    /// </summary>
+    [Fact]
+    public void GetEnumerator_CurrentBeforeMoveNext_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var lines = TestData.GetPredefinedShares().ToPinnedSecureShareLines();
+        using var shares = Shares<SecureBigInteger>.FromTextLines(lines);
+        var enumerator = ((IEnumerable)shares).GetEnumerator();
+        using var disposable = enumerator as IDisposable;
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => _ = enumerator.Current);
+    }
+
+    /// <summary>
     /// Tests that <see cref="Shares{TNumber}.Count"/> reports the number of shares parsed
     /// from the pre-defined predefined-shares fixture.
     /// </summary>

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/ConstantTimeSecretReconstructorTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/ConstantTimeSecretReconstructorTest.cs
@@ -1,0 +1,158 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ConstantTimeSecretReconstructorTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/04/2026 12:00:00 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.BigInteger;
+
+using Moq;
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Cryptography.SecureInput;
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using System.Linq;
+using System.Numerics;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="ConstantTimeSecretReconstructor{TNumber}"/> on the
+/// <see cref="BigInteger"/> backend. Mirror of the SecureBigInteger-side test class, kept for
+/// symmetry across the two backend hierarchies. Note that the constant-time guarantee does
+/// <b>not</b> hold on this backend — <see cref="BigInteger"/> arithmetic is variable-time, so
+/// the type is constant-time in shape only. These tests therefore assert the wiring, the
+/// round-trip correctness, and the type / marker relationships, not any timing property.
+/// </summary>
+public class ConstantTimeSecretReconstructorTest
+{
+    /// <summary>
+    /// Tests that the parameterless constructor — which wires the recommended constant-time
+    /// default (<see cref="MersenneSafeGcdAlgorithm{TNumber}"/>) — reconstructs the original
+    /// secret from a K-of-N subset of shares.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_WithParameterlessCtor_RestoresSecret()
+    {
+        // Arrange
+        using var splitter = new SecretSplitter<BigInteger>();
+        using var reconstructor = new ConstantTimeSecretReconstructor<BigInteger>();
+        using var pinnedText = "constant-time round-trip".ToPinnedSecure();
+        using var secret = Secret<BigInteger>.FromText(pinnedText);
+
+        // Act
+        using var shares = splitter.MakeShares(3, 7, secret);
+        var subset = shares.Where(share => share.IsIndexOdd).ToArray();
+        using var recoveredSecret = reconstructor.Reconstruction(subset);
+
+        // Assert
+        Assert.Equal(secret, recoveredSecret);
+    }
+
+    /// <summary>
+    /// Tests that the constructor taking an explicit constant-time strategy reconstructs the
+    /// original secret from a K-of-N subset of shares.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_WithExplicitConstantTimeGcd_RestoresSecret()
+    {
+        // Arrange
+        using var splitter = new SecretSplitter<BigInteger>();
+        using var reconstructor = new ConstantTimeSecretReconstructor<BigInteger>(
+            new MersenneSafeGcdAlgorithm<BigInteger>());
+        using var pinnedText = "constant-time round-trip".ToPinnedSecure();
+        using var secret = Secret<BigInteger>.FromText(pinnedText);
+
+        // Act
+        using var shares = splitter.MakeShares(3, 7, secret);
+        var subset = shares.Where(share => share.IsIndexOdd).ToArray();
+        using var recoveredSecret = reconstructor.Reconstruction(subset);
+
+        // Assert
+        Assert.Equal(secret, recoveredSecret);
+    }
+
+    /// <summary>
+    /// Tests that disposing a <see cref="ConstantTimeSecretReconstructor{TNumber}"/> built
+    /// around a caller-supplied <see cref="ISecurityLevelManager{TNumber}"/> does NOT cascade
+    /// dispose to the injected manager — ownership stays with the caller, matching the base
+    /// reconstructor contract.
+    /// </summary>
+    [Fact]
+    public void Dispose_WithInjectedManager_DoesNotDisposeIt()
+    {
+        // Arrange
+        var managerMock = new Mock<ISecurityLevelManager<BigInteger>>();
+        var reconstructor = new ConstantTimeSecretReconstructor<BigInteger>(
+            new MersenneSafeGcdAlgorithm<BigInteger>(),
+            managerMock.Object);
+
+        // Act — caller-supplied manager: must NOT be disposed by the reconstructor.
+        reconstructor.Dispose();
+        reconstructor.Dispose();
+        reconstructor.Dispose();
+
+        // Assert
+        managerMock.Verify(m => m.Dispose(), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="ConstantTimeSecretReconstructor{TNumber}"/> is a
+    /// <see cref="SecretReconstructor{TNumber}"/> and an <see cref="IReconstructionUseCase{TNumber}"/>,
+    /// so it is a drop-in wherever the base reconstructor or the use-case interface is expected
+    /// (including dependency-injection registration).
+    /// </summary>
+    [Fact]
+    public void Instance_IsAssignableToBaseReconstructorAndUseCase()
+    {
+        // Arrange
+        using var reconstructor = new ConstantTimeSecretReconstructor<BigInteger>();
+
+        // Act & Assert
+        Assert.IsAssignableFrom<SecretReconstructor<BigInteger>>(reconstructor);
+        Assert.IsAssignableFrom<IReconstructionUseCase<BigInteger>>(reconstructor);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> is a member of the
+    /// constant-time GCD family (<see cref="IConstantTimeExtendedGcdAlgorithm{TNumber}"/>) —
+    /// the property that lets it be passed to the constant-time reconstructor while a
+    /// variable-time strategy cannot.
+    /// </summary>
+    [Fact]
+    public void MersenneSafeGcdAlgorithm_IsMemberOfConstantTimeGcdFamily()
+    {
+        // Arrange
+        var algorithm = new MersenneSafeGcdAlgorithm<BigInteger>();
+
+        // Act & Assert
+        Assert.IsAssignableFrom<IConstantTimeExtendedGcdAlgorithm<BigInteger>>(algorithm);
+    }
+}

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/FixedIterationSecretReconstructorTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/FixedIterationSecretReconstructorTest.cs
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// <copyright file="ConstantTimeSecretReconstructorTest.cs" company="Private">
+// <copyright file="FixedIterationSecretReconstructorTest.cs" company="Private">
 // Copyright (c) 2026 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
@@ -44,17 +44,18 @@ using System.Numerics;
 using Xunit;
 
 /// <summary>
-/// Tests for <see cref="ConstantTimeSecretReconstructor{TNumber}"/> on the
+/// Tests for <see cref="FixedIterationSecretReconstructor{TNumber}"/> on the
 /// <see cref="BigInteger"/> backend. Mirror of the SecureBigInteger-side test class, kept for
-/// symmetry across the two backend hierarchies. Note that the constant-time guarantee does
-/// <b>not</b> hold on this backend — <see cref="BigInteger"/> arithmetic is variable-time, so
-/// the type is constant-time in shape only. These tests therefore assert the wiring, the
-/// round-trip correctness, and the type / marker relationships, not any timing property.
+/// symmetry across the two backend hierarchies. The fixed-iteration guarantee (an
+/// operand-independent GCD iteration count) is backend-independent and holds here too; what
+/// <see cref="BigInteger"/> lacks is per-operation constant-time arithmetic, which this type
+/// does not claim. These tests assert the wiring, the round-trip correctness, and the type /
+/// marker relationships, not any timing property.
 /// </summary>
-public class ConstantTimeSecretReconstructorTest
+public class FixedIterationSecretReconstructorTest
 {
     /// <summary>
-    /// Tests that the parameterless constructor — which wires the recommended constant-time
+    /// Tests that the parameterless constructor — which wires the recommended fixed-iteration
     /// default (<see cref="MersenneSafeGcdAlgorithm{TNumber}"/>) — reconstructs the original
     /// secret from a K-of-N subset of shares.
     /// </summary>
@@ -63,8 +64,8 @@ public class ConstantTimeSecretReconstructorTest
     {
         // Arrange
         using var splitter = new SecretSplitter<BigInteger>();
-        using var reconstructor = new ConstantTimeSecretReconstructor<BigInteger>();
-        using var pinnedText = "constant-time round-trip".ToPinnedSecure();
+        using var reconstructor = new FixedIterationSecretReconstructor<BigInteger>();
+        using var pinnedText = "fixed-iteration round-trip".ToPinnedSecure();
         using var secret = Secret<BigInteger>.FromText(pinnedText);
 
         // Act
@@ -77,7 +78,7 @@ public class ConstantTimeSecretReconstructorTest
     }
 
     /// <summary>
-    /// Tests that the constructor taking an explicit constant-time strategy reconstructs the
+    /// Tests that the constructor taking an explicit fixed-iteration strategy reconstructs the
     /// original secret from a K-of-N subset of shares.
     /// </summary>
     [Fact]
@@ -85,9 +86,9 @@ public class ConstantTimeSecretReconstructorTest
     {
         // Arrange
         using var splitter = new SecretSplitter<BigInteger>();
-        using var reconstructor = new ConstantTimeSecretReconstructor<BigInteger>(
+        using var reconstructor = new FixedIterationSecretReconstructor<BigInteger>(
             new MersenneSafeGcdAlgorithm<BigInteger>());
-        using var pinnedText = "constant-time round-trip".ToPinnedSecure();
+        using var pinnedText = "fixed-iteration round-trip".ToPinnedSecure();
         using var secret = Secret<BigInteger>.FromText(pinnedText);
 
         // Act
@@ -100,7 +101,7 @@ public class ConstantTimeSecretReconstructorTest
     }
 
     /// <summary>
-    /// Tests that disposing a <see cref="ConstantTimeSecretReconstructor{TNumber}"/> built
+    /// Tests that disposing a <see cref="FixedIterationSecretReconstructor{TNumber}"/> built
     /// around a caller-supplied <see cref="ISecurityLevelManager{TNumber}"/> does NOT cascade
     /// dispose to the injected manager — ownership stays with the caller, matching the base
     /// reconstructor contract.
@@ -110,7 +111,7 @@ public class ConstantTimeSecretReconstructorTest
     {
         // Arrange
         var managerMock = new Mock<ISecurityLevelManager<BigInteger>>();
-        var reconstructor = new ConstantTimeSecretReconstructor<BigInteger>(
+        var reconstructor = new FixedIterationSecretReconstructor<BigInteger>(
             new MersenneSafeGcdAlgorithm<BigInteger>(),
             managerMock.Object);
 
@@ -124,7 +125,7 @@ public class ConstantTimeSecretReconstructorTest
     }
 
     /// <summary>
-    /// Tests that <see cref="ConstantTimeSecretReconstructor{TNumber}"/> is a
+    /// Tests that <see cref="FixedIterationSecretReconstructor{TNumber}"/> is a
     /// <see cref="SecretReconstructor{TNumber}"/> and an <see cref="IReconstructionUseCase{TNumber}"/>,
     /// so it is a drop-in wherever the base reconstructor or the use-case interface is expected
     /// (including dependency-injection registration).
@@ -133,7 +134,7 @@ public class ConstantTimeSecretReconstructorTest
     public void Instance_IsAssignableToBaseReconstructorAndUseCase()
     {
         // Arrange
-        using var reconstructor = new ConstantTimeSecretReconstructor<BigInteger>();
+        using var reconstructor = new FixedIterationSecretReconstructor<BigInteger>();
 
         // Act & Assert
         Assert.IsAssignableFrom<SecretReconstructor<BigInteger>>(reconstructor);
@@ -142,17 +143,17 @@ public class ConstantTimeSecretReconstructorTest
 
     /// <summary>
     /// Tests that <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> is a member of the
-    /// constant-time GCD family (<see cref="IConstantTimeExtendedGcdAlgorithm{TNumber}"/>) —
-    /// the property that lets it be passed to the constant-time reconstructor while a
+    /// fixed-iteration GCD family (<see cref="IFixedIterationExtendedGcdAlgorithm{TNumber}"/>) —
+    /// the property that lets it be passed to the fixed-iteration reconstructor while a
     /// variable-time strategy cannot.
     /// </summary>
     [Fact]
-    public void MersenneSafeGcdAlgorithm_IsMemberOfConstantTimeGcdFamily()
+    public void MersenneSafeGcdAlgorithm_IsMemberOfFixedIterationGcdFamily()
     {
         // Arrange
         var algorithm = new MersenneSafeGcdAlgorithm<BigInteger>();
 
         // Act & Assert
-        Assert.IsAssignableFrom<IConstantTimeExtendedGcdAlgorithm<BigInteger>>(algorithm);
+        Assert.IsAssignableFrom<IFixedIterationExtendedGcdAlgorithm<BigInteger>>(algorithm);
     }
 }

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/SecretSplitterTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/SecretSplitterTest.cs
@@ -325,4 +325,56 @@ public class SecretSplitterTest
 
         Assert.Equal(new BigInteger[] { 1, 2, 3, 4, 5 }, actualIndices);
     }
+
+    /// <summary>
+    /// Tests that injecting a deterministic <see cref="IRandomSource"/> makes
+    /// <see cref="SecretSplitter{TNumber}.MakeShares(int, int, int, out Secret{TNumber})"/>
+    /// fully reproducible: two splitters seeded identically produce the same random secret and
+    /// the same shares. This is the capability the RNG seam unlocks — without it the split is
+    /// non-deterministic and only round-trip assertions are possible.
+    /// </summary>
+    [Fact]
+    public void MakeShares_WithDeterministicRandomSource_ProducesReproducibleSecretAndShares()
+    {
+        // Arrange — two independent splitters, identical seed.
+        using var splitterA = new SecretSplitter<BigInteger>(new DeterministicRandomSource(20260710));
+        using var splitterB = new SecretSplitter<BigInteger>(new DeterministicRandomSource(20260710));
+
+        // Act
+        using var sharesA = splitterA.MakeShares(3, 5, 31, out var secretA);
+        using var sharesB = splitterB.MakeShares(3, 5, 31, out var secretB);
+        var sharesArrayA = new Share<BigInteger>[5];
+        var sharesArrayB = new Share<BigInteger>[5];
+        sharesA.CopyTo(sharesArrayA, 0);
+        sharesB.CopyTo(sharesArrayB, 0);
+
+        // Assert — identical generated secret and identical shares.
+        Assert.Equal(secretA, secretB);
+        Assert.Equal(sharesArrayA, sharesArrayB);
+
+        secretA.Dispose();
+        secretB.Dispose();
+    }
+
+    /// <summary>
+    /// Tests that a different seed yields a different random secret — proof that the split
+    /// output is genuinely wired to the injected <see cref="IRandomSource"/> and not a constant.
+    /// </summary>
+    [Fact]
+    public void MakeShares_WithDifferentSeeds_ProducesDifferentSecret()
+    {
+        // Arrange
+        using var splitterA = new SecretSplitter<BigInteger>(new DeterministicRandomSource(1));
+        using var splitterB = new SecretSplitter<BigInteger>(new DeterministicRandomSource(2));
+
+        // Act
+        using var sharesA = splitterA.MakeShares(3, 5, 31, out var secretA);
+        using var sharesB = splitterB.MakeShares(3, 5, 31, out var secretB);
+
+        // Assert
+        Assert.NotEqual(secretA, secretB);
+
+        secretA.Dispose();
+        secretB.Dispose();
+    }
 }

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingConcurrencyTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingConcurrencyTest.cs
@@ -1,0 +1,110 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ShamirsSecretSharingConcurrencyTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.BigInteger;
+
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using Xunit;
+
+/// <summary>
+/// Concurrency stress tests for Shamir's Secret Sharing over the <see cref="BigInteger"/> backend.
+/// They exercise the supported concurrency contract: many threads, each using their own
+/// <see cref="SecretSplitter{TNumber}"/> and <see cref="SecretReconstructor{TNumber}"/> instances,
+/// split and reconstruct in parallel, and every round-trip must recover its own secret. This surfaces
+/// hidden shared mutable state in the split/reconstruct path (e.g. the reflection-backed
+/// <c>Calculator</c> factory or the <c>MersennePrimeProvider</c> singleton).
+/// </summary>
+/// <remarks>
+/// A shared splitter/reconstructor is deliberately NOT exercised: it mutates its security level and
+/// is documented as not thread-safe (architecture review item A7). Opt-in via the
+/// <c>Category=Stress</c> trait; gated to net8.0+ (see <see cref="StressTraits"/>).
+/// </remarks>
+public class ShamirsSecretSharingConcurrencyTest
+{
+    /// <summary>
+    /// Independent splitter/reconstructor instances used concurrently each recover their own secret.
+    /// </summary>
+    [Fact]
+    [Trait(StressTraits.CategoryKey, StressTraits.CategoryValue)]
+    public void ParallelRoundTrip_WithIndependentInstances_EachRecoversItsSecret()
+    {
+        // Arrange
+        const int degreeOfParallelism = 16;
+        const int roundTripsPerWorker = 25;
+
+        // Act & Assert
+        Parallel.For(0, degreeOfParallelism, worker =>
+        {
+            for (int iteration = 0; iteration < roundTripsPerWorker; iteration++)
+            {
+                using var secret = new Secret<BigInteger>(BuildSecret(worker, iteration));
+                using var secretSplitter = new SecretSplitter<BigInteger>();
+                using var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+                using var shares = secretSplitter.MakeShares(3, 5, secret);
+
+                var subset = shares.Take(3).ToArray();
+                using var recovered = secretReconstructor.Reconstruction(subset);
+
+                Assert.Equal(secret, recovered);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Builds a distinct, non-empty secret for the given worker/iteration so concurrent round-trips
+    /// operate on varied inputs (and varied security levels via varied length).
+    /// </summary>
+    /// <param name="worker">The parallel worker index.</param>
+    /// <param name="iteration">The per-worker iteration index.</param>
+    /// <returns>A deterministic, distinct secret byte array of length 1..12.</returns>
+    private static byte[] BuildSecret(int worker, int iteration)
+    {
+        int length = 1 + ((worker + iteration) % 12);
+        var secretBytes = new byte[length];
+        for (int j = 0; j < length; j++)
+        {
+            secretBytes[j] = (byte)((worker * 31) + (iteration * 7) + j + 1);
+        }
+
+        return secretBytes;
+    }
+}
+
+#endif

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingPropertyTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingPropertyTest.cs
@@ -1,0 +1,123 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ShamirsSecretSharingPropertyTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.BigInteger;
+
+using CsCheck;
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using System.Linq;
+using System.Numerics;
+using Xunit;
+
+/// <summary>
+/// Property-based round-trip tests for Shamir's Secret Sharing over the <see cref="BigInteger"/>
+/// backend. They assert the core Shamir invariant — any <c>threshold</c>-sized subset of the
+/// generated shares reconstructs the original secret — across randomly generated secrets and
+/// <c>(threshold, numberOfShares)</c> configurations, complementing the hand-authored InlineData suites.
+/// </summary>
+public class ShamirsSecretSharingPropertyTest
+{
+    /// <summary>
+    /// Inclusive upper bound for the generated secret length in bytes.
+    /// </summary>
+    private const int MaxSecretLength = 32;
+
+    /// <summary>
+    /// Inclusive upper bound for the generated number of shares.
+    /// </summary>
+    private const int MaxShares = 7;
+
+    /// <summary>
+    /// Number of generated cases per property. Executed with <c>threads: 1</c> to honour the
+    /// project-wide requirement that security-sensitive tests never run in parallel.
+    /// </summary>
+    private const int Iterations = 250;
+
+    /// <summary>
+    /// Any qualifying subset — exactly <c>threshold</c> of the <c>numberOfShares</c> generated shares —
+    /// reconstructs the original secret.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_FromAnyThresholdSubset_RecoversSecret()
+    {
+        // Arrange
+        var generator = ShamirsSecretSharingGenerators.SubsetReconstruction(MaxSecretLength, MaxShares);
+
+        // Act & Assert
+        generator.Sample((secretBytes, threshold, numberOfShares, subsetOffset) =>
+        {
+            using var secret = new Secret<BigInteger>(secretBytes);
+            using var secretSplitter = new SecretSplitter<BigInteger>();
+            using var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            using var shares = secretSplitter.MakeShares(threshold, numberOfShares, secret);
+
+            // A wrap-around window of length threshold over the (index-sorted) shares is an
+            // arbitrary qualifying subset; length ≤ numberOfShares guarantees distinct shares.
+            var subset = shares.Concat(shares).Skip(subsetOffset).Take(threshold).ToArray();
+            using var recovered = secretReconstructor.Reconstruction(subset);
+
+            Assert.Equal(secret, recovered);
+        }, iter: Iterations, threads: 1);
+    }
+
+    /// <summary>
+    /// Reconstruction from the complete, over-determined share set (all <c>numberOfShares</c> shares,
+    /// which is more than <c>threshold</c>) also recovers the original secret — extra shares beyond the
+    /// threshold must not break recovery.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_FromFullShareSet_RecoversSecret()
+    {
+        // Arrange
+        var generator = ShamirsSecretSharingGenerators.FullSetReconstruction(MaxSecretLength, MaxShares);
+
+        // Act & Assert
+        generator.Sample((secretBytes, threshold, numberOfShares) =>
+        {
+            using var secret = new Secret<BigInteger>(secretBytes);
+            using var secretSplitter = new SecretSplitter<BigInteger>();
+            using var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+            using var shares = secretSplitter.MakeShares(threshold, numberOfShares, secret);
+
+            using var recovered = secretReconstructor.Reconstruction(shares);
+
+            Assert.Equal(secret, recovered);
+        }, iter: Iterations, threads: 1);
+    }
+}
+
+#endif

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ConstantTimeSecretReconstructorTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ConstantTimeSecretReconstructorTest.cs
@@ -1,0 +1,158 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ConstantTimeSecretReconstructorTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/04/2026 12:00:00 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.SecureBigInteger;
+
+using Moq;
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Cryptography.SecureInput;
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using SecretSharingDotNet.Math.Numerics;
+using System.Linq;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="ConstantTimeSecretReconstructor{TNumber}"/> on the
+/// <see cref="SecureBigInteger"/> backend — the backend on which the constant-time guarantee
+/// is meaningful. Covers the split/reconstruct round-trip through each constructor, the
+/// caller-owned security-level-manager ownership contract, and the type / marker
+/// relationships that make the constant-time pairing safe by construction. Mirror of the
+/// BigInteger-side test class.
+/// </summary>
+public class ConstantTimeSecretReconstructorTest
+{
+    /// <summary>
+    /// Tests that the parameterless constructor — which wires the recommended constant-time
+    /// default (<see cref="MersenneSafeGcdAlgorithm{TNumber}"/>) — reconstructs the original
+    /// secret from a K-of-N subset of shares.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_WithParameterlessCtor_RestoresSecret()
+    {
+        // Arrange
+        using var splitter = new SecretSplitter<SecureBigInteger>();
+        using var reconstructor = new ConstantTimeSecretReconstructor<SecureBigInteger>();
+        using var pinnedText = "constant-time round-trip".ToPinnedSecure();
+        using var secret = Secret<SecureBigInteger>.FromText(pinnedText);
+
+        // Act
+        using var shares = splitter.MakeShares(3, 7, secret);
+        var subset = shares.Where(share => share.IsIndexOdd).ToArray();
+        using var recoveredSecret = reconstructor.Reconstruction(subset);
+
+        // Assert
+        Assert.Equal(secret, recoveredSecret);
+    }
+
+    /// <summary>
+    /// Tests that the constructor taking an explicit constant-time strategy reconstructs the
+    /// original secret from a K-of-N subset of shares.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_WithExplicitConstantTimeGcd_RestoresSecret()
+    {
+        // Arrange
+        using var splitter = new SecretSplitter<SecureBigInteger>();
+        using var reconstructor = new ConstantTimeSecretReconstructor<SecureBigInteger>(
+            new MersenneSafeGcdAlgorithm<SecureBigInteger>());
+        using var pinnedText = "constant-time round-trip".ToPinnedSecure();
+        using var secret = Secret<SecureBigInteger>.FromText(pinnedText);
+
+        // Act
+        using var shares = splitter.MakeShares(3, 7, secret);
+        var subset = shares.Where(share => share.IsIndexOdd).ToArray();
+        using var recoveredSecret = reconstructor.Reconstruction(subset);
+
+        // Assert
+        Assert.Equal(secret, recoveredSecret);
+    }
+
+    /// <summary>
+    /// Tests that disposing a <see cref="ConstantTimeSecretReconstructor{TNumber}"/> built
+    /// around a caller-supplied <see cref="ISecurityLevelManager{TNumber}"/> does NOT cascade
+    /// dispose to the injected manager — ownership stays with the caller, matching the base
+    /// reconstructor contract.
+    /// </summary>
+    [Fact]
+    public void Dispose_WithInjectedManager_DoesNotDisposeIt()
+    {
+        // Arrange
+        var managerMock = new Mock<ISecurityLevelManager<SecureBigInteger>>();
+        var reconstructor = new ConstantTimeSecretReconstructor<SecureBigInteger>(
+            new MersenneSafeGcdAlgorithm<SecureBigInteger>(),
+            managerMock.Object);
+
+        // Act — caller-supplied manager: must NOT be disposed by the reconstructor.
+        reconstructor.Dispose();
+        reconstructor.Dispose();
+        reconstructor.Dispose();
+
+        // Assert
+        managerMock.Verify(m => m.Dispose(), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="ConstantTimeSecretReconstructor{TNumber}"/> is a
+    /// <see cref="SecretReconstructor{TNumber}"/> and an <see cref="IReconstructionUseCase{TNumber}"/>,
+    /// so it is a drop-in wherever the base reconstructor or the use-case interface is expected
+    /// (including dependency-injection registration).
+    /// </summary>
+    [Fact]
+    public void Instance_IsAssignableToBaseReconstructorAndUseCase()
+    {
+        // Arrange
+        using var reconstructor = new ConstantTimeSecretReconstructor<SecureBigInteger>();
+
+        // Act & Assert
+        Assert.IsAssignableFrom<SecretReconstructor<SecureBigInteger>>(reconstructor);
+        Assert.IsAssignableFrom<IReconstructionUseCase<SecureBigInteger>>(reconstructor);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> is a member of the
+    /// constant-time GCD family (<see cref="IConstantTimeExtendedGcdAlgorithm{TNumber}"/>) —
+    /// the property that lets it be passed to the constant-time reconstructor while a
+    /// variable-time strategy cannot.
+    /// </summary>
+    [Fact]
+    public void MersenneSafeGcdAlgorithm_IsMemberOfConstantTimeGcdFamily()
+    {
+        // Arrange
+        var algorithm = new MersenneSafeGcdAlgorithm<SecureBigInteger>();
+
+        // Act & Assert
+        Assert.IsAssignableFrom<IConstantTimeExtendedGcdAlgorithm<SecureBigInteger>>(algorithm);
+    }
+}

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/FixedIterationSecretReconstructorTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/FixedIterationSecretReconstructorTest.cs
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// <copyright file="ConstantTimeSecretReconstructorTest.cs" company="Private">
+// <copyright file="FixedIterationSecretReconstructorTest.cs" company="Private">
 // Copyright (c) 2026 All Rights Reserved
 // </copyright>
 // <author>Sebastian Walther</author>
@@ -44,17 +44,16 @@ using System.Linq;
 using Xunit;
 
 /// <summary>
-/// Tests for <see cref="ConstantTimeSecretReconstructor{TNumber}"/> on the
-/// <see cref="SecureBigInteger"/> backend — the backend on which the constant-time guarantee
-/// is meaningful. Covers the split/reconstruct round-trip through each constructor, the
-/// caller-owned security-level-manager ownership contract, and the type / marker
-/// relationships that make the constant-time pairing safe by construction. Mirror of the
-/// BigInteger-side test class.
+/// Tests for <see cref="FixedIterationSecretReconstructor{TNumber}"/> on the
+/// <see cref="SecureBigInteger"/> backend. Covers the split/reconstruct round-trip through
+/// each constructor, the caller-owned security-level-manager ownership contract, and the
+/// type / marker relationships that make the fixed-iteration pairing safe by construction.
+/// Mirror of the BigInteger-side test class.
 /// </summary>
-public class ConstantTimeSecretReconstructorTest
+public class FixedIterationSecretReconstructorTest
 {
     /// <summary>
-    /// Tests that the parameterless constructor — which wires the recommended constant-time
+    /// Tests that the parameterless constructor — which wires the recommended fixed-iteration
     /// default (<see cref="MersenneSafeGcdAlgorithm{TNumber}"/>) — reconstructs the original
     /// secret from a K-of-N subset of shares.
     /// </summary>
@@ -63,8 +62,8 @@ public class ConstantTimeSecretReconstructorTest
     {
         // Arrange
         using var splitter = new SecretSplitter<SecureBigInteger>();
-        using var reconstructor = new ConstantTimeSecretReconstructor<SecureBigInteger>();
-        using var pinnedText = "constant-time round-trip".ToPinnedSecure();
+        using var reconstructor = new FixedIterationSecretReconstructor<SecureBigInteger>();
+        using var pinnedText = "fixed-iteration round-trip".ToPinnedSecure();
         using var secret = Secret<SecureBigInteger>.FromText(pinnedText);
 
         // Act
@@ -77,7 +76,7 @@ public class ConstantTimeSecretReconstructorTest
     }
 
     /// <summary>
-    /// Tests that the constructor taking an explicit constant-time strategy reconstructs the
+    /// Tests that the constructor taking an explicit fixed-iteration strategy reconstructs the
     /// original secret from a K-of-N subset of shares.
     /// </summary>
     [Fact]
@@ -85,9 +84,9 @@ public class ConstantTimeSecretReconstructorTest
     {
         // Arrange
         using var splitter = new SecretSplitter<SecureBigInteger>();
-        using var reconstructor = new ConstantTimeSecretReconstructor<SecureBigInteger>(
+        using var reconstructor = new FixedIterationSecretReconstructor<SecureBigInteger>(
             new MersenneSafeGcdAlgorithm<SecureBigInteger>());
-        using var pinnedText = "constant-time round-trip".ToPinnedSecure();
+        using var pinnedText = "fixed-iteration round-trip".ToPinnedSecure();
         using var secret = Secret<SecureBigInteger>.FromText(pinnedText);
 
         // Act
@@ -100,7 +99,7 @@ public class ConstantTimeSecretReconstructorTest
     }
 
     /// <summary>
-    /// Tests that disposing a <see cref="ConstantTimeSecretReconstructor{TNumber}"/> built
+    /// Tests that disposing a <see cref="FixedIterationSecretReconstructor{TNumber}"/> built
     /// around a caller-supplied <see cref="ISecurityLevelManager{TNumber}"/> does NOT cascade
     /// dispose to the injected manager — ownership stays with the caller, matching the base
     /// reconstructor contract.
@@ -110,7 +109,7 @@ public class ConstantTimeSecretReconstructorTest
     {
         // Arrange
         var managerMock = new Mock<ISecurityLevelManager<SecureBigInteger>>();
-        var reconstructor = new ConstantTimeSecretReconstructor<SecureBigInteger>(
+        var reconstructor = new FixedIterationSecretReconstructor<SecureBigInteger>(
             new MersenneSafeGcdAlgorithm<SecureBigInteger>(),
             managerMock.Object);
 
@@ -124,7 +123,7 @@ public class ConstantTimeSecretReconstructorTest
     }
 
     /// <summary>
-    /// Tests that <see cref="ConstantTimeSecretReconstructor{TNumber}"/> is a
+    /// Tests that <see cref="FixedIterationSecretReconstructor{TNumber}"/> is a
     /// <see cref="SecretReconstructor{TNumber}"/> and an <see cref="IReconstructionUseCase{TNumber}"/>,
     /// so it is a drop-in wherever the base reconstructor or the use-case interface is expected
     /// (including dependency-injection registration).
@@ -133,7 +132,7 @@ public class ConstantTimeSecretReconstructorTest
     public void Instance_IsAssignableToBaseReconstructorAndUseCase()
     {
         // Arrange
-        using var reconstructor = new ConstantTimeSecretReconstructor<SecureBigInteger>();
+        using var reconstructor = new FixedIterationSecretReconstructor<SecureBigInteger>();
 
         // Act & Assert
         Assert.IsAssignableFrom<SecretReconstructor<SecureBigInteger>>(reconstructor);
@@ -142,17 +141,17 @@ public class ConstantTimeSecretReconstructorTest
 
     /// <summary>
     /// Tests that <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> is a member of the
-    /// constant-time GCD family (<see cref="IConstantTimeExtendedGcdAlgorithm{TNumber}"/>) —
-    /// the property that lets it be passed to the constant-time reconstructor while a
+    /// fixed-iteration GCD family (<see cref="IFixedIterationExtendedGcdAlgorithm{TNumber}"/>) —
+    /// the property that lets it be passed to the fixed-iteration reconstructor while a
     /// variable-time strategy cannot.
     /// </summary>
     [Fact]
-    public void MersenneSafeGcdAlgorithm_IsMemberOfConstantTimeGcdFamily()
+    public void MersenneSafeGcdAlgorithm_IsMemberOfFixedIterationGcdFamily()
     {
         // Arrange
         var algorithm = new MersenneSafeGcdAlgorithm<SecureBigInteger>();
 
         // Act & Assert
-        Assert.IsAssignableFrom<IConstantTimeExtendedGcdAlgorithm<SecureBigInteger>>(algorithm);
+        Assert.IsAssignableFrom<IFixedIterationExtendedGcdAlgorithm<SecureBigInteger>>(algorithm);
     }
 }

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/SecretSplitterTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/SecretSplitterTest.cs
@@ -330,4 +330,57 @@ public class SecretSplitterTest
 
         Assert.Equal(6, expectedIndex);
     }
+
+    /// <summary>
+    /// Tests that injecting a deterministic <see cref="IRandomSource"/> makes
+    /// <see cref="SecretSplitter{TNumber}.MakeShares(int, int, int, out Secret{TNumber})"/>
+    /// fully reproducible: two splitters seeded identically produce the same random secret and
+    /// the same shares. This is the capability the RNG seam unlocks — without it the split is
+    /// non-deterministic and only round-trip assertions are possible. Mirror of the BigInteger-side test.
+    /// </summary>
+    [Fact]
+    public void MakeShares_WithDeterministicRandomSource_ProducesReproducibleSecretAndShares()
+    {
+        // Arrange — two independent splitters, identical seed.
+        using var splitterA = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(20260710));
+        using var splitterB = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(20260710));
+
+        // Act
+        using var sharesA = splitterA.MakeShares(3, 5, 31, out var secretA);
+        using var sharesB = splitterB.MakeShares(3, 5, 31, out var secretB);
+        var sharesArrayA = new Share<SecureBigInteger>[5];
+        var sharesArrayB = new Share<SecureBigInteger>[5];
+        sharesA.CopyTo(sharesArrayA, 0);
+        sharesB.CopyTo(sharesArrayB, 0);
+
+        // Assert — identical generated secret and identical shares.
+        Assert.Equal(secretA, secretB);
+        Assert.Equal(sharesArrayA, sharesArrayB);
+
+        secretA.Dispose();
+        secretB.Dispose();
+    }
+
+    /// <summary>
+    /// Tests that a different seed yields a different random secret — proof that the split
+    /// output is genuinely wired to the injected <see cref="IRandomSource"/> and not a constant.
+    /// Mirror of the BigInteger-side test.
+    /// </summary>
+    [Fact]
+    public void MakeShares_WithDifferentSeeds_ProducesDifferentSecret()
+    {
+        // Arrange
+        using var splitterA = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(1));
+        using var splitterB = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(2));
+
+        // Act
+        using var sharesA = splitterA.MakeShares(3, 5, 31, out var secretA);
+        using var sharesB = splitterB.MakeShares(3, 5, 31, out var secretB);
+
+        // Assert
+        Assert.NotEqual(secretA, secretB);
+
+        secretA.Dispose();
+        secretB.Dispose();
+    }
 }

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingConcurrencyTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingConcurrencyTest.cs
@@ -1,0 +1,110 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ShamirsSecretSharingConcurrencyTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.SecureBigInteger;
+
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using SecretSharingDotNet.Math.Numerics;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+/// <summary>
+/// Concurrency stress tests for Shamir's Secret Sharing over the <see cref="SecureBigInteger"/>
+/// backend. They exercise the supported concurrency contract: many threads, each using their own
+/// <see cref="SecretSplitter{TNumber}"/> and <see cref="SecretReconstructor{TNumber}"/> instances
+/// (the latter over the constant-time <see cref="MersenneSafeGcdAlgorithm{TNumber}"/>), split and
+/// reconstruct in parallel, and every round-trip must recover its own secret.
+/// </summary>
+/// <remarks>
+/// A shared splitter/reconstructor is deliberately NOT exercised: it mutates its security level and
+/// is documented as not thread-safe (architecture review item A7). The workload is smaller than the
+/// <c>BigInteger</c> suite because <see cref="SecureBigInteger"/> arithmetic is considerably slower.
+/// Opt-in via the <c>Category=Stress</c> trait; gated to net8.0+ (see <see cref="StressTraits"/>).
+/// </remarks>
+public class ShamirsSecretSharingConcurrencyTest
+{
+    /// <summary>
+    /// Independent splitter/reconstructor instances used concurrently each recover their own secret.
+    /// </summary>
+    [Fact]
+    [Trait(StressTraits.CategoryKey, StressTraits.CategoryValue)]
+    public void ParallelRoundTrip_WithIndependentInstances_EachRecoversItsSecret()
+    {
+        // Arrange
+        const int degreeOfParallelism = 8;
+        const int roundTripsPerWorker = 5;
+
+        // Act & Assert
+        Parallel.For(0, degreeOfParallelism, worker =>
+        {
+            for (int iteration = 0; iteration < roundTripsPerWorker; iteration++)
+            {
+                using var secret = new Secret<SecureBigInteger>(BuildSecret(worker, iteration));
+                using var secretSplitter = new SecretSplitter<SecureBigInteger>();
+                using var secretReconstructor = new SecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>());
+                using var shares = secretSplitter.MakeShares(3, 5, secret);
+
+                var subset = shares.Take(3).ToArray();
+                using var recovered = secretReconstructor.Reconstruction(subset);
+
+                Assert.Equal(secret, recovered);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Builds a distinct, non-empty secret for the given worker/iteration so concurrent round-trips
+    /// operate on varied inputs (and varied security levels via varied length).
+    /// </summary>
+    /// <param name="worker">The parallel worker index.</param>
+    /// <param name="iteration">The per-worker iteration index.</param>
+    /// <returns>A deterministic, distinct secret byte array of length 1..6.</returns>
+    private static byte[] BuildSecret(int worker, int iteration)
+    {
+        int length = 1 + ((worker + iteration) % 6);
+        var secretBytes = new byte[length];
+        for (int j = 0; j < length; j++)
+        {
+            secretBytes[j] = (byte)((worker * 31) + (iteration * 7) + j + 1);
+        }
+
+        return secretBytes;
+    }
+}
+
+#endif

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingPropertyTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingPropertyTest.cs
@@ -1,0 +1,130 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ShamirsSecretSharingPropertyTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.SecureBigInteger;
+
+using CsCheck;
+using SecretSharingDotNet.Cryptography;
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using SecretSharingDotNet.Math.Numerics;
+using System.Linq;
+using Xunit;
+
+/// <summary>
+/// Property-based round-trip tests for Shamir's Secret Sharing over the <see cref="SecureBigInteger"/>
+/// backend. They assert the core Shamir invariant — any <c>threshold</c>-sized subset of the
+/// generated shares reconstructs the original secret — across randomly generated secrets and
+/// <c>(threshold, numberOfShares)</c> configurations, complementing the hand-authored InlineData suites.
+/// </summary>
+/// <remarks>
+/// The generated space (secret length, share count, iterations) is deliberately smaller than the
+/// <c>BigInteger</c> suite because <see cref="SecureBigInteger"/> arithmetic — including the
+/// constant-time <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> reconstruction path exercised here —
+/// is considerably slower.
+/// </remarks>
+public class ShamirsSecretSharingPropertyTest
+{
+    /// <summary>
+    /// Inclusive upper bound for the generated secret length in bytes.
+    /// </summary>
+    private const int MaxSecretLength = 8;
+
+    /// <summary>
+    /// Inclusive upper bound for the generated number of shares.
+    /// </summary>
+    private const int MaxShares = 5;
+
+    /// <summary>
+    /// Number of generated cases per property. Kept modest because <see cref="SecureBigInteger"/> is
+    /// slow; executed with <c>threads: 1</c> to honour the project-wide requirement that
+    /// security-sensitive tests never run in parallel.
+    /// </summary>
+    private const int Iterations = 50;
+
+    /// <summary>
+    /// Any qualifying subset — exactly <c>threshold</c> of the <c>numberOfShares</c> generated shares —
+    /// reconstructs the original secret.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_FromAnyThresholdSubset_RecoversSecret()
+    {
+        // Arrange
+        var generator = ShamirsSecretSharingGenerators.SubsetReconstruction(MaxSecretLength, MaxShares);
+
+        // Act & Assert
+        generator.Sample((secretBytes, threshold, numberOfShares, subsetOffset) =>
+        {
+            using var secret = new Secret<SecureBigInteger>(secretBytes);
+            using var secretSplitter = new SecretSplitter<SecureBigInteger>();
+            using var secretReconstructor = new SecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>());
+            using var shares = secretSplitter.MakeShares(threshold, numberOfShares, secret);
+
+            // A wrap-around window of length threshold over the (index-sorted) shares is an
+            // arbitrary qualifying subset; length ≤ numberOfShares guarantees distinct shares.
+            var subset = shares.Concat(shares).Skip(subsetOffset).Take(threshold).ToArray();
+            using var recovered = secretReconstructor.Reconstruction(subset);
+
+            Assert.Equal(secret, recovered);
+        }, iter: Iterations, threads: 1);
+    }
+
+    /// <summary>
+    /// Reconstruction from the complete, over-determined share set (all <c>numberOfShares</c> shares,
+    /// which is more than <c>threshold</c>) also recovers the original secret — extra shares beyond the
+    /// threshold must not break recovery.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_FromFullShareSet_RecoversSecret()
+    {
+        // Arrange
+        var generator = ShamirsSecretSharingGenerators.FullSetReconstruction(MaxSecretLength, MaxShares);
+
+        // Act & Assert
+        generator.Sample((secretBytes, threshold, numberOfShares) =>
+        {
+            using var secret = new Secret<SecureBigInteger>(secretBytes);
+            using var secretSplitter = new SecretSplitter<SecureBigInteger>();
+            using var secretReconstructor = new SecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>());
+            using var shares = secretSplitter.MakeShares(threshold, numberOfShares, secret);
+
+            using var recovered = secretReconstructor.Reconstruction(shares);
+
+            Assert.Equal(secret, recovered);
+        }, iter: Iterations, threads: 1);
+    }
+}
+
+#endif

--- a/tests/Cryptography/ShamirsSecretSharing/ShamirsSecretSharingGenerators.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/ShamirsSecretSharingGenerators.cs
@@ -1,0 +1,84 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ShamirsSecretSharingGenerators.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing;
+
+using CsCheck;
+
+/// <summary>
+/// Shared CsCheck generators for the Shamir's Secret Sharing property tests. Backend-agnostic:
+/// they yield raw secret bytes together with a valid share configuration, which both the
+/// <c>BigInteger</c> and <c>SecureBigInteger</c> property suites feed into their respective
+/// <see cref="SecretSharingDotNet.Cryptography.ShamirsSecretSharing.SecretSplitter{TNumber}"/>.
+/// </summary>
+/// <remarks>
+/// The generated configurations always satisfy the Shamir constraint <c>2 ≤ threshold ≤ numberOfShares</c>.
+/// Secret length and share count are bounded by the caller so the (slow) <c>SecureBigInteger</c>
+/// backend can request a smaller space than the <c>BigInteger</c> backend.
+/// </remarks>
+internal static class ShamirsSecretSharingGenerators
+{
+    /// <summary>
+    /// Generates a random secret, a valid <c>(threshold, numberOfShares)</c> configuration and a
+    /// <c>subsetOffset</c> in <c>[0, numberOfShares - 1]</c>. The offset selects a wrap-around window
+    /// of exactly <c>threshold</c> shares, i.e. an arbitrary qualifying subset.
+    /// </summary>
+    /// <param name="maxSecretLength">Inclusive upper bound for the generated secret length in bytes.</param>
+    /// <param name="maxShares">Inclusive upper bound for the generated number of shares.</param>
+    /// <returns>A generator of <c>(Secret, Threshold, NumberOfShares, SubsetOffset)</c> tuples.</returns>
+    public static Gen<(byte[] Secret, int Threshold, int NumberOfShares, int SubsetOffset)> SubsetReconstruction(
+        int maxSecretLength, int maxShares) =>
+        Gen.Byte.Array[1, maxSecretLength].SelectMany(secret =>
+            Gen.Int[2, maxShares].SelectMany(numberOfShares =>
+                Gen.Int[2, numberOfShares].SelectMany(threshold =>
+                    Gen.Int[0, numberOfShares - 1].Select(subsetOffset =>
+                        (secret, threshold, numberOfShares, subsetOffset)))));
+
+    /// <summary>
+    /// Generates a random secret and a valid <c>(threshold, numberOfShares)</c> configuration, used to
+    /// reconstruct from the complete (possibly over-determined) share set.
+    /// </summary>
+    /// <param name="maxSecretLength">Inclusive upper bound for the generated secret length in bytes.</param>
+    /// <param name="maxShares">Inclusive upper bound for the generated number of shares.</param>
+    /// <returns>A generator of <c>(Secret, Threshold, NumberOfShares)</c> tuples.</returns>
+    public static Gen<(byte[] Secret, int Threshold, int NumberOfShares)> FullSetReconstruction(
+        int maxSecretLength, int maxShares) =>
+        Gen.Byte.Array[1, maxSecretLength].SelectMany(secret =>
+            Gen.Int[2, maxShares].SelectMany(numberOfShares =>
+                Gen.Int[2, numberOfShares].Select(threshold =>
+                    (secret, threshold, numberOfShares))));
+}
+
+#endif

--- a/tests/Math/Numerics/SecureBigIntegerTest.cs
+++ b/tests/Math/Numerics/SecureBigIntegerTest.cs
@@ -1722,6 +1722,23 @@ public class SecureBigIntegerTests
     }
 
     /// <summary>
+    /// Security property (SB-1): <c>GetHashCode</c> does not depend on secret value content. Two
+    /// distinct values that share the same sign and limb count produce the same hash, so the hash
+    /// carries only public metadata (sign, bit-length bucket), never value bits.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_DifferentValuesSameLimbCount_ReturnsSameHashCode()
+    {
+        // Arrange — two distinct single-limb positive values (same sign, same limb count).
+        using var operandA = new SecureBigInteger(42);
+        using var operandB = new SecureBigInteger(99);
+
+        // Act & Assert — distinct values, but the hash reflects only sign + limb count.
+        Assert.NotEqual(operandA, operandB);
+        Assert.Equal(operandA.GetHashCode(), operandB.GetHashCode());
+    }
+
+    /// <summary>
     /// Tests the <see cref="IComparable{T}"/> convention that a non-null instance
     /// compared to <see langword="null"/> returns <c>1</c>.
     /// </summary>

--- a/tests/SecretSharingDotNetTest.csproj
+++ b/tests/SecretSharingDotNetTest.csproj
@@ -39,6 +39,12 @@
         <PackageReference Include="System.Memory" />
     </ItemGroup>
 
+    <!-- CsCheck (property-based testing) targets net8.0 only; the property tests are gated behind
+         #if NET8_0_OR_GREATER, mirroring the net8+-only Timing harness. -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="CsCheck" />
+    </ItemGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\src\SecretSharingDotNet.csproj"/>
     </ItemGroup>

--- a/tests/StressTraits.cs
+++ b/tests/StressTraits.cs
@@ -1,0 +1,56 @@
+// ----------------------------------------------------------------------------
+// <copyright file="StressTraits.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/11/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#endregion
+
+#if NET8_0_OR_GREATER
+
+namespace SecretSharingDotNetTest;
+
+/// <summary>
+/// xUnit trait constants for the opt-in concurrency stress tests.
+/// </summary>
+/// <remarks>
+/// Stress tests spawn multiple threads inside a single test method to exercise the library's
+/// supported concurrency contract (independent splitter/reconstructor instances used in parallel).
+/// They carry the <c>Category=Stress</c> trait so they can be run in isolation or excluded, and are
+/// gated to net8.0+ to avoid the intermittent Mono fatal-signal artefacts observed when the
+/// .NET Framework target frameworks run under concurrency. Run only the stress category explicitly
+/// with <c>--filter "Category=Stress"</c>.
+/// </remarks>
+internal static class StressTraits
+{
+    public const string CategoryKey = "Category";
+
+    public const string CategoryValue = "Stress";
+}
+
+#endif

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -4,11 +4,11 @@
     ".NETFramework,Version=v4.7.2": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.6.0"
+          "Microsoft.CodeCoverage": "18.7.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -22,9 +22,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA==",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA==",
         "dependencies": {
           "System.Reflection.Metadata": "8.0.0"
         }
@@ -103,8 +103,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
+        "resolved": "18.7.0",
+        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net472": {
         "type": "Transitive",
@@ -285,11 +285,11 @@
     ".NETFramework,Version=v4.8": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.6.0"
+          "Microsoft.CodeCoverage": "18.7.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -303,9 +303,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA==",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA==",
         "dependencies": {
           "System.Reflection.Metadata": "8.0.0"
         }
@@ -384,8 +384,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
+        "resolved": "18.7.0",
+        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net48": {
         "type": "Transitive",
@@ -566,11 +566,11 @@
     ".NETFramework,Version=v4.8.1": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.6.0"
+          "Microsoft.CodeCoverage": "18.7.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -584,9 +584,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA==",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA==",
         "dependencies": {
           "System.Reflection.Metadata": "8.0.0"
         }
@@ -665,8 +665,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
+        "resolved": "18.7.0",
+        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net481": {
         "type": "Transitive",
@@ -847,12 +847,12 @@
     "net10.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.6.0",
-          "Microsoft.TestPlatform.TestHost": "18.6.0"
+          "Microsoft.CodeCoverage": "18.7.0",
+          "Microsoft.TestPlatform.TestHost": "18.7.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -866,9 +866,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA=="
       },
       "Moq": {
         "type": "Direct",
@@ -920,8 +920,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
+        "resolved": "18.7.0",
+        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net461": {
         "type": "Transitive",
@@ -960,10 +960,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
+        "resolved": "18.7.0",
+        "contentHash": "kYwfmebCs8992zaxEDkvG7S+YEouTeKfYVKUFEkwh1W2dIoOaevBt80XSKVXCUFEhusjOIm1sFfHBnoJgygrRA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.7.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -1051,12 +1051,12 @@
     "net8.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.6.0",
-          "Microsoft.TestPlatform.TestHost": "18.6.0"
+          "Microsoft.CodeCoverage": "18.7.0",
+          "Microsoft.TestPlatform.TestHost": "18.7.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -1070,9 +1070,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA=="
       },
       "Moq": {
         "type": "Direct",
@@ -1124,8 +1124,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
+        "resolved": "18.7.0",
+        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net461": {
         "type": "Transitive",
@@ -1164,10 +1164,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
+        "resolved": "18.7.0",
+        "contentHash": "kYwfmebCs8992zaxEDkvG7S+YEouTeKfYVKUFEkwh1W2dIoOaevBt80XSKVXCUFEhusjOIm1sFfHBnoJgygrRA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.7.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -1255,12 +1255,12 @@
     "net9.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.6.0",
-          "Microsoft.TestPlatform.TestHost": "18.6.0"
+          "Microsoft.CodeCoverage": "18.7.0",
+          "Microsoft.TestPlatform.TestHost": "18.7.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -1274,9 +1274,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA=="
       },
       "Moq": {
         "type": "Direct",
@@ -1328,8 +1328,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
+        "resolved": "18.7.0",
+        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net461": {
         "type": "Transitive",
@@ -1368,10 +1368,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
+        "resolved": "18.7.0",
+        "contentHash": "kYwfmebCs8992zaxEDkvG7S+YEouTeKfYVKUFEkwh1W2dIoOaevBt80XSKVXCUFEhusjOIm1sFfHBnoJgygrRA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.7.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -4,11 +4,11 @@
     ".NETFramework,Version=v4.7.2": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0"
+          "Microsoft.CodeCoverage": "18.6.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -22,9 +22,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA==",
         "dependencies": {
           "System.Reflection.Metadata": "8.0.0"
         }
@@ -103,8 +103,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.6.0",
+        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net472": {
         "type": "Transitive",
@@ -285,11 +285,11 @@
     ".NETFramework,Version=v4.8": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0"
+          "Microsoft.CodeCoverage": "18.6.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -303,9 +303,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA==",
         "dependencies": {
           "System.Reflection.Metadata": "8.0.0"
         }
@@ -384,8 +384,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.6.0",
+        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net48": {
         "type": "Transitive",
@@ -566,11 +566,11 @@
     ".NETFramework,Version=v4.8.1": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0"
+          "Microsoft.CodeCoverage": "18.6.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -584,9 +584,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA==",
         "dependencies": {
           "System.Reflection.Metadata": "8.0.0"
         }
@@ -665,8 +665,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.6.0",
+        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net481": {
         "type": "Transitive",
@@ -847,12 +847,12 @@
     "net10.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.6.0",
+          "Microsoft.TestPlatform.TestHost": "18.6.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -866,9 +866,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
       },
       "Moq": {
         "type": "Direct",
@@ -920,8 +920,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.6.0",
+        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net461": {
         "type": "Transitive",
@@ -960,10 +960,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.6.0",
+        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -1051,12 +1051,12 @@
     "net8.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.6.0",
+          "Microsoft.TestPlatform.TestHost": "18.6.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -1070,9 +1070,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
       },
       "Moq": {
         "type": "Direct",
@@ -1124,8 +1124,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.6.0",
+        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net461": {
         "type": "Transitive",
@@ -1164,10 +1164,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.6.0",
+        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -1255,12 +1255,12 @@
     "net9.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.6.0",
+          "Microsoft.TestPlatform.TestHost": "18.6.0"
         }
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
@@ -1274,9 +1274,9 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
       },
       "Moq": {
         "type": "Direct",
@@ -1328,8 +1328,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.6.0",
+        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net461": {
         "type": "Transitive",
@@ -1368,10 +1368,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.6.0",
+        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -845,6 +845,12 @@
       }
     },
     "net10.0": {
+      "CsCheck": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "j1ddNwZJHtuXJo0haeDtEX/j/iDJYLlZdIvaEmb7ftxTN9p4e5/jn6hYGXH/Em6RFfDRGWaNQ17LOMR3MhYWwA=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",
@@ -1049,6 +1055,12 @@
       }
     },
     "net8.0": {
+      "CsCheck": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "j1ddNwZJHtuXJo0haeDtEX/j/iDJYLlZdIvaEmb7ftxTN9p4e5/jn6hYGXH/Em6RFfDRGWaNQ17LOMR3MhYWwA=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",
@@ -1253,6 +1265,12 @@
       }
     },
     "net9.0": {
+      "CsCheck": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "j1ddNwZJHtuXJo0haeDtEX/j/iDJYLlZdIvaEmb7ftxTN9p4e5/jn6hYGXH/Em6RFfDRGWaNQ17LOMR3MhYWwA=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",

--- a/tests/stryker-config.json
+++ b/tests/stryker-config.json
@@ -1,0 +1,30 @@
+{
+  "stryker-config": {
+    "target-framework": "net10.0",
+    "test-case-filter": "Category!=Timing&Category!=Stress",
+    "coverage-analysis": "perTest",
+    "mutation-level": "Standard",
+    "reporters": [
+      "html",
+      "json",
+      "cleartext"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    },
+    "mutate": [
+      "!**/SecureBigInteger.cs",
+      "!**/SecureBigIntCalculator.cs",
+      "!**/PinnedPoolArray`1.cs",
+      "!**/PinnedPoolArrayList.cs",
+      "!**/CountedEqualityComparer`1.cs",
+      "!**/ICountedEqualityComparer`1.cs",
+      "!**/SecureRandom.cs",
+      "!**/CryptoRandomSource.cs",
+      "!**/ErrorMessages.Designer.cs",
+      "!**/AssemblyInfo.cs"
+    ]
+  }
+}


### PR DESCRIPTION
## Release v1.0.1-rc02

Second release candidate of 1.0.1. Brings `main` up to the current `develop` state and bumps the version from `1.0.1-rc01` to `1.0.1-rc02`.

### Consumer-facing changes since rc01

**Added**
- `FixedIterationSecretReconstructor<TNumber>` — a `SecretReconstructor<TNumber>` that accepts only `IFixedIterationExtendedGcdAlgorithm<TNumber>` strategies (pairing it with a variable-time GCD is a compile-time error); its parameterless constructor defaults to `MersenneSafeGcdAlgorithm<TNumber>`.
- `IFixedIterationExtendedGcdAlgorithm<TNumber>` — marker interface tagging extended-GCD strategies whose iteration count is operand-independent.

**Changed**
- `SecureBigInteger.GetHashCode` now hashes only public metadata (sign + limb count) instead of secret limb content; `Calculator<TNumber>`, `Share<TNumber>`, and `ExtendedGcdResult<TNumber>` inherit this via delegation.

**Fixed**
- `Secret<TNumber>.GetHashCode` is now consistent with by-value `Secret<TNumber>.Equals` (previously identity-based, silently breaking `Secret<TNumber>` as a dictionary/set key).
- `SharesEnumerator<TNumber>.Current` now throws `InvalidOperationException` when accessed before the first `MoveNext` or past the end, per the `IEnumerator` contract.

### Version bump
`src/SecretSharingDotNet.csproj` (`<Version>` + `PackageReleaseNotes`), `src/Properties/AssemblyInfo.cs` (`AssemblyInformationalVersion`; `AssemblyVersion` / `AssemblyFileVersion` stay `1.0.1`), `README.md` (NuGet + tag badges, install snippets, breaking-changes note), and `CHANGELOG.md` (dated `[1.0.1-rc02]` section + a fresh `[Unreleased]` placeholder).

### Under the hood since rc01 (no public API change)
Property-based tests (CsCheck), opt-in concurrency stress tests, a Stryker mutation-testing workflow, an internal injectable RNG seam, and CI hardening (action SHA-pinning, OIDC Trusted Publishing, least-privilege permissions). These are test / CI / internal only and are intentionally not listed in the consumer `CHANGELOG.md`.

### After merge
Tag `main` with `v1.0.1-rc02` to trigger the NuGet publish workflow.
