### PR TITLE
fix: replace reflection-based backend discovery with an explicit registry

### DIFF
--- a/src/Math/Calculator.cs
+++ b/src/Math/Calculator.cs
@@ -32,12 +32,10 @@
 namespace SecretSharingDotNet.Math;
 
 using Cryptography.SecureArray;
+using Numerics;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
+using System.Numerics;
 
 /// <summary>
 /// Non-generic base of the calculator strategy pattern that decouples Shamir's Secret
@@ -60,17 +58,23 @@ public abstract class Calculator : IDisposable
     private bool disposed;
 
     /// <summary>
-    /// Saves a dictionary of number data types derived from the <see cref="Calculator{TNumber}"/> class.
+    /// Explicit registry of the in-tree numeric backends, keyed by their numeric data type.
+    /// Replaces the former reflection-based subtype discovery: it carries no
+    /// <c>System.Reflection</c> or <c>System.Linq.Expressions</c> dependency, so it is
+    /// trimming- and NativeAOT-safe and free of static-initialisation-order fragility.
+    /// New in-tree backends are added here; the registry is intentionally closed to
+    /// external types.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-    private static readonly ReadOnlyDictionary<Type, Type> ChildTypes =
-        new ReadOnlyDictionary<Type, Type>(GetDerivedNumberTypes());
-
-    /// <summary>
-    /// Saves a dictionary of constructors of number data types derived from the <see cref="Calculator{TNumber}"/> class.
-    /// </summary>
-    private static readonly IReadOnlyDictionary<Type, Func<byte[], int, Calculator>> ChildBaseCtors =
-        new ReadOnlyDictionary<Type, Func<byte[], int, Calculator>>(GetDerivedCtors<Func<byte[], int, Calculator>>());
+    private static readonly IReadOnlyDictionary<Type, BackendRegistration> Backends =
+        new Dictionary<Type, BackendRegistration>
+        {
+            [typeof(BigInteger)] = new BackendRegistration(
+                (data, length) => new BigIntCalculator(data, length),
+                (Func<BigInteger, Calculator<BigInteger>>)(value => new BigIntCalculator(value))),
+            [typeof(SecureBigInteger)] = new BackendRegistration(
+                (data, length) => new SecureBigIntCalculator(data, length),
+                (Func<SecureBigInteger, Calculator<SecureBigInteger>>)(value => new SecureBigIntCalculator(value))),
+        };
 
     /// <summary>
     /// Gets the length, in bytes, of the canonical two's-complement byte representation
@@ -139,9 +143,9 @@ public abstract class Calculator : IDisposable
     /// <paramref name="numberType"/> is not a registered backend in this assembly. The generic
     /// <see cref="Create{TNumber}(byte[], int)"/> overload translates this to
     /// <see cref="NotSupportedException"/>; this base-class entry point intentionally surfaces
-    /// the raw lookup failure for plugin diagnostics.
+    /// the raw lookup failure for backend-lookup diagnostics.
     /// </exception>
-    public static Calculator Create(byte[] data, int length, Type numberType) => ChildBaseCtors[numberType](data, length);
+    public static Calculator Create(byte[] data, int length, Type numberType) => Backends[numberType].FromBytes(data, length);
 
     /// <summary>
     /// Strongly-typed counterpart to <see cref="Create(byte[], int, Type)"/>. Resolves the backend
@@ -155,7 +159,7 @@ public abstract class Calculator : IDisposable
     /// <returns>A <see cref="Calculator{TNumber}"/> instance bound to <typeparamref name="TNumber"/>.</returns>
     /// <remarks>
     /// Closes the leak-on-type-mismatch window of the
-    /// <c>Calculator.Create(...) as Calculator&lt;TNumber&gt;</c> idiom: if a third-party plugin
+    /// <c>Calculator.Create(...) as Calculator&lt;TNumber&gt;</c> idiom: if a misregistered
     /// backend produces a <see cref="Calculator"/> subtype that is not assignable to
     /// <see cref="Calculator{TNumber}"/>, the original instance — which may hold pinned, security-
     /// sensitive buffers on the <see cref="Numerics.SecureBigInteger"/> backend — is disposed
@@ -163,8 +167,8 @@ public abstract class Calculator : IDisposable
     /// </remarks>
     /// <exception cref="NotSupportedException">
     /// The registered backend for <typeparamref name="TNumber"/> is not assignable to
-    /// <see cref="Calculator{TNumber}"/> — a configuration error in a third-party plugin
-    /// backend rather than invalid user input.
+    /// <see cref="Calculator{TNumber}"/> — a backend-registration error rather than invalid
+    /// user input.
     /// </exception>
     /// <exception cref="System.Collections.Generic.KeyNotFoundException">
     /// No backend is registered for <typeparamref name="TNumber"/>.
@@ -183,76 +187,25 @@ public abstract class Calculator : IDisposable
     }
 
     /// <summary>
+    /// Builds a <see cref="Calculator{TNumber}"/> from a strongly-typed <typeparamref name="TNumber"/>
+    /// value using the registered backend factory. Backs the implicit
+    /// <c>TNumber</c> → <see cref="Calculator{TNumber}"/> conversion.
+    /// </summary>
+    /// <typeparam name="TNumber">Numeric backend type.</typeparam>
+    /// <param name="value">The numeric value to wrap.</param>
+    /// <returns>A <see cref="Calculator{TNumber}"/> bound to <typeparamref name="TNumber"/>.</returns>
+    /// <exception cref="System.Collections.Generic.KeyNotFoundException">
+    /// No backend is registered for <typeparamref name="TNumber"/>. The calling conversion
+    /// operator translates this to <see cref="NotSupportedException"/>.
+    /// </exception>
+    internal static Calculator<TNumber> FromValue<TNumber>(TNumber value) =>
+        ((Func<TNumber, Calculator<TNumber>>)Backends[typeof(TNumber)].FromValue)(value);
+
+    /// <summary>
     /// Returns a <see cref="System.String"/> that represents the current <see cref="Calculator"/>.
     /// </summary>
     /// <returns>The <see cref="System.String"/> representation of this <see cref="Calculator"/> object</returns>
     public abstract override string ToString();
-
-    /// <summary>
-    /// Returns a dictionary of constructors of number data types derived from the <see cref="Calculator"/> class.
-    /// </summary>
-    /// <returns>A dictionary of constructors of number data types derived from the <see cref="Calculator"/> class.</returns>
-    protected static Dictionary<Type, TDelegate> GetDerivedCtors<TDelegate>() where TDelegate : Delegate
-    {
-        var delegateType = typeof(TDelegate);
-        var methodInfo = delegateType.GetMethod(nameof(Func<>.Invoke)) ??
-                         throw new InvalidOperationException(
-                             $"Delegate type '{delegateType.Name}' does not have an '{nameof(Func<>.Invoke)}' method.");
-        var parameterTypes = methodInfo.GetParameters().Select(x => x.ParameterType).ToArray();
-        var parameterExpressions = parameterTypes.Select(Expression.Parameter).ToArray();
-        var expressions = parameterExpressions.OfType<Expression>().ToArray();
-
-        var res = new Dictionary<Type, TDelegate>(ChildTypes.Count);
-        foreach (var childType in ChildTypes)
-        {
-            var constructorInfos = childType.Value.GetConstructors();
-            foreach (var constructorInfo in constructorInfos)
-            {
-                var ctorParams = constructorInfo.GetParameters();
-                if (ctorParams.Length != parameterTypes.Length)
-                {
-                    continue;
-                }
-
-                var matches = true;
-                for (int i = 0; i < ctorParams.Length; i++)
-                {
-                    if (ctorParams[i].ParameterType == parameterTypes[i])
-                    {
-                        continue;
-                    }
-
-                    matches = false;
-                    break;
-                }
-
-                if (!matches)
-                {
-                    continue;
-                }
-
-                var ctor = Expression
-                    .Lambda<TDelegate>(Expression.New(constructorInfo, expressions), parameterExpressions)
-                    .Compile();
-                res.Add(childType.Key, ctor);
-            }
-        }
-
-        return res;
-    }
-
-    /// <summary>
-    /// Returns a dictionary of number data types derived from the <see cref="Calculator"/> class.
-    /// </summary>
-    /// <returns></returns>
-    /// <remarks>The key represents the integer data type of the derived calculator. The value represents the type of derived calculator.</remarks>
-    private static Dictionary<Type, Type> GetDerivedNumberTypes()
-    {
-        var asm = Assembly.GetAssembly(typeof(Calculator));
-        var listOfClasses = asm?.GetTypes()
-            .Where(x => x.IsSubclassOf(typeof(Calculator)) && !x.IsGenericType);
-        return listOfClasses?.ToDictionary(type => type.BaseType?.GetGenericArguments()[0]) ?? [];
-    }
 
     /// <summary>
     /// Releases the resources used by the current instance of the <see cref="Calculator"/> class.
@@ -280,5 +233,41 @@ public abstract class Calculator : IDisposable
 
         // Release unmanaged resources here
         this.disposed = true;
+    }
+
+    /// <summary>
+    /// Bundles the two construction entry points of a registered backend: the
+    /// <c>(byte[], length)</c> factory used by <see cref="Create(byte[], int, Type)"/> and the
+    /// strongly-typed <c>(TNumber)</c> factory used by the <c>TNumber</c> →
+    /// <see cref="Calculator{TNumber}"/> conversion. The latter is stored as a
+    /// <see cref="System.Delegate"/> because its type (<c>Func&lt;TNumber, Calculator&lt;TNumber&gt;&gt;</c>)
+    /// is generic per backend and cannot be expressed in this non-generic dictionary.
+    /// </summary>
+    private sealed class BackendRegistration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BackendRegistration"/> class.
+        /// </summary>
+        /// <param name="fromBytes">Factory building a <see cref="Calculator"/> from a byte array and a length.</param>
+        /// <param name="fromValue">
+        /// Factory building a <c>Calculator&lt;TNumber&gt;</c> from a <c>TNumber</c> value, held as a
+        /// <see cref="System.Delegate"/> (a <c>Func&lt;TNumber, Calculator&lt;TNumber&gt;&gt;</c>).
+        /// </param>
+        internal BackendRegistration(Func<byte[], int, Calculator> fromBytes, Delegate fromValue)
+        {
+            this.FromBytes = fromBytes;
+            this.FromValue = fromValue;
+        }
+
+        /// <summary>
+        /// Gets the factory that builds a <see cref="Calculator"/> from a byte-array representation and a length.
+        /// </summary>
+        internal Func<byte[], int, Calculator> FromBytes { get; }
+
+        /// <summary>
+        /// Gets the strongly-typed <c>Func&lt;TNumber, Calculator&lt;TNumber&gt;&gt;</c> factory, held as a
+        /// <see cref="System.Delegate"/> and cast back by <see cref="FromValue{TNumber}"/>.
+        /// </summary>
+        internal Delegate FromValue { get; }
     }
 }

--- a/src/Math/Calculator`1.cs
+++ b/src/Math/Calculator`1.cs
@@ -33,7 +33,6 @@ namespace SecretSharingDotNet.Math;
 using System;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 /// <summary>
 /// Generic strategy-pattern base that decouples Shamir's Secret Sharing from the concrete
@@ -82,13 +81,6 @@ public abstract class Calculator<TNumber> :
     /// Indicates whether the resources used by the current instance have been released.
     /// </summary>
     private bool disposed;
-
-    /// <summary>
-    /// Saves a dictionary of constructors of number data types derived from the <see cref="Calculator{TNumber}"/> class.
-    /// </summary>
-    private static readonly ReadOnlyDictionary<Type, Func<TNumber, Calculator<TNumber>>> ChildCtors =
-        new ReadOnlyDictionary<Type, Func<TNumber, Calculator<TNumber>>>(
-            GetDerivedCtors<Func<TNumber, Calculator<TNumber>>>());
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Calculator{TNumber}"/> class.
@@ -393,7 +385,7 @@ public abstract class Calculator<TNumber> :
     {
         try
         {
-            return ChildCtors[typeof(TNumber)](number);
+            return Calculator.FromValue(number);
         }
         catch (KeyNotFoundException)
         {


### PR DESCRIPTION
## Summary

Replaces the reflection-based numeric-backend discovery in `Calculator` with an explicit, closed registry (architecture-review item **A1**). The old mechanism scanned the assembly with `Assembly.GetTypes()` and compiled constructor delegates via `Expression.Compile`, which is trimming-/NativeAOT-hostile and carries a fragile static-initialisation order.

## What changes

- **Removed** the reflection machinery: `GetDerivedNumberTypes()` (`Assembly.GetTypes()`), `GetDerivedCtors<TDelegate>()` (`Expression.Compile`), the `ChildTypes` / `ChildBaseCtors` / `ChildCtors` caches, and the `System.Reflection` / `System.Linq` / `System.Linq.Expressions` / `System.Collections.ObjectModel` usings.
- **Added** an explicit, closed registry keyed by numeric type (`Backends` + a private `BackendRegistration`) that holds both construction entry points per backend:
  - the `(byte[], length)` factory behind `Calculator.Create(byte[], int, Type)`, and
  - the strongly-typed `(TNumber)` factory behind the `TNumber` → `Calculator<TNumber>` implicit conversion (via a new `internal Calculator.FromValue<TNumber>`).
- The two in-tree backends (`BigIntCalculator`, `SecureBigIntCalculator`) are registered by hand. No reflection or `Expression` dependency remains, and there is no static-init-order coupling — the factories are lambdas, so no backend is instantiated during `Calculator`'s static initialisation. The path is now trimming-/NativeAOT-safe.

## Behaviour

Unchanged. The public `Create` overloads and the implicit conversion keep their signatures and exception contracts: an unregistered type surfaces `KeyNotFoundException` from the non-generic base entry point, translated to `NotSupportedException` by the generic overload and the conversion operator.

## Design note

The registry is intentionally **internal and closed** — a public backend-registration (plugin) API is deliberately deferred. An injectable backend in a secret-sharing library is a footgun (a weak or non-constant-time backend silently degrades the guarantees), mirroring the internal-only `IRandomSource` seam from #334. `internal` → `public` later is a safe additive move if a real external-backend need appears.

## Public API delta

None additive. Removes the `protected static GetDerivedCtors<TDelegate>` reflection helper — a technically-protected member, but reflection plumbing with no legitimate external caller.

## Testing

Full single-threaded suite green on all six test target frameworks (net8.0/9.0/10.0: 1706 each; net472/48/481: 1692 each; 0 failures). No behaviour or test-count change — the existing construction-heavy tests (every implicit `(Calculator<T>)value` conversion and `Create` call) exercise both registry paths.

Refs: A1 (architecture review — extensibility). Related seam: #334 (internal-only `IRandomSource`).
