### PR TITLE
build(deps): bump github/codeql-action from 4.37.0 to 4.37.4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
           10.0.100
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
 
@@ -55,4 +55,4 @@ jobs:
       run: dotnet build --configuration Release SecretSharingDotNet.slnx
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4


### PR DESCRIPTION
Bumps the `init` and `analyze` steps of the CodeQL workflow from v4.37.0 to v4.37.4 in a single change.

## Why manually

Dependabot proposed this bump as two separate pull requests, #354 (analyze) and #355 (init). Both steps run in the same job and must use the same action version — `init` writes a configuration file that `analyze` reads back — so each pull request on its own aborted the workflow:

```
##[error]Loaded a configuration file for version '4.37.0', but running version '4.37.4'
CodeQL job status was configuration error.
```

#356 added a Dependabot `groups` entry for `github/codeql-action*` so future bumps arrive together, and #354/#355 were closed. Closing a Dependabot pull request also suppresses that version bump, so v4.37.4 will not be re-proposed — hence this manual update. The grouping takes effect from the next release onwards.

## Pinned SHA

`f205ea1c3313d32999d8d6a48b4f6530d4437b38` — verified against tag `v4.37.4` of `github/codeql-action` (annotated tag `ea14db8afdef5d462e69d78c4ca45002d4522418` dereferenced to its commit).

## Verification

Both steps move together, so the CodeQL job should complete without the configuration error. This pull request's own CodeQL run is the check.