### PR TITLE
ci(deps): group codeql-action updates into a single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,11 @@ updates:
       - "shinji-san"
     reviewers:
       - "shinji-san"
+    groups:
+      # The init and analyze steps of the CodeQL workflow must run the same
+      # action version: init writes a configuration file that analyze reads
+      # back, and a version skew aborts the job with a configuration error.
+      # Grouping keeps both steps in a single pull request.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
## Problem

Dependabot treats `github/codeql-action/init` and `github/codeql-action/analyze` as two independent dependencies and opens one pull request per step — currently #354 (analyze → v4.37.4) and #355 (init → v4.37.4).

Both steps live in the same job in `.github/workflows/codeql-analysis.yml` and must run the same action version: `init` writes a configuration file that `analyze` reads back. Bumping only one of them produces a version skew and aborts the job:

```
##[warning]1 issue was detected with this workflow: Not all workflow steps that
use `github/codeql-action` actions use the same version.
##[error]Loaded a configuration file for version '4.37.0', but running version '4.37.4'
##[error]analyze post-action step failed: ...
CodeQL job status was configuration error.
```

Consequence: each of #354 and #355 is red on its own and cannot be validated independently, even though the change itself is correct. The build-and-test jobs pass in both.

## Change

Add a Dependabot `groups` entry for the `github-actions` ecosystem so all `github/codeql-action*` dependencies are bumped together in one pull request.

## Follow-up

After this is merged, close #354 and #355 and let Dependabot re-open a single grouped pull request that moves both steps to v4.37.4 at once.