### PR TITLE
ci: refresh the pinned .NET SDK patch versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,9 +37,9 @@ jobs:
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: |
-          8.0.416
-          9.0.307
-          10.0.100
+          8.0.423
+          9.0.316
+          10.0.302
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -35,9 +35,9 @@ jobs:
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: |
-          8.0.416
-          9.0.307
-          10.0.100
+          8.0.423
+          9.0.316
+          10.0.302
 
     - name: Restore
       run: dotnet restore --locked-mode SecretSharingDotNet.slnx
@@ -79,9 +79,9 @@ jobs:
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: |
-          8.0.416
-          9.0.307
-          10.0.100
+          8.0.423
+          9.0.316
+          10.0.302
 
     - name: Restore
       run: dotnet restore --locked-mode SecretSharingDotNet.slnx

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -41,9 +41,9 @@ jobs:
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: |
-          8.0.416
-          9.0.307
-          10.0.100
+          8.0.423
+          9.0.316
+          10.0.302
 
     - name: Restore
       run: dotnet restore --locked-mode SecretSharingDotNet.slnx
@@ -74,9 +74,9 @@ jobs:
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: |
-          8.0.416
-          9.0.307
-          10.0.100
+          8.0.423
+          9.0.316
+          10.0.302
 
     # Guard against a tag that does not match the version being packed. Without it a
     # tag pushed without bumping the version builds the previous release, and the push


### PR DESCRIPTION
Implements the stale-SDK-pin finding from the 2026-08-05 workflow audit.

All five `setup-dotnet` blocks (dotnetall: `build` + `build-windows`; publishing: `test-windows` + `build`; codeql-analysis: `analyze`) move in lockstep from 8.0.416 / 9.0.307 / 10.0.100 to **8.0.423 / 9.0.316 / 10.0.302**, picking up the current servicing patches of each channel.

For .NET 10 this chooses the 3xx feature band over staying on 10.0.1xx on purpose: the committed `packages.lock.json` files are maintained with the local 10.0.302 SDK, so CI and the local toolchain now run the same NuGet — locked-mode compatibility between the two stands proven by the existing green runs in both directions.

Note: the `publishing.yml` pins are not exercised by PR checks (tag-triggered workflow); they are value-identical to the dotnetall pins that this PR's own CI runs on both runner images.