### PR TITLE
ci: add timeouts and drop persisted credentials in dotnetall.yml

### DIFF
--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -26,10 +26,15 @@ jobs:
   build:
 
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
+    # No later step needs the git token: restore talks to nuget.org and
+    # nothing pushes.
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Setup .NET SDKs
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
@@ -86,10 +91,15 @@ jobs:
   build-windows:
 
     runs-on: windows-2025
+    timeout-minutes: 30
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
+    # No later step needs the git token: restore talks to nuget.org and
+    # nothing pushes.
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Setup .NET SDKs
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0


### PR DESCRIPTION
The last two hygiene items from the 2026-08-05 workflow audit:

- **`timeout-minutes: 30`** on both jobs — runs take 8–10 minutes, the implicit default is 360, and that is what a hung run would burn. Matches `publishing.yml`'s precedent.
- **`persist-credentials: false`** on both checkouts — no later step needs the git token (restore talks to nuget.org, nothing pushes), so it no longer lingers in the git config for the rest of the job. Consistent with the SHA-pinned, least-privilege posture.

Deliberately scoped to `dotnetall.yml` as named in the audit; the CodeQL and publishing workflows keep their current shape, and the Dependabot auto-heal checkout must keep its credentials because it pushes. This PR's own CI proves both checkouts still work on both runner images.