### PR TITLE
feat: add a domain exception hierarchy for share and reconstruction errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a domain exception hierarchy rooted at `SecretSharingException` (derives from `Exception`): `InvalidShareException` for a malformed share and `ReconstructionException` for a set of individually valid shares that cannot be reconstructed. Catching `SecretSharingException` handles any Shamir-domain failure uniformly.
+
 ### Changed
+- Parsing or constructing a `Share<TNumber>` from its serialized form (the pinned-char constructor and the byte-array constructor) now throws `InvalidShareException` for a malformed share, instead of a mix of `ArgumentException`, `FormatException`, and `ArgumentOutOfRangeException`. `InvalidShareException` derives from `SecretSharingException` (not from the former BCL types), so `catch` clauses targeting `FormatException` / `ArgumentException` for parse failures must be updated. Passing an already-decoded, non-positive index through the `(index, value)` calculator constructor still throws `ArgumentOutOfRangeException`.
+- `SecretReconstructor<TNumber>.Reconstruction` now throws `ReconstructionException` (duplicate share indices, no maximum y-value, or a zero / non-invertible denominator during interpolation) instead of `ArgumentException`. `ReconstructionException` derives from `SecretSharingException` (not from `ArgumentException`), so `catch (ArgumentException)` around reconstruction must be updated.
 - Updated `Microsoft.SourceLink.GitHub` from `10.0.300` to `10.0.301` (build-time dependency; moves the transitive `System.IO.Hashing` from `10.0.8` to `10.0.10`).
 - Updated `Microsoft.NET.Test.Sdk` and `Microsoft.TestPlatform.ObjectModel` from `18.7.0` to `18.8.1`, and `Microsoft.Extensions.DependencyInjection` from `10.0.9` to `10.0.10` (test and sample dependencies).
 

--- a/src/Cryptography/InvalidShareException.cs
+++ b/src/Cryptography/InvalidShareException.cs
@@ -1,0 +1,104 @@
+// ----------------------------------------------------------------------------
+// <copyright file="InvalidShareException.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>08/06/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography;
+
+using System;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
+
+/// <summary>
+/// The exception that is thrown when a share cannot be parsed or constructed from its
+/// serialized form because the input is malformed — for example a share string with no
+/// <c>INDEX-VALUE</c> separator, an empty coordinate, a non-hexadecimal character, or a
+/// share whose decoded index is not positive.
+/// </summary>
+/// <remarks>
+/// Applies to the serialized-input construction paths (a pinned character buffer or a
+/// byte-array pair). Supplying an already-decoded, non-positive index directly through the
+/// <c>(index, value)</c> calculator constructor remains an argument error and throws
+/// <see cref="ArgumentOutOfRangeException"/> instead.
+/// </remarks>
+[Serializable]
+public class InvalidShareException : SecretSharingException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidShareException"/> class.
+    /// </summary>
+    public InvalidShareException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidShareException"/> class with a
+    /// specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public InvalidShareException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidShareException"/> class with a
+    /// specified error message and a reference to the inner exception that is the cause of
+    /// this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">
+    /// The exception that is the cause of the current exception, or <see langword="null"/> if
+    /// no inner exception is specified.
+    /// </param>
+    public InvalidShareException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+#if !NET8_0_OR_GREATER
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidShareException"/> class with
+    /// serialized data.
+    /// </summary>
+    /// <param name="info">
+    /// The <see cref="SerializationInfo"/> that holds the serialized object data about the
+    /// exception being thrown.
+    /// </param>
+    /// <param name="context">
+    /// The <see cref="StreamingContext"/> that contains contextual information about the
+    /// source or destination.
+    /// </param>
+    protected InvalidShareException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
+#endif
+}

--- a/src/Cryptography/ReconstructionException.cs
+++ b/src/Cryptography/ReconstructionException.cs
@@ -1,0 +1,103 @@
+// ----------------------------------------------------------------------------
+// <copyright file="ReconstructionException.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>08/06/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography;
+
+using System;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
+
+/// <summary>
+/// The exception that is thrown when a secret cannot be reconstructed from a set of shares
+/// that are individually well-formed — for example shares carrying duplicate indices, a set
+/// with no usable maximum y-value, or a denominator that has no modular inverse in the
+/// finite field (a zero or non-invertible denominator during Lagrange interpolation).
+/// </summary>
+/// <remarks>
+/// Distinguishes a genuine reconstruction failure from caller misuse: passing fewer than two
+/// shares or a <see langword="null"/> share collection remains an argument error and throws
+/// from the <see cref="ArgumentException"/> family instead.
+/// </remarks>
+[Serializable]
+public class ReconstructionException : SecretSharingException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReconstructionException"/> class.
+    /// </summary>
+    public ReconstructionException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReconstructionException"/> class with a
+    /// specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public ReconstructionException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReconstructionException"/> class with a
+    /// specified error message and a reference to the inner exception that is the cause of
+    /// this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">
+    /// The exception that is the cause of the current exception, or <see langword="null"/> if
+    /// no inner exception is specified.
+    /// </param>
+    public ReconstructionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+#if !NET8_0_OR_GREATER
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReconstructionException"/> class with
+    /// serialized data.
+    /// </summary>
+    /// <param name="info">
+    /// The <see cref="SerializationInfo"/> that holds the serialized object data about the
+    /// exception being thrown.
+    /// </param>
+    /// <param name="context">
+    /// The <see cref="StreamingContext"/> that contains contextual information about the
+    /// source or destination.
+    /// </param>
+    protected ReconstructionException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
+#endif
+}

--- a/src/Cryptography/SecretSharingException.cs
+++ b/src/Cryptography/SecretSharingException.cs
@@ -1,0 +1,105 @@
+// ----------------------------------------------------------------------------
+// <copyright file="SecretSharingException.cs" company="Private">
+// Copyright (c) 2026 All Rights Reserved
+// </copyright>
+// <author>Sebastian Walther</author>
+// <date>08/06/2026 00:00:00 AM</date>
+// ----------------------------------------------------------------------------
+
+#region License
+// ----------------------------------------------------------------------------
+// Copyright 2026 Sebastian Walther
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+
+namespace SecretSharingDotNet.Cryptography;
+
+using System;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
+
+/// <summary>
+/// Represents the base type for all errors that arise from a Shamir's Secret Sharing
+/// domain operation, such as parsing a malformed share or reconstructing a secret from
+/// an inconsistent set of shares.
+/// </summary>
+/// <remarks>
+/// Catch <see cref="SecretSharingException"/> to handle any secret-sharing-specific
+/// failure uniformly. Its subtypes (<see cref="InvalidShareException"/>,
+/// <see cref="ReconstructionException"/>) narrow the failure to a specific cause.
+/// Argument validation performed on values passed directly by the caller (for example a
+/// negative share index or fewer than two shares) continues to use the standard
+/// <see cref="ArgumentException"/> family and is intentionally not part of this hierarchy.
+/// </remarks>
+[Serializable]
+public class SecretSharingException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SecretSharingException"/> class.
+    /// </summary>
+    public SecretSharingException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SecretSharingException"/> class with a
+    /// specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public SecretSharingException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SecretSharingException"/> class with a
+    /// specified error message and a reference to the inner exception that is the cause of
+    /// this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">
+    /// The exception that is the cause of the current exception, or <see langword="null"/> if
+    /// no inner exception is specified.
+    /// </param>
+    public SecretSharingException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+#if !NET8_0_OR_GREATER
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SecretSharingException"/> class with
+    /// serialized data.
+    /// </summary>
+    /// <param name="info">
+    /// The <see cref="SerializationInfo"/> that holds the serialized object data about the
+    /// exception being thrown.
+    /// </param>
+    /// <param name="context">
+    /// The <see cref="StreamingContext"/> that contains contextual information about the
+    /// source or destination.
+    /// </param>
+    protected SecretSharingException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
+#endif
+}

--- a/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
+++ b/src/Cryptography/ShamirsSecretSharing/SecretReconstructor`3.cs
@@ -147,7 +147,7 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="shares"/> contains fewer than two entries.
     /// </exception>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="ReconstructionException">
     /// Two or more entries in <paramref name="shares"/> share the same <see cref="Share{TNumber}.Index"/>.
     /// </exception>
     /// <remarks>
@@ -191,7 +191,7 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
         {
             if (!seenIndices.Add(shares[i].Index))
             {
-                throw new ArgumentException(ErrorMessages.ShareIndicesNotDistinct, nameof(shares));
+                throw new ReconstructionException(ErrorMessages.ShareIndicesNotDistinct);
             }
         }
 
@@ -283,7 +283,7 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="shares"/> contains fewer than two entries.
     /// </exception>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="ReconstructionException">
     /// <paramref name="shares"/> has no maximum y-value, or contains entries with duplicate
     /// <see cref="Share{TNumber}.Index"/> values.
     /// </exception>
@@ -323,7 +323,7 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
 
         if (maximumY is null)
         {
-            throw new ArgumentException(ErrorMessages.NoMaximumY, nameof(shares));
+            throw new ReconstructionException(ErrorMessages.NoMaximumY);
         }
 
         this.securityLevelManager.AdjustSecurityLevel(maximumY);
@@ -344,7 +344,7 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
     /// <exception cref="System.ArgumentNullException">
     /// Thrown when the <paramref name="numerator"/> or <paramref name="denominator"/> parameter is null.
     /// </exception>
-    /// <exception cref="System.ArgumentException">
+    /// <exception cref="ReconstructionException">
     /// Thrown when the <paramref name="denominator"/> is zero (its modular inverse does not exist) or
     /// when the denominator is not invertible modulo the prime (gcd does not equal 1).
     /// </exception>
@@ -371,7 +371,7 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
         using var normalizedDenominator = denominator.MersenneModulo(mersenneExponent);
         if (normalizedDenominator.IsZero)
         {
-            throw new ArgumentException(ErrorMessages.InverseOfZeroDoesNotExist, nameof(denominator));
+            throw new ReconstructionException(ErrorMessages.InverseOfZeroDoesNotExist);
         }
 
         // The extended GCD still operates on the prime VALUE: the algorithm is
@@ -381,7 +381,7 @@ public class SecretReconstructor<TNumber, TExtendedGcdAlgorithm, TExtendedGcdRes
         // Check whether the denominator is invertible modulo the prime
         if (!result.GreatestCommonDivisor.IsOne)
         {
-            throw new ArgumentException(ErrorMessages.DenominatorIsNotInvertibleModuloPrime, nameof(denominator));
+            throw new ReconstructionException(ErrorMessages.DenominatorIsNotInvertibleModuloPrime);
         }
 
         // Normalize inverse: x mod M_p (Bezout coefficient may be negative)

--- a/src/Cryptography/Share`1.cs
+++ b/src/Cryptography/Share`1.cs
@@ -220,13 +220,11 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="shareString"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="shareString"/> does not contain the coordinate separator,
-    /// or contains non-hexadecimal characters. In the latter case, the exception message
-    /// identifies the zero-based position of the first invalid character.
-    /// </exception>
-    /// <exception cref="FormatException">
-    /// Thrown when either coordinate is empty after prefix stripping, or when the index is not positive.
+    /// <exception cref="InvalidShareException">
+    /// Thrown when <paramref name="shareString"/> is malformed: it does not contain the coordinate
+    /// separator, contains non-hexadecimal characters (the message identifies the zero-based position
+    /// of the first invalid character), has an empty coordinate after prefix stripping, or decodes to
+    /// an index that is not positive.
     /// </exception>
     public Share(PinnedPoolArray<char> shareString)
     {
@@ -243,7 +241,7 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="indexBytes"/> or <paramref name="valueBytes"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="ArgumentOutOfRangeException">
+    /// <exception cref="InvalidShareException">
     /// Thrown when the decoded index is less than one.
     /// </exception>
     /// <exception cref="NotSupportedException">
@@ -588,19 +586,17 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
     /// <returns>A tuple containing the parsed index and value as instances of <see cref="Calculator{TNumber}"/>.</returns>
     /// <remarks>
     /// Validation and decoding run in a single pass: <see cref="DecodeHexToCalculator"/> emits an
-    /// <see cref="ArgumentException"/> at the first non-hexadecimal character it encounters, with
+    /// <see cref="InvalidShareException"/> at the first non-hexadecimal character it encounters, with
     /// the character's position included in the message.
     /// </remarks>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="serialized"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="ArgumentException">
-    /// Thrown when the provided <paramref name="serialized"/> does not contain a coordinate separator
-    /// or contains non-hexadecimal characters (a message includes the zero-based position of the first
-    /// invalid character).
-    /// </exception>
-    /// <exception cref="FormatException">
-    /// Thrown when either the share index or value is empty, or when the index is not positive.
+    /// <exception cref="InvalidShareException">
+    /// Thrown when the provided <paramref name="serialized"/> is malformed: it does not contain a
+    /// coordinate separator, contains non-hexadecimal characters (the message includes the zero-based
+    /// position of the first invalid character), has an empty coordinate, or decodes to an index that
+    /// is not positive.
     /// </exception>
     private static (Calculator<TNumber> Index, Calculator<TNumber> Value) ParseCore(PinnedPoolArray<char> serialized)
     {
@@ -615,7 +611,7 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
         var separatorIndex = IndexOf(buf, start, end, CoordinateSeparator);
         if (separatorIndex < 0)
         {
-            throw new ArgumentException(string.Format(ErrorMessages.InvalidShareFormat, CoordinateSeparator));
+            throw new InvalidShareException(string.Format(ErrorMessages.InvalidShareFormat, CoordinateSeparator));
         }
 
         var indexStart = StripHexPrefix(buf, start, separatorIndex);
@@ -625,7 +621,7 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
 
         if (indexLen == 0 || valueLen == 0)
         {
-            throw new FormatException(ErrorMessages.ShareIndexAndValueMustBeNonEmpty);
+            throw new InvalidShareException(ErrorMessages.ShareIndexAndValueMustBeNonEmpty);
         }
 
         Calculator<TNumber> index = null;
@@ -637,7 +633,7 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
             using var one = Calculator<TNumber>.One;
             if (index < one)
             {
-                throw new FormatException(ErrorMessages.ShareIndexMustBePositive);
+                throw new InvalidShareException(ErrorMessages.ShareIndexMustBePositive);
             }
 
             var result = (index, value);
@@ -661,7 +657,7 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
     /// call or the index validation throws, any already-allocated <see cref="Calculator{TNumber}"/> is disposed
     /// to prevent resource leaks.
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
+    /// <exception cref="InvalidShareException">
     /// Thrown when the decoded index is less than one.
     /// </exception>
     /// <exception cref="NotSupportedException">
@@ -679,7 +675,7 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
             using var one = Calculator<TNumber>.One;
             if (index < one)
             {
-                throw new ArgumentOutOfRangeException(nameof(indexBytes), ErrorMessages.ShareIndexMustBePositive);
+                throw new InvalidShareException(ErrorMessages.ShareIndexMustBePositive);
             }
 
             value = Calculator.Create<TNumber>(valueBytes, valueBytes.Length);
@@ -707,7 +703,7 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
     /// cleared on dispose. Odd-length input is left-padded by writing the single high nibble into the
     /// first output byte.
     /// </remarks>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="InvalidShareException">
     /// Thrown when a non-hexadecimal character is encountered. The message identifies the zero-based
     /// position of the invalid character within <paramref name="buf"/>.
     /// </exception>
@@ -724,7 +720,7 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
             var low = GetHexValue(buf[offset]);
             if (low < 0)
             {
-                throw new ArgumentException(string.Format(ErrorMessages.InvalidHexCharacter, offset));
+                throw new InvalidShareException(string.Format(ErrorMessages.InvalidHexCharacter, offset));
             }
 
             bytesArray[writeIndex++] = (byte)low;
@@ -737,7 +733,7 @@ public sealed record Share<TNumber> : IComparable<Share<TNumber>>, IDisposable
             var low = GetHexValue(buf[offset + readIndex + 1]);
             if (high < 0 || low < 0)
             {
-                throw new ArgumentException(
+                throw new InvalidShareException(
                     string.Format(ErrorMessages.InvalidHexCharacter, high < 0 ? offset + readIndex : offset + readIndex + 1));
             }
 

--- a/tests/Cryptography/BigInteger/ShareTest.cs
+++ b/tests/Cryptography/BigInteger/ShareTest.cs
@@ -142,19 +142,19 @@ public class ShareTest
 
     /// <summary>
     /// Tests that the byte-array constructor rejects index bytes that decode to zero with
-    /// <see cref="ArgumentOutOfRangeException"/> — same positivity invariant as the
-    /// calculator-based constructor.
+    /// <see cref="InvalidShareException"/> — the same positivity invariant as the calculator-based
+    /// constructor, surfaced as a malformed-share error on the byte-decode path.
     /// </summary>
     [Fact]
-    public void Constructor_ByteArrays_ZeroIndex_ThrowsArgumentOutOfRangeException()
+    public void Constructor_ByteArrays_ZeroIndex_ThrowsInvalidShareException()
     {
         // Arrange
         var indexBytes = new byte[] { 0 };
         var valueBytes = new byte[] { 10 };
 
         // Act & Assert
-        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new Share<BigInteger>(indexBytes, valueBytes));
-        Assert.Equal("indexBytes", ex.ParamName);
+        var ex = Assert.Throws<InvalidShareException>(() => new Share<BigInteger>(indexBytes, valueBytes));
+        Assert.IsAssignableFrom<SecretSharingException>(ex);
     }
 
     /// <summary>
@@ -291,16 +291,16 @@ public class ShareTest
 
     /// <summary>
     /// Tests that the pinned-char constructor rejects malformed inputs (here a hyphen-only
-    /// separator without valid hex on either side) with <see cref="ArgumentException"/>.
+    /// separator without valid hex on either side) with <see cref="InvalidShareException"/>.
     /// </summary>
     [Fact]
-    public void Constructor_InvalidPinnedInput_ShouldThrowArgumentException()
+    public void Constructor_InvalidPinnedInput_ShouldThrowInvalidShareException()
     {
         // Arrange
         using var pinned = "invalid-input".ToPinnedSecure();
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => new Share<BigInteger>(pinned));
+        Assert.Throws<InvalidShareException>(() => new Share<BigInteger>(pinned));
     }
 
     /// <summary>
@@ -405,7 +405,7 @@ public class ShareTest
 
     /// <summary>
     /// Tests that the pinned-char constructor rejects an uppercase <c>0X</c> prefix on
-    /// either coordinate with <see cref="ArgumentException"/> — only the lowercase
+    /// either coordinate with <see cref="InvalidShareException"/> — only the lowercase
     /// <c>0x</c> form is accepted.
     /// </summary>
     /// <param name="shareString">Share text with an uppercase prefix variant.</param>
@@ -419,12 +419,12 @@ public class ShareTest
         using var pinned = shareString.ToPinnedSecure();
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => new Share<BigInteger>(pinned));
+        Assert.Throws<InvalidShareException>(() => new Share<BigInteger>(pinned));
     }
 
     /// <summary>
     /// Tests that the pinned-char constructor rejects non-hex characters after a valid
-    /// <c>0x</c> prefix with <see cref="ArgumentException"/>.
+    /// <c>0x</c> prefix with <see cref="InvalidShareException"/>.
     /// </summary>
     /// <param name="shareString">Share text containing non-hex characters after the prefix.</param>
     [Theory]
@@ -436,11 +436,11 @@ public class ShareTest
         using var pinned = shareString.ToPinnedSecure();
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => new Share<BigInteger>(pinned));
+        Assert.Throws<InvalidShareException>(() => new Share<BigInteger>(pinned));
     }
 
     /// <summary>
-    /// Tests that the pinned-char constructor's <see cref="ArgumentException"/> for invalid
+    /// Tests that the pinned-char constructor's <see cref="InvalidShareException"/> for invalid
     /// hex includes the offending character's position in the message — aids debugging
     /// without leaking the surrounding share material.
     /// </summary>
@@ -452,7 +452,7 @@ public class ShareTest
         using var pinned = "01-ZX".ToPinnedSecure();
 
         // Act
-        var ex = Assert.Throws<ArgumentException>(() => new Share<BigInteger>(pinned));
+        var ex = Assert.Throws<InvalidShareException>(() => new Share<BigInteger>(pinned));
 
         // Assert
         Assert.Contains("3", ex.Message);
@@ -460,11 +460,11 @@ public class ShareTest
 
     /// <summary>
     /// Tests the odd-length branch in the hex-to-calculator decoder: a single-character
-    /// coordinate with a non-hex character must throw <see cref="ArgumentException"/>
+    /// coordinate with a non-hex character must throw <see cref="InvalidShareException"/>
     /// rather than silently truncating.
     /// </summary>
     [Fact]
-    public void Constructor_OddLengthWithInvalidChar_ThrowsArgumentException()
+    public void Constructor_OddLengthWithInvalidChar_ThrowsInvalidShareException()
     {
         // Arrange
         // Single-char (odd-length) index with a non-hex character exercises the
@@ -472,7 +472,7 @@ public class ShareTest
         using var pinned = "Z-01".ToPinnedSecure();
 
         // Act
-        var ex = Assert.Throws<ArgumentException>(() => new Share<BigInteger>(pinned));
+        var ex = Assert.Throws<InvalidShareException>(() => new Share<BigInteger>(pinned));
 
         // Assert
         Assert.Contains("0", ex.Message);
@@ -480,7 +480,7 @@ public class ShareTest
 
     /// <summary>
     /// Tests that the pinned-char constructor rejects a <c>0x</c> prefix followed by no
-    /// hex digits at all with <see cref="FormatException"/> — distinguishes "missing
+    /// hex digits at all with <see cref="InvalidShareException"/> — distinguishes "missing
     /// coordinate" from "invalid coordinate".
     /// </summary>
     /// <param name="shareString">Share text where the prefix is not followed by digits.</param>
@@ -494,7 +494,7 @@ public class ShareTest
         using var pinned = shareString.ToPinnedSecure();
 
         // Act & Assert
-        Assert.Throws<FormatException>(() => new Share<BigInteger>(pinned));
+        Assert.Throws<InvalidShareException>(() => new Share<BigInteger>(pinned));
     }
 
     /// <summary>

--- a/tests/Cryptography/SecureBigInteger/ShareTest.cs
+++ b/tests/Cryptography/SecureBigInteger/ShareTest.cs
@@ -145,18 +145,18 @@ public class ShareTest
 
     /// <summary>
     /// Tests that the byte-array constructor rejects index bytes that decode to zero with
-    /// <see cref="ArgumentOutOfRangeException"/>.
+    /// <see cref="InvalidShareException"/> — surfaced as a malformed-share error on the byte-decode path.
     /// </summary>
     [Fact]
-    public void Constructor_ByteArrays_ZeroIndex_ThrowsArgumentOutOfRangeException()
+    public void Constructor_ByteArrays_ZeroIndex_ThrowsInvalidShareException()
     {
         // Arrange
         var indexBytes = new byte[] { 0 };
         var valueBytes = new byte[] { 10 };
 
         // Act & Assert
-        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new Share<SecureBigInteger>(indexBytes, valueBytes));
-        Assert.Equal("indexBytes", ex.ParamName);
+        var ex = Assert.Throws<InvalidShareException>(() => new Share<SecureBigInteger>(indexBytes, valueBytes));
+        Assert.IsAssignableFrom<SecretSharingException>(ex);
     }
 
     /// <summary>
@@ -293,16 +293,16 @@ public class ShareTest
 
     /// <summary>
     /// Tests that the pinned-char constructor rejects malformed inputs (here a hyphen-only
-    /// separator without valid hex on either side) with <see cref="ArgumentException"/>.
+    /// separator without valid hex on either side) with <see cref="InvalidShareException"/>.
     /// </summary>
     [Fact]
-    public void Constructor_InvalidPinnedInput_ShouldThrowArgumentException()
+    public void Constructor_InvalidPinnedInput_ShouldThrowInvalidShareException()
     {
         // Arrange
         using var pinned = "invalid-input".ToPinnedSecure();
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => new Share<SecureBigInteger>(pinned));
+        Assert.Throws<InvalidShareException>(() => new Share<SecureBigInteger>(pinned));
     }
 
     /// <summary>
@@ -407,7 +407,7 @@ public class ShareTest
 
     /// <summary>
     /// Tests that the pinned-char constructor rejects an uppercase <c>0X</c> prefix on
-    /// either coordinate with <see cref="ArgumentException"/> — only the lowercase
+    /// either coordinate with <see cref="InvalidShareException"/> — only the lowercase
     /// <c>0x</c> form is accepted.
     /// </summary>
     /// <param name="shareString">Share text with an uppercase prefix variant.</param>
@@ -421,12 +421,12 @@ public class ShareTest
         using var pinned = shareString.ToPinnedSecure();
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => new Share<SecureBigInteger>(pinned));
+        Assert.Throws<InvalidShareException>(() => new Share<SecureBigInteger>(pinned));
     }
 
     /// <summary>
     /// Tests that the pinned-char constructor rejects non-hex characters after a valid
-    /// <c>0x</c> prefix with <see cref="ArgumentException"/>.
+    /// <c>0x</c> prefix with <see cref="InvalidShareException"/>.
     /// </summary>
     /// <param name="shareString">Share text containing non-hex characters after the prefix.</param>
     [Theory]
@@ -438,11 +438,11 @@ public class ShareTest
         using var pinned = shareString.ToPinnedSecure();
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => new Share<SecureBigInteger>(pinned));
+        Assert.Throws<InvalidShareException>(() => new Share<SecureBigInteger>(pinned));
     }
 
     /// <summary>
-    /// Tests that the pinned-char constructor's <see cref="ArgumentException"/> for invalid
+    /// Tests that the pinned-char constructor's <see cref="InvalidShareException"/> for invalid
     /// hex includes the offending character's position in the message.
     /// </summary>
     [Fact]
@@ -453,7 +453,7 @@ public class ShareTest
         using var pinned = "01-ZX".ToPinnedSecure();
 
         // Act
-        var ex = Assert.Throws<ArgumentException>(() => new Share<SecureBigInteger>(pinned));
+        var ex = Assert.Throws<InvalidShareException>(() => new Share<SecureBigInteger>(pinned));
 
         // Assert
         Assert.Contains("3", ex.Message);
@@ -461,10 +461,10 @@ public class ShareTest
 
     /// <summary>
     /// Tests the odd-length branch in the hex-to-calculator decoder: a single-character
-    /// coordinate with a non-hex character must throw <see cref="ArgumentException"/>.
+    /// coordinate with a non-hex character must throw <see cref="InvalidShareException"/>.
     /// </summary>
     [Fact]
-    public void Constructor_OddLengthWithInvalidChar_ThrowsArgumentException()
+    public void Constructor_OddLengthWithInvalidChar_ThrowsInvalidShareException()
     {
         // Arrange
         // Single-char (odd-length) index with a non-hex character exercises the
@@ -472,7 +472,7 @@ public class ShareTest
         using var pinned = "Z-01".ToPinnedSecure();
 
         // Act
-        var ex = Assert.Throws<ArgumentException>(() => new Share<SecureBigInteger>(pinned));
+        var ex = Assert.Throws<InvalidShareException>(() => new Share<SecureBigInteger>(pinned));
 
         // Assert
         Assert.Contains("0", ex.Message);
@@ -480,7 +480,7 @@ public class ShareTest
 
     /// <summary>
     /// Tests that the pinned-char constructor rejects a <c>0x</c> prefix followed by no
-    /// hex digits at all with <see cref="FormatException"/>.
+    /// hex digits at all with <see cref="InvalidShareException"/>.
     /// </summary>
     /// <param name="shareString">Share text where the prefix is not followed by digits.</param>
     [Theory]
@@ -493,7 +493,7 @@ public class ShareTest
         using var pinned = shareString.ToPinnedSecure();
 
         // Act & Assert
-        Assert.Throws<FormatException>(() => new Share<SecureBigInteger>(pinned));
+        Assert.Throws<InvalidShareException>(() => new Share<SecureBigInteger>(pinned));
     }
 
     /// <summary>

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/SecretReconstructorTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/SecretReconstructorTest.cs
@@ -35,6 +35,7 @@
 namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.BigInteger;
 
 using Moq;
+using SecretSharingDotNet;
 using SecretSharingDotNet.Cryptography;
 using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
 using SecretSharingDotNet.Math;
@@ -200,12 +201,11 @@ public class SecretReconstructorTest
     /// <summary>
     /// Tests that <see cref="SecretReconstructor{TNumber}.Reconstruction"/> rejects share
     /// arrays that contain two entries with the same x-coordinate but inconsistent values
-    /// at the input-validation layer (<see cref="ArgumentException"/> with
-    /// <see cref="ArgumentException.ParamName"/> = <c>shares</c>), rather than failing
-    /// deep inside <c>DivMod</c> with a misleading "inverse of zero" diagnostic.
+    /// at the input-validation layer (<see cref="ReconstructionException"/>), rather than
+    /// failing deep inside <c>DivMod</c> with a misleading "inverse of zero" diagnostic.
     /// </summary>
     [Fact]
-    public void Reconstruction_WithDuplicateShareIndices_ThrowsArgumentException()
+    public void Reconstruction_WithDuplicateShareIndices_ThrowsReconstructionException()
     {
         // Arrange — two shares carrying the same index but inconsistent values
         // (e.g. mixed in from two different splits). Pre-fix this passed the
@@ -226,8 +226,8 @@ public class SecretReconstructorTest
         };
 
         // Act & Assert — fail at the input-validation layer, not in DivMod.
-        var ex = Assert.Throws<ArgumentException>(() => reconstructor.Reconstruction(shares));
-        Assert.Equal("shares", ex.ParamName);
+        var ex = Assert.Throws<ReconstructionException>(() => reconstructor.Reconstruction(shares));
+        Assert.IsAssignableFrom<SecretSharingException>(ex);
     }
 
     /// <summary>
@@ -236,7 +236,7 @@ public class SecretReconstructorTest
     /// — the validation is by x-coordinate only, since duplicate y-values are legitimate
     /// on a polynomial that happens to be locally flat. Reconstruction may legitimately
     /// fail later (the shares are not on a real polynomial), but never with the
-    /// share-distinctness ArgumentException.
+    /// share-distinctness ReconstructionException.
     /// </summary>
     [Fact]
     public void Reconstruction_WithDistinctIndicesAndDuplicateValues_DoesNotThrowAtValidation()
@@ -245,7 +245,7 @@ public class SecretReconstructorTest
         // the old Share-structural Distinct() check this would still pass; under
         // the index-only check it must continue to pass. The reconstruction
         // itself may legitimately fail later (these shares aren't on a real
-        // polynomial), but never with the share-distinctness ArgumentException.
+        // polynomial), but never with the share-distinctness ReconstructionException.
         using var reconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
         var idx1 = (Calculator<BigInteger>)(BigInteger)1;
         var idx2 = (Calculator<BigInteger>)(BigInteger)2;
@@ -260,9 +260,9 @@ public class SecretReconstructorTest
         // Act & Assert — reconstruction completes (or fails later) but does not
         // raise the share-distinctness validation.
         var ex = Record.Exception(() => reconstructor.Reconstruction(shares));
-        if (ex is ArgumentException ae)
+        if (ex is ReconstructionException re)
         {
-            Assert.NotEqual("shares", ae.ParamName);
+            Assert.DoesNotContain(ErrorMessages.ShareIndicesNotDistinct, re.Message);
         }
     }
 }

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/SecretReconstructorTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/SecretReconstructorTest.cs
@@ -35,6 +35,7 @@
 namespace SecretSharingDotNetTest.Cryptography.ShamirsSecretSharing.SecureBigInteger;
 
 using Moq;
+using SecretSharingDotNet;
 using SecretSharingDotNet.Cryptography;
 using SecretSharingDotNet.Cryptography.ShamirsSecretSharing;
 using SecretSharingDotNet.Math;
@@ -200,12 +201,11 @@ public class SecretReconstructorTest
     /// <summary>
     /// Tests that <see cref="SecretReconstructor{TNumber}.Reconstruction"/> rejects share
     /// arrays that contain two entries with the same x-coordinate but inconsistent values
-    /// at the input-validation layer (<see cref="ArgumentException"/> with
-    /// <see cref="ArgumentException.ParamName"/> = <c>shares</c>), rather than failing
-    /// deep inside <c>DivMod</c> with a misleading "inverse of zero" diagnostic.
+    /// at the input-validation layer (<see cref="ReconstructionException"/>), rather than
+    /// failing deep inside <c>DivMod</c> with a misleading "inverse of zero" diagnostic.
     /// </summary>
     [Fact]
-    public void Reconstruction_WithDuplicateShareIndices_ThrowsArgumentException()
+    public void Reconstruction_WithDuplicateShareIndices_ThrowsReconstructionException()
     {
         // Arrange — two shares carrying the same index but inconsistent values
         // (e.g. mixed in from two different splits). Pre-fix this passed the
@@ -226,8 +226,8 @@ public class SecretReconstructorTest
         };
 
         // Act & Assert — fail at the input-validation layer, not in DivMod.
-        var ex = Assert.Throws<ArgumentException>(() => reconstructor.Reconstruction(shares));
-        Assert.Equal("shares", ex.ParamName);
+        var ex = Assert.Throws<ReconstructionException>(() => reconstructor.Reconstruction(shares));
+        Assert.IsAssignableFrom<SecretSharingException>(ex);
     }
 
     /// <summary>
@@ -236,7 +236,7 @@ public class SecretReconstructorTest
     /// — the validation is by x-coordinate only, since duplicate y-values are legitimate
     /// on a polynomial that happens to be locally flat. Reconstruction may legitimately
     /// fail later (the shares are not on a real polynomial), but never with the
-    /// share-distinctness ArgumentException.
+    /// share-distinctness ReconstructionException.
     /// </summary>
     [Fact]
     public void Reconstruction_WithDistinctIndicesAndDuplicateValues_DoesNotThrowAtValidation()
@@ -245,7 +245,7 @@ public class SecretReconstructorTest
         // the old Share-structural Distinct() check this would still pass; under
         // the index-only check it must continue to pass. The reconstruction
         // itself may legitimately fail later (these shares aren't on a real
-        // polynomial), but never with the share-distinctness ArgumentException.
+        // polynomial), but never with the share-distinctness ReconstructionException.
         using var reconstructor = new SecretReconstructor<SecureBigInteger>(new ExtendedEuclideanAlgorithm<SecureBigInteger>());
         var idx1 = (Calculator<SecureBigInteger>)(SecureBigInteger)1;
         var idx2 = (Calculator<SecureBigInteger>)(SecureBigInteger)2;
@@ -260,9 +260,9 @@ public class SecretReconstructorTest
         // Act & Assert — reconstruction completes (or fails later) but does not
         // raise the share-distinctness validation.
         var ex = Record.Exception(() => reconstructor.Reconstruction(shares));
-        if (ex is ArgumentException ae)
+        if (ex is ReconstructionException re)
         {
-            Assert.NotEqual("shares", ae.ParamName);
+            Assert.DoesNotContain(ErrorMessages.ShareIndicesNotDistinct, re.Message);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a domain exception hierarchy so consumers can catch a Shamir's Secret Sharing failure uniformly instead of parsing message strings or catching a mix of BCL exception types (architecture-review item **A8**).

```
SecretSharingException : Exception       root (domain catch-all)
├── InvalidShareException                a malformed share (parse / byte-decode)
└── ReconstructionException              individually valid shares that cannot be reconstructed
```

## What changes

- **`Share<TNumber>` parsing/construction from a serialized form** (the pinned-char constructor and the byte-array constructor) now throws **`InvalidShareException`** for a malformed share — previously a mix of `ArgumentException`, `FormatException`, and `ArgumentOutOfRangeException` depending on the defect (missing separator, empty coordinate, non-hex character, non-positive decoded index). The `(index, value)` calculator constructor keeps `ArgumentOutOfRangeException` for a non-positive index: that is a direct argument, not a parse failure.
- **`SecretReconstructor<TNumber>.Reconstruction` / `DivMod`** now throw **`ReconstructionException`** for duplicate share indices, no maximum y-value, and a zero or non-invertible denominator during interpolation — previously `ArgumentException`.
- Argument validation on values passed directly by the caller (a negative share index via the calculator constructor, fewer than two shares, `null` arguments, min/max share counts, security-level bounds) is intentionally **unchanged** and stays in the `ArgumentException` family.

## Breaking change

`InvalidShareException` and `ReconstructionException` derive from `SecretSharingException` (→ `Exception`), **not** from the former BCL types. `catch` clauses targeting `FormatException` / `ArgumentException` for share-parse or reconstruction failures must be updated. Documented in `CHANGELOG.md` under `[Unreleased]`.

## Serialization

The three types are `[Serializable]` with a `protected (SerializationInfo, StreamingContext)` constructor guarded to the pre-net8 target frameworks (`#if !NET8_0_OR_GREATER`); net8+ obsoletes legacy binary serialization (SYSLIB0051). Exception messages are unchanged and still sourced from `ErrorMessages.resx` (no new resource keys).

## Public API delta

Adds three public types (`SecretSharingException`, `InvalidShareException`, `ReconstructionException`). Changes the thrown exception type at the share-parse and reconstruction sites (see Breaking change).

## Testing

`ShareTest` and `SecretReconstructorTest` for both the `BigInteger` and `SecureBigInteger` backends are updated to the new types and assert the `SecretSharingException` catch-all. Full single-threaded suite green on all six test target frameworks (net8.0/9.0/10.0: 1706 each; net472/48/481: 1692 each; 0 failures).

Refs: A8 (architecture review — exception design).
