### PR TITLE
ci: group NuGet updates and disable Dependabot auto-rebases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,23 @@ updates:
       - "shinji-san"
     reviewers:
       - "shinji-san"
+    groups:
+      # One collective PR per week instead of one per package: a single
+      # lock-file regeneration, no two PRs rewriting the same
+      # packages.lock.json, and less open-PR time in which a develop merge
+      # can trigger a rebase.
+      nuget-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      nuget-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    # Dependabot's failing auto-rebases closed its own PRs as "no longer
+    # updatable" (#347-#350), silently dropping the bumps. Rebase only on an
+    # explicit "@dependabot rebase" comment.
+    rebase-strategy: "disabled"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,18 +16,36 @@ updates:
       # One collective PR per week instead of one per package: a single
       # lock-file regeneration, no two PRs rewriting the same
       # packages.lock.json, and less open-PR time in which a develop merge
-      # can trigger a rebase.
+      # can trigger a rebase. Only version updates ever land here: with
+      # target-branch set, this block does not govern security updates.
       nuget-version-updates:
         applies-to: version-updates
-        patterns:
-          - "*"
-      nuget-security-updates:
-        applies-to: security-updates
         patterns:
           - "*"
     # Dependabot's failing auto-rebases closed its own PRs as "no longer
     # updatable" (#347-#350), silently dropping the bumps. Rebase only on an
     # explicit "@dependabot rebase" comment.
+    rebase-strategy: "disabled"
+
+  # Security updates always target the default branch (main) and ignore any
+  # block that sets target-branch, so they need this dedicated block.
+  # open-pull-requests-limit: 0 disables version updates against main
+  # (releases flow develop -> main); security pull requests are not subject
+  # to that limit.
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    assignees:
+      - "shinji-san"
+    reviewers:
+      - "shinji-san"
+    groups:
+      nuget-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
     rebase-strategy: "disabled"
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
Option B from the Dependabot analysis (config-only hardening):

- **`groups`** for the nuget ecosystem: one collective weekly PR (version updates and security updates each grouped) → a single lock-file regeneration per cycle, no two branches rewriting `tests/packages.lock.json` in conflicting ways, less open-PR time in which a develop merge can trigger a rebase.
- **`rebase-strategy: disabled`**: removes the exact trigger behind the self-closes of #347–#350 (failing auto-rebase → PR closed as *no longer updatable* → bump silently suppressed). Rebases now only on an explicit `@dependabot rebase` comment; with `strict` branch protection an out-of-date grouped PR needs a manual rebase before merge.

The github-actions ecosystem is untouched — its rebases work (no lock files involved).

Note: the truncation defect itself is not fixed by this (upstream dependabot-core issue); the auto-heal workflow PR complements it.