### PR TITLE
ci: auto-heal truncated lock files on Dependabot pull requests

### DIFF
--- a/.github/workflows/dependabot-autoheal.yml
+++ b/.github/workflows/dependabot-autoheal.yml
@@ -1,0 +1,77 @@
+name: SecretSharingDotNet - Dependabot Lock-File Auto-Heal
+
+# Dependabot's NuGet updater regenerates a multi-targeted packages.lock.json
+# with only a single framework section (dependabot-core defect), so every
+# NuGet update PR fails the locked-mode restore with NU1004. This workflow
+# re-runs the restore over the full TFM matrix on Dependabot's own branch
+# and pushes the completed lock files back to the PR.
+#
+# pull_request_target instead of pull_request on purpose: the fix must push
+# to the PR branch, and a Dependabot-triggered pull_request run only gets a
+# read-only GITHUB_TOKEN. pull_request_target always executes the workflow
+# definition from the BASE branch (develop), never the PR's version of it.
+on:
+  pull_request_target:
+    branches:
+    - develop
+    paths:
+    - 'Directory.Packages.props'
+    - '**/packages.lock.json'
+
+permissions:
+  contents: write
+
+# Per PR: a newer synchronize event supersedes a running heal.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  heal:
+    # Hard-gated to in-repo branches authored by Dependabot. Only Dependabot
+    # and maintainers can create such branches and events, so the restore
+    # below never evaluates MSBuild logic from an untrusted fork.
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+    steps:
+    # AUTOHEAL_PUSH_TOKEN is a fine-grained PAT (this repository only,
+    # permission Contents: read/write, nothing else). It exists because a
+    # push made with the default GITHUB_TOKEN does not trigger workflows
+    # (recursion guard), so the healed commit would keep the PR's stale red
+    # checks. The fallback keeps the healing itself functional without the
+    # secret; CI then needs a manual re-run.
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        token: ${{ secrets.AUTOHEAL_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+    - name: Setup .NET SDKs
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        dotnet-version: |
+          8.0.423
+          9.0.316
+          10.0.302
+
+    - name: Regenerate the lock files
+      run: dotnet restore --force-evaluate SecretSharingDotNet.slnx
+
+    - name: Push the completed lock files
+      run: |
+        set -euo pipefail
+        if git diff --quiet -- '*packages.lock.json'; then
+          echo "Lock files are already complete; nothing to heal."
+          exit 0
+        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -- '*packages.lock.json'
+        git commit -m "build: regenerate multi-TFM lock files after Dependabot update"
+        git push origin "HEAD:${HEAD_REF}"
+      env:
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/dependabot-autoheal.yml
+++ b/.github/workflows/dependabot-autoheal.yml
@@ -12,8 +12,13 @@ name: SecretSharingDotNet - Dependabot Lock-File Auto-Heal
 # definition from the BASE branch (develop), never the PR's version of it.
 on:
   pull_request_target:
+    # develop takes Dependabot's version updates; security updates always
+    # target the default branch (main). For main-based PRs this only takes
+    # effect once this file has reached main via a release merge --
+    # pull_request_target executes the base branch's workflow version.
     branches:
     - develop
+    - main
     paths:
     - 'Directory.Packages.props'
     - '**/packages.lock.json'


### PR DESCRIPTION
Option A from the Dependabot analysis. Reacts to Dependabot's own NuGet PRs, re-runs `dotnet restore --force-evaluate` over the full TFM matrix and pushes the completed lock files back to the PR branch — the NU1004 reds heal themselves within minutes, and the foreign commit additionally makes Dependabot stop rebasing that PR (removing the failing-rebase path that closed #347–#350).

## Security shape

- `pull_request_target` is required for write access — a Dependabot-triggered `pull_request` run only gets a read-only `GITHUB_TOKEN` ([docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)). The executed workflow definition always comes from the **base branch**, never from the PR.
- The job is hard-gated to PRs **authored by `dependabot[bot]`** with an **in-repo head branch** — only Dependabot and maintainers can produce such events, so `dotnet restore` never evaluates MSBuild logic from an untrusted fork.
- `permissions: contents: write` only; Actions SHA-pinned; same SDK pins as the CI workflows; 15-min timeout; per-PR concurrency.

## One-time setup required after merge

Create a **fine-grained PAT** (this repository only, permission *Contents: Read and write*, nothing else) and store it as secret `AUTOHEAL_PUSH_TOKEN` — in **Settings → Secrets and variables → Actions** *and* **→ Dependabot** (Dependabot-triggered runs read the Dependabot secret store). Reason: a push with the default `GITHUB_TOKEN` does not trigger workflows (recursion guard), so the healed commit would keep the PR's stale red checks. Without the secret the workflow still heals, but CI needs a manual re-run.

## Interplay

- Complements the grouping/rebase-strategy config PR (Option B); with both, the weekly grouped PR arrives, gets healed automatically, and full CI (including `build-windows`) runs on the healed commit.
- This workflow only takes effect once the file exists on `develop` (pull_request_target reads the base branch); it cannot be exercised by this PR's own checks. First real verification is the next Dependabot NuGet PR.