### PR TITLE
ci: tidy up the publishing workflow

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -4,8 +4,13 @@ on:
   push:
     tags:
     - 'v*'
-    paths-ignore:
-    - '**.md'
+
+# Serialize releases across all tags, and never cancel one: a publish interrupted
+# between pack and push leaves the release half-done. This deliberately differs from
+# the CI workflows, which group per ref and do cancel in progress.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -15,6 +20,7 @@ jobs:
   build:
 
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
@@ -82,9 +88,23 @@ jobs:
     - name: Remove obsolete NuGet packages
       run: rm -f src/bin/Release/SecretSharingDotNet*.nupkg
 
+    # The extraction below is driven entirely by these two headings. If one stops
+    # matching, the pipeline yields an empty README and pack fails with a NU5040 that
+    # names the empty file rather than the renamed heading; if one matches twice, the
+    # extraction duplicates content and ships a wrong README without any error at all.
+    # Check both up front so the real cause is named. The install heading is matched
+    # without its trailing emoji, so it stays in step with dotnetall.yml.
     - name: Prepare README.md for NuGet package
       run: |
-           grep -n "## Install SecretSharingDotNet package 📥" README.md | cut -d: -f 1| xargs -i tail -n +{} README.md > TMP.md && sed -i '1s/^/# Setup\r\n/' TMP.md && mv -f TMP.md README.md
+           set -euo pipefail
+           for heading in "## Install SecretSharingDotNet package" "# CLI building instructions"; do
+             matches="$(grep -cF "$heading" README.md || true)"
+             if [ "$matches" -ne 1 ]; then
+               echo "::error file=README.md::Expected exactly one line containing '$heading', found ${matches}. The packaged README is built by extracting between these headings."
+               exit 1
+             fi
+           done
+           grep -n "## Install SecretSharingDotNet package" README.md | cut -d: -f 1| xargs -i tail -n +{} README.md > TMP.md && sed -i '1s/^/# Setup\r\n/' TMP.md && mv -f TMP.md README.md
            grep -n "# CLI building instructions" README.md | cut -d: -f 1| xargs -i head -n {} README.md | head -n -1 > TMP.md && mv -f TMP.md README.md
 
     - name: Create package

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -5,11 +5,15 @@ on:
     tags:
     - 'v*'
 
-# Serialize releases across all tags, and never cancel one: a publish interrupted
-# between pack and push leaves the release half-done. This deliberately differs from
-# the CI workflows, which group per ref and do cancel in progress.
+# Keep a tag from racing itself: a re-pushed tag or a re-run queues behind the run
+# already publishing that version instead of pushing it twice at once. Never cancel in
+# progress, because a publish interrupted between pack and push leaves the release
+# half-done -- this is where the CI workflows differ, they do cancel.
+# Grouped per ref on purpose. A workflow-level group holds only one pending run, so a
+# third tag arriving while one publishes and another waits would cancel the waiting
+# one and that version would never be published.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
Housekeeping findings from the `publishing.yml` audit, after #361 took the two that could make a
release go green without publishing. Nothing here changes what gets published.

## Dead `paths-ignore`

GitHub does not evaluate path filters for tag pushes, so `paths-ignore: '**.md'` never applied.
Removing it is behaviour-preserving; leaving it in suggests that a release commit touching only
markdown would skip publishing, which is not what happens.

## README headings are now checked before extraction

The packaged README is produced by extracting the region between two headings. Two ways that went
wrong:

- **A heading stops matching** → the pipeline produces an empty `README.md` and `dotnet pack` fails
  with NU5040, naming the empty file rather than the heading somebody renamed — and only after a
  full build and test run.
- **A heading matches twice** → `xargs` runs the extraction twice, the content is duplicated, and a
  wrong README ships with no error at all.

Both are now caught up front by requiring exactly one match of each heading, with an error that
names the actual cause. The install heading is matched **without** its trailing 📥, which also
resolves a divergence: `dotnetall.yml` greps it without the emoji and `publishing.yml` grepped it
with, so changing the emoji would have broken releases while CI stayed green.

## Releases are serialized

The workflow had no `concurrency` group. Added one, deliberately different from the CI workflows:

- grouped by `github.workflow` rather than by ref, so two tags pushed in quick succession queue
  instead of publishing concurrently (a per-ref group would not serialize them, since each tag is
  its own ref)
- `cancel-in-progress: false`, because a publish interrupted between pack and push leaves the
  release half-done

## `timeout-minutes: 30`

The release job takes roughly ten minutes. Without a timeout, a hung publish holds a runner for the
six-hour default.

## Deliberately not changed: the API key argument

The audit also flagged the temporary NuGet API key being passed as a `${{ }}` argument rather than
through `env:`. Checked against the actual rc02 release run
([29202004299](https://github.com/shinji-san/SecretSharingDotNet/actions/runs/29202004299)): the
rendered command appears in the log as `-k  ***  -s https://api.nuget.org/v3/index.json`, so
`NuGet/login` already masks it. There is no log exposure and no injection surface, since the value
comes from an action output rather than user input. What remains is the key appearing in the
process argv on an ephemeral single-tenant runner. Moving it to `env:` would buy no secrecy while
touching the one step that actually publishes and that no CI run exercises, so it stays as is.

## Verification

`publishing.yml` runs only on `v*` tags, so the PR checks do not exercise it. Verified locally, with
the README step extracted from the parsed YAML so that what ran is what the workflow will run:

- **Behaviour preserved:** old pipeline vs new step on the current README produce **byte-identical**
  output (53336 bytes, 979 lines) — confirming the emoji-free pattern selects the same heading.
- **Renamed heading:** new → exit 1 naming the heading, `README.md` left untouched. Old → exit 0 and
  a 0-byte README, i.e. failure deferred to NU5040.
- **Duplicated heading:** new → exit 1 reporting `found 2`. Old → silently duplicated content.

Structure checked after parsing: trigger is `{push: {tags: [v*]}}`, `concurrency` is
`{group: ${{ github.workflow }}, cancel-in-progress: false}`, `timeout-minutes: 30`, 12 steps, and
the Publish step still carries no `env:` block.
