### PR TITLE
chore: ignore TestResults output and Claude Code local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,12 @@
 # Ignore JetBrains Rider / IntelliJ IDEA meta info
 .idea
 
-# Ignore Claude Code local state — machine-local permission settings and
-# temporary worktrees created by background sessions.
+# Ignore Claude Code local state — machine-local permission settings,
+# temporary worktrees created by background sessions, and the project MCP
+# config (points at Rider's localhost endpoint with an ephemeral port).
 .claude/settings.local.json
 .claude/worktrees/
+.mcp.json
 
 # Ignore swap files
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 **/[Bb]in
 **/[Oo]bj
 
+# Ignore test-run output — `dotnet test` with a trx logger or coverage
+# collector writes TestResults/ next to the test project, not under bin/.
+**/TestResults/
+
 # Ignore Visual Studio Code
 **/.vscode
 
@@ -21,6 +25,11 @@
 
 # Ignore JetBrains Rider / IntelliJ IDEA meta info
 .idea
+
+# Ignore Claude Code local state — machine-local permission settings and
+# temporary worktrees created by background sessions.
+.claude/settings.local.json
+.claude/worktrees/
 
 # Ignore swap files
 *.swp


### PR DESCRIPTION
Closes the gaps found in the .gitignore review:

1. **`**/TestResults/`** — `dotnet test` with a trx logger or coverage collector writes `TestResults/` next to the test project (not under `bin/`), which would pollute `git status`.
2. **Claude Code local state** — `.claude/settings.local.json` and `.claude/worktrees/` were previously only covered by a per-user global git ignore, so they would appear as untracked on other machines and for other contributors.
3. **`.mcp.json`** — the project MCP config only points at Rider's localhost endpoint with an ephemeral port, so it is machine-local state rather than shareable team configuration.

Verified with `git check-ignore -v`: all representative paths (`.claude/settings.local.json`, `.claude/worktrees/foo/x.cs`, `tests/TestResults/run.trx`, `samples/.../TestResults/x`, `.mcp.json`) match from the repo .gitignore itself.