### PR TITLE
ci: fail the release on a tag/version mismatch or a failed decryption

### DIFF
--- a/.github/secrets/decrypt_publisher_snk.sh
+++ b/.github/secrets/decrypt_publisher_snk.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
+# Abort on the first failure. Without this the script keeps going after a failed gpg
+# call and still exits 0, because the trailing sed always succeeds -- the workflow step
+# then reports success and the run only breaks later, at signing time, with an error
+# that points at the missing key file instead of the failed decryption.
+set -euo pipefail
 CDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-rm -f ${CDIR}/../../src/SecretSharingDotNet.snk
+
+# Fail loudly on a missing or empty secret. An empty PUBLISHER_PUB_KEY would otherwise
+# rewrite AssemblyInfo.cs with an empty public key rather than stopping the run.
+: "${PUBLISHER_SNK:?PUBLISHER_SNK is unset or empty}"
+: "${PUBLISHER_PUB_KEY:?PUBLISHER_PUB_KEY is unset or empty}"
+
+rm -f "${CDIR}/../../src/SecretSharingDotNet.snk"
 # Decrypt the file
 # --batch to prevent interactive command --yes to assume "yes" for questions
-gpg --quiet --batch --yes --decrypt --passphrase="$PUBLISHER_SNK" --output ${CDIR}/../../src/SecretSharingDotNet.snk ${CDIR}/SecretSharingDotNetPublisher.snk.gpg
-sed -i -r "s/(InternalsVisibleTo.*PublicKey=)([0-9a-f]+)(.*)/\1$PUBLISHER_PUB_KEY\3/g" ${CDIR}/../../src/Properties/AssemblyInfo.cs
+gpg --quiet --batch --yes --decrypt --passphrase="$PUBLISHER_SNK" --output "${CDIR}/../../src/SecretSharingDotNet.snk" "${CDIR}/SecretSharingDotNetPublisher.snk.gpg"
+sed -i -r "s/(InternalsVisibleTo.*PublicKey=)([0-9a-f]+)(.*)/\1$PUBLISHER_PUB_KEY\3/g" "${CDIR}/../../src/Properties/AssemblyInfo.cs"

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -28,6 +28,42 @@ jobs:
           9.0.307
           10.0.100
 
+    # Guard against a tag that does not match the version being packed. Without it a
+    # tag pushed without bumping the version builds the previous release, and the push
+    # below hits --skip-duplicate, which reports success without publishing anything.
+    # Runs before the signing key is decrypted, so a mismatched tag never touches it.
+    - name: Verify tag matches package version
+      run: |
+        set -euo pipefail
+        tag_version="${GITHUB_REF_NAME#v}"
+        csproj_version="$(dotnet msbuild src/SecretSharingDotNet.csproj -getProperty:Version)"
+        release_notes="$(dotnet msbuild src/SecretSharingDotNet.csproj -getProperty:PackageReleaseNotes)"
+        informational_version="$(sed -n 's/.*AssemblyInformationalVersion("\([^"]*\)").*/\1/p' src/Properties/AssemblyInfo.cs)"
+
+        mismatch=0
+        if [ "$csproj_version" != "$tag_version" ]; then
+          echo "::error file=src/SecretSharingDotNet.csproj::<Version> is '$csproj_version', but tag ${GITHUB_REF_NAME} implies '$tag_version'"
+          mismatch=1
+        fi
+        if [ "$informational_version" != "$tag_version" ]; then
+          echo "::error file=src/Properties/AssemblyInfo.cs::AssemblyInformationalVersion is '$informational_version', but tag ${GITHUB_REF_NAME} implies '$tag_version'"
+          mismatch=1
+        fi
+        case "$release_notes" in
+          *"/blob/${GITHUB_REF_NAME}/"*) ;;
+          *)
+            echo "::error file=src/SecretSharingDotNet.csproj::PackageReleaseNotes does not link to tag ${GITHUB_REF_NAME}: ${release_notes}"
+            mismatch=1
+            ;;
+        esac
+
+        if [ "$mismatch" -ne 0 ]; then
+          echo "Refusing to publish: the release version is not in lockstep with the tag ${GITHUB_REF_NAME}."
+          echo "Publishing anyway would push an already-released version, which --skip-duplicate reports as success without publishing anything."
+          exit 1
+        fi
+        echo "Tag ${GITHUB_REF_NAME} matches version ${csproj_version}."
+
     - name: Decrypt large secret
       run: ./.github/secrets/decrypt_publisher_snk.sh
       env:


### PR DESCRIPTION
Closes the two highest-impact findings from the `publishing.yml` audit. Both are cases where the
release workflow reports success without doing what the release intended.

## 1. No tag ↔ version check, and `--skip-duplicate` hides the consequence

The workflow triggers on `v*`, but nothing verified that the tag matches the version being packed.
The version is hard-coded in three places that must move in lockstep:

| file | field |
|---|---|
| `src/SecretSharingDotNet.csproj` | `<Version>` |
| `src/SecretSharingDotNet.csproj` | `PackageReleaseNotes` changelog URL |
| `src/Properties/AssemblyInfo.cs` | `AssemblyInformationalVersion` |

All three currently read `1.0.1-rc02`, the latest tag is `v1.0.1-rc02`, and `1.0.1-rc02` is already
on NuGet. So tagging `v1.0.1-rc03` today without editing them would build `1.0.1-rc02`, push it,
get "version already exists" back, and `dotnet nuget push --skip-duplicate` would turn that into a
green run. The release would look complete with nothing published.

A new **Verify tag matches package version** step compares `${GITHUB_REF_NAME#v}` against all three
and fails with `::error file=…::` annotations naming the offending file. Two deliberate placement
choices:

- It runs **before** `Decrypt large secret`, so a mismatched tag never causes the signing key to be
  decrypted.
- It reads the version via `dotnet msbuild -getProperty:Version`, which evaluates the project
  without a restore, so the check costs seconds instead of failing after a full build and test run.

`--skip-duplicate` is kept: with the guard in place, the remaining case it covers is re-running a
release for the same version, which is what it is for.

## 2. `decrypt_publisher_snk.sh` reported success on a failed decryption

The script had no `set -e`, and `gpg` was not its last command — the trailing `sed` always succeeds,
so a failed decryption still exited 0. The step went green and the run only broke later, at signing
time, with an error naming the missing key file rather than the failed decryption. An empty
`PUBLISHER_PUB_KEY` would likewise rewrite `AssemblyInfo.cs` with an empty public key.

Now: `set -euo pipefail`, both secrets required to be present and non-empty via `${VAR:?}`, and
quoted paths.

## Verification

`publishing.yml` only runs on `v*` tags, so **the PR checks do not exercise either change** — this
was verified locally instead.

Version guard, with the script extracted from the parsed YAML and executed, so what ran is exactly
what the workflow will run:

- matching tag `v1.0.1-rc02` → exit 0, `Tag v1.0.1-rc02 matches version 1.0.1-rc02.`
- mismatched tag `v9.9.9` → exit 1, all three annotations emitted
- csproj bumped to `1.0.1-rc03` but `AssemblyInfo.cs` left behind → exit 1 with **only** the
  AssemblyInfo annotation, confirming the three checks fire independently
- `dotnet msbuild -getProperty:Version` confirmed to work on a fresh unrestored clone

Decrypt script, all three previously-silent failures now exit non-zero (each returned 0 before):

- `PUBLISHER_SNK` unset → exit 1
- `PUBLISHER_PUB_KEY` empty → exit 1
- wrong passphrase → exit 2, and `AssemblyInfo.cs` verified untouched, i.e. the `sed` correctly did
  not run

Also checked: the file keeps its executable bit, `bash -n` passes, the workflow YAML parses and the
new step lands at position 3 of 12, and the step uses the `GITHUB_REF_NAME` shell variable rather
than a `${{ }}` interpolation.

The happy path is unchanged: a tag that matches the version and a successful decryption behave
exactly as before. The first real exercise will be the next release tag.

## Not in this PR

The remaining audit findings — dead `paths-ignore` on a tag trigger, the brittle README preparation
(fails loudly with NU5040, so not silent), missing `concurrency`, the API key passed via `${{ }}`
interpolation instead of `env:`, and no `timeout-minutes`.
