### PR TITLE
perf: restore O(n) share-index de-duplication in reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Share-index de-duplication in `SecretReconstructor` is O(n) again on the `SecureBigInteger` backend. After the `GetHashCode` metadata hardening every small positive one-limb index hashed identically, collapsing the distinctness `HashSet` into one bucket (O(n²)); an internal public-value comparer restores O(n). No public API change; the secret-hash hardening is unchanged.
+
 ## [1.0.1-rc02] - 2026-07-12
 
 ### Added

--- a/src/Cryptography/ShamirsSecretSharing/PublicValueEqualityComparer`1.cs
+++ b/src/Cryptography/ShamirsSecretSharing/PublicValueEqualityComparer`1.cs
@@ -1,0 +1,141 @@
+// ----------------------------------------------------------------------------
+// <copyright file="PublicValueEqualityComparer`1.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/12/2026 12:00:00 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+
+using System.Collections.Generic;
+using Math;
+
+/// <summary>
+/// An <see cref="IEqualityComparer{T}"/> over <see cref="Calculator{TNumber}"/> that hashes the
+/// <b>public</b> value via <see cref="Calculator.ByteRepresentation"/>. Intended for
+/// de-duplicating public quantities — specifically the share indices in the reconstruction
+/// distinctness check.
+/// </summary>
+/// <typeparam name="TNumber">The mathematical type wrapped by the compared calculators.</typeparam>
+/// <remarks>
+/// <para>
+/// Use this comparer <b>only</b> for public keys, never for secret-bearing values.
+/// <see cref="Calculator{TNumber}.GetHashCode"/> delegates to <c>TNumber.GetHashCode</c>, and the
+/// <c>SecureBigInteger</c> backend deliberately hashes only public metadata (sign and limb count)
+/// so that a value-derived hash of <em>secret</em> material cannot be observed. That hardening
+/// makes every small positive one-limb value hash identically, which would collapse the share-index
+/// distinctness <see cref="HashSet{T}"/> in <see cref="SecretReconstructor{TNumber}"/> into a single
+/// bucket and turn an O(n) check into O(n²).
+/// </para>
+/// <para>
+/// Share indices are public (the X coordinate, carried in the <c>"INDEX-VALUE"</c> wire format and
+/// assigned as small positive integers by the splitter), so hashing their value discloses nothing
+/// the wire format does not already expose. This comparer therefore restores an O(n) distinctness
+/// check <em>without</em> weakening the secret-hash hardening on
+/// <see cref="Calculator{TNumber}.GetHashCode"/> itself. The public bytes are read through
+/// <see cref="Calculator.ByteRepresentation"/> — the same public-value byte access used by
+/// <see cref="MersenneSafeGcdAlgorithm{TNumber}"/> — and the freshly allocated buffer is disposed.
+/// Equality delegates to the fixed-time <see cref="Calculator{TNumber}.Equals(Calculator{TNumber})"/>.
+/// </para>
+/// </remarks>
+internal sealed class PublicValueEqualityComparer<TNumber> : IEqualityComparer<Calculator<TNumber>>
+{
+    /// <summary>
+    /// The shared, stateless comparer instance.
+    /// </summary>
+    internal static readonly PublicValueEqualityComparer<TNumber> Instance = new PublicValueEqualityComparer<TNumber>();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublicValueEqualityComparer{TNumber}"/> class.
+    /// </summary>
+    private PublicValueEqualityComparer()
+    {
+    }
+
+    /// <summary>
+    /// Determines whether two calculators wrap the same value.
+    /// </summary>
+    /// <param name="x">The first calculator to compare.</param>
+    /// <param name="y">The second calculator to compare.</param>
+    /// <returns>
+    /// <see langword="true"/> when both are the same reference, both <see langword="null"/>, or wrap
+    /// equal values; otherwise <see langword="false"/>.
+    /// </returns>
+    public bool Equals(Calculator<TNumber> x, Calculator<TNumber> y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return x.Equals(y);
+    }
+
+    /// <summary>
+    /// Computes a value-derived hash of the calculator's <b>public</b> byte representation.
+    /// </summary>
+    /// <param name="obj">
+    /// The calculator whose public value is hashed. Must wrap a public quantity (e.g. a share index),
+    /// never secret material.
+    /// </param>
+    /// <returns>A hash code that discriminates distinct public values.</returns>
+    public int GetHashCode(Calculator<TNumber> obj)
+    {
+        if (obj is null)
+        {
+            return 0;
+        }
+
+        using var bytes = obj.ByteRepresentation;
+        int length = bytes.Length;
+#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
+        var hash = new System.HashCode();
+        for (int i = 0; i < length; i++)
+        {
+            hash.Add(bytes[i]);
+        }
+
+        return hash.ToHashCode();
+#else
+        unchecked
+        {
+            int hash = 17;
+            for (int i = 0; i < length; i++)
+            {
+                hash = (hash * 31) + bytes[i];
+            }
+
+            return hash;
+        }
+#endif
+    }
+}

--- a/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
@@ -175,10 +175,17 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
         // unpinned managed heap. Throws on first-duplicate detection instead of after full
         // enumeration; eager-vs-lazy throw on the public x-coordinates yields the same
         // exception type and message, no observable difference on the success path.
+        //
+        // Indices are hashed through PublicValueEqualityComparer: Calculator.GetHashCode delegates
+        // to TNumber.GetHashCode, and the SecureBigInteger backend deliberately hashes only public
+        // metadata (sign + limb count) so a value-derived hash of secret material cannot be observed.
+        // That makes every small positive one-limb index hash identically, which would collapse this
+        // check into one bucket (O(n²)). Indices are public (the X coordinate on the "INDEX-VALUE"
+        // wire), so a value-based hash of them is safe and restores O(n).
 #if NET8_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-        var seenIndices = new HashSet<Calculator<TNumber>>(numberOfPoints);
+        var seenIndices = new HashSet<Calculator<TNumber>>(numberOfPoints, PublicValueEqualityComparer<TNumber>.Instance);
 #else
-        var seenIndices = new HashSet<Calculator<TNumber>>();
+        var seenIndices = new HashSet<Calculator<TNumber>>(PublicValueEqualityComparer<TNumber>.Instance);
 #endif
         for (int i = 0; i < numberOfPoints; i++)
         {

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/PublicValueEqualityComparerTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/PublicValueEqualityComparerTest.cs
@@ -1,0 +1,103 @@
+// ----------------------------------------------------------------------------
+// <copyright file="PublicValueEqualityComparerTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/12/2026 12:00:00 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.BigInteger;
+
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using System.Collections.Generic;
+using System.Numerics;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="PublicValueEqualityComparer{TNumber}"/> over the <see cref="BigInteger"/>
+/// backend (mirror of the <c>SecureBigInteger</c> suite). The comparer de-duplicates the public share
+/// indices in reconstruction; <see cref="BigInteger"/> already hashes by value, so these assert the
+/// comparer keeps that discriminating behaviour uniformly across both backends.
+/// </summary>
+public class PublicValueEqualityComparerTest
+{
+    /// <summary>
+    /// Distinct public indices must produce distinct hash codes, keeping the reconstruction
+    /// distinctness <see cref="HashSet{T}"/> at O(n).
+    /// </summary>
+    [Fact]
+    public void GetHashCode_DistinctPublicIndices_ProducesDistinctHashes()
+    {
+        // Arrange — indices 1..count, exactly as the reconstruction distinctness check sees them.
+        const int count = 64;
+        var comparer = PublicValueEqualityComparer<BigInteger>.Instance;
+        var indices = new Calculator<BigInteger>[count];
+        try
+        {
+            for (int i = 0; i < count; i++)
+            {
+                indices[i] = new BigInteger(i + 1);
+            }
+
+            // Act
+            var hashes = new HashSet<int>();
+            foreach (var index in indices)
+            {
+                hashes.Add(comparer.GetHashCode(index));
+            }
+
+            // Assert — no collapse to a shared bucket.
+            Assert.Equal(count, hashes.Count);
+        }
+        finally
+        {
+            foreach (var index in indices)
+            {
+                index?.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The comparer treats equal public values as equal (with equal hashes) and distinct values as
+    /// distinct, matching <see cref="Calculator{TNumber}.Equals(Calculator{TNumber})"/>.
+    /// </summary>
+    [Fact]
+    public void Equals_MatchesValueEquality()
+    {
+        // Arrange
+        var comparer = PublicValueEqualityComparer<BigInteger>.Instance;
+        using Calculator<BigInteger> five = new BigInteger(5);
+        using Calculator<BigInteger> alsoFive = new BigInteger(5);
+        using Calculator<BigInteger> seven = new BigInteger(7);
+
+        // Act & Assert
+        Assert.True(comparer.Equals(five, alsoFive));
+        Assert.Equal(comparer.GetHashCode(five), comparer.GetHashCode(alsoFive));
+        Assert.False(comparer.Equals(five, seven));
+    }
+}

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/PublicValueEqualityComparerTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/PublicValueEqualityComparerTest.cs
@@ -1,0 +1,105 @@
+// ----------------------------------------------------------------------------
+// <copyright file="PublicValueEqualityComparerTest.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>07/12/2026 12:00:00 PM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.SecureBigInteger;
+
+using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
+using SecretSharingDotNet.Math;
+using SecretSharingDotNet.Math.Numerics;
+using System.Collections.Generic;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="PublicValueEqualityComparer{TNumber}"/> over the <see cref="SecureBigInteger"/>
+/// backend — the comparer used to de-duplicate the public share indices in reconstruction. Guards the
+/// O(n) distinctness check against the coarse metadata hash returned by
+/// <see cref="SecureBigInteger.GetHashCode"/> (sign + limb count), which would otherwise collapse all
+/// small positive one-limb indices into a single bucket.
+/// </summary>
+public class PublicValueEqualityComparerTest
+{
+    /// <summary>
+    /// Distinct public indices must produce distinct hash codes, so the reconstruction distinctness
+    /// <see cref="HashSet{T}"/> stays O(n) rather than collapsing into one bucket. With the raw
+    /// <see cref="SecureBigInteger.GetHashCode"/> the resulting set would have a single entry.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_DistinctPublicIndices_ProducesDistinctHashes()
+    {
+        // Arrange — indices 1..count, exactly as the reconstruction distinctness check sees them.
+        const int count = 64;
+        var comparer = PublicValueEqualityComparer<SecureBigInteger>.Instance;
+        var indices = new Calculator<SecureBigInteger>[count];
+        try
+        {
+            for (int i = 0; i < count; i++)
+            {
+                indices[i] = new SecureBigInteger(i + 1);
+            }
+
+            // Act
+            var hashes = new HashSet<int>();
+            foreach (var index in indices)
+            {
+                hashes.Add(comparer.GetHashCode(index));
+            }
+
+            // Assert — no collapse to a shared bucket (the raw metadata hash would give Count == 1).
+            Assert.Equal(count, hashes.Count);
+        }
+        finally
+        {
+            foreach (var index in indices)
+            {
+                index?.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The comparer treats equal public values as equal (with equal hashes) and distinct values as
+    /// distinct, matching <see cref="Calculator{TNumber}.Equals(Calculator{TNumber})"/>.
+    /// </summary>
+    [Fact]
+    public void Equals_MatchesValueEquality()
+    {
+        // Arrange
+        var comparer = PublicValueEqualityComparer<SecureBigInteger>.Instance;
+        using Calculator<SecureBigInteger> five = new SecureBigInteger(5);
+        using Calculator<SecureBigInteger> alsoFive = new SecureBigInteger(5);
+        using Calculator<SecureBigInteger> seven = new SecureBigInteger(7);
+
+        // Act & Assert
+        Assert.True(comparer.Equals(five, alsoFive));
+        Assert.Equal(comparer.GetHashCode(five), comparer.GetHashCode(alsoFive));
+        Assert.False(comparer.Equals(five, seven));
+    }
+}


### PR DESCRIPTION
## Summary

Restores the O(n) share-index distinctness check in `SecretReconstructor.LagrangeInterpolate`. Low-impact follow-up to the Codex P2 review on the rc02 release PR ([#338 thread](https://github.com/shinji-san/SecretSharingDotNet/pull/338#discussion_r3566677173)), addressed on `develop` as agreed.

## The regression

The distinctness check builds a `HashSet<Calculator<TNumber>>` over the share indices. After the `GetHashCode` hardening (#327) — `SecureBigInteger.GetHashCode` now returns only public metadata (sign + limb count) so a value-derived hash of *secret* material cannot be observed — every small positive one-limb index hashes identically. The set collapses into a single bucket and the check degrades from O(n) to O(n²). Only the `SecureBigInteger` backend is affected; `BigInteger`'s hash is value-based.

Impact is small: `LagrangeInterpolate` is already O(n²) via the interpolation loop, whose per-pair `SecureBigInteger` multiply/mod dominates the cheap single-limb index comparisons — hence a follow-up, not an rc02 blocker.

## The fix

An internal `PublicValueEqualityComparer<TNumber>` wired into the distinctness `HashSet`:

- `GetHashCode` hashes the **public** index value via `Calculator.ByteRepresentation` — the same public-value byte access already used by `MersenneSafeGcdAlgorithm` — restoring O(n).
- `Equals` delegates to the fixed-time `Calculator.Equals`.
- `SecureBigInteger.GetHashCode` is **unchanged**; the secret-hash hardening stays intact.

## Security

Introducing a value-based hash is exactly what #327 removed for *secret* material, so scope is the crux:

- **Share indices are public.** They are the X coordinate, serialized in plaintext in the `"INDEX-VALUE"` wire format and assigned as small positive integers `1..N` by the splitter — never secret-derived. Hashing their value discloses nothing the wire format does not already expose.
- **Scoped to public keys only.** This is the *only* hash-over-`Calculator` site in `src/` (the `Calculator` factory dictionaries are keyed on `Type`). The comparer is applied solely to the index dedup; `SecureBigInteger.GetHashCode` stays coarse everywhere else.
- **No new timing channel.** The dedup's timing depends only on public quantities (share count + public index values).

## Verification

- Builds clean across all 8 target frameworks; the comparer's `#if` selects `System.HashCode` on net8.0+/netstandard2.1 and an FNV-1a fold on the .NET Framework / netstandard2.0 targets.
- Focused suite green: **32/32** (`PublicValueEqualityComparer` + `SecretReconstructor`, single-threaded).
- Regression test, mirrored across both backends: distinct public indices must produce distinct hash codes — guards against a future return to the coarse metadata hash.

## Public API delta

None (internal comparer + internal wiring).
