### PR TITLE
ci: skip the redundant implicit restore in the CodeQL build

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Build
       if: matrix.language == 'csharp'
-      run: dotnet build --configuration Release SecretSharingDotNet.slnx
+      run: dotnet build --configuration Release --no-restore SecretSharingDotNet.slnx
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4


### PR DESCRIPTION
Fixes #359.

## Problem

`codeql-analysis.yml` built without `--no-restore`:

```yaml
    - name: Restore
      if: matrix.language == 'csharp'
      run: dotnet restore --locked-mode SecretSharingDotNet.slnx

    - name: Build
      if: matrix.language == 'csharp'
      run: dotnet build --configuration Release SecretSharingDotNet.slnx
```

so `dotnet build` performed a second, implicit restore that does not carry the `--locked-mode` flag
added in #358. `dotnetall.yml` and `publishing.yml` both pass `--no-restore`, making this workflow
the odd one out.

It was never an open hole — the explicit Restore step runs first and aborts the job on lock-file
drift — but it cost a full extra restore pass per run and left the `--locked-mode` guarantee here
resting on step ordering instead of on the build command itself.

## Change

One line: add `--no-restore` to the build step, so all three workflows share the same
restore-then-build pattern.

## Verification

CodeQL only needs to observe the compilation, and the explicit Restore step still runs before the
build, so the database is populated exactly as before.

Locally, running the CI sequence on this branch — `dotnet restore --locked-mode` followed by
`dotnet build --configuration Release --no-restore` — succeeds with 0 errors and compiles all eight
target frameworks (`netstandard2.0`, `netstandard2.1`, `net472`, `net48`, `net481`, `net8.0`,
`net9.0`, `net10.0`). The `Analyze (csharp)` check on this PR exercises the real thing.
