### PR TITLE
ci: verify NuGet lock files with --locked-mode restore

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Restore
       if: matrix.language == 'csharp'
-      run: dotnet restore SecretSharingDotNet.slnx
+      run: dotnet restore --locked-mode SecretSharingDotNet.slnx
 
     - name: Build
       if: matrix.language == 'csharp'

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -40,7 +40,7 @@ jobs:
           10.0.100
 
     - name: Restore
-      run: dotnet restore SecretSharingDotNet.slnx
+      run: dotnet restore --locked-mode SecretSharingDotNet.slnx
 
     - name: Build
       run: dotnet build --configuration Release --no-restore SecretSharingDotNet.slnx

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -35,7 +35,7 @@ jobs:
         PUBLISHER_PUB_KEY: ${{ secrets.PUBLISHER_PUB_KEY }}
 
     - name: Restore
-      run: dotnet restore SecretSharingDotNet.slnx
+      run: dotnet restore --locked-mode SecretSharingDotNet.slnx
 
     - name: Build
       run: dotnet build --configuration Release --no-restore SecretSharingDotNet.slnx


### PR DESCRIPTION
## Problem

All projects inherit `RestorePackagesWithLockFile=true` from `Directory.Packages.props`, and all
three `packages.lock.json` files (`src`, `tests`, `samples`) are committed and carry `contentHash`
entries.

That property only means "write and update the lock file during restore" — it does **not** mean
"validate against it". Because none of the workflows passed `--locked-mode`, a CI restore would
silently regenerate the lock file whenever the resolved dependency graph drifted, and the build
would stay green. The committed lock files therefore delivered neither reproducibility nor the
supply-chain check their `contentHash` entries are meant to provide.

## Change

Add `--locked-mode` to the restore step in all three workflows:

- `.github/workflows/dotnetall.yml`
- `.github/workflows/publishing.yml`
- `.github/workflows/codeql-analysis.yml`

`publishing.yml` matters most here, since that job produces the NuGet package that actually ships.

## Verification

`dotnet restore --locked-mode SecretSharingDotNet.slnx` succeeds against the current lock files and
leaves all three of them unchanged, so this does not start out red. The lock files are already in
sync with `Directory.Packages.props`; only the enforcement was missing.

From now on, a dependency change requires the regenerated `packages.lock.json` to be committed
alongside it, otherwise CI fails — which is the intended behaviour.

## Follow-up (not in this PR)

`codeql-analysis.yml` runs `dotnet build` without `--no-restore`, unlike the other two workflows,
so its implicit restore does not carry `--locked-mode`. This is not a hole today — the explicit
restore step runs first and aborts the job on drift — but it is redundant work and inconsistent.
Tracked in #359.

