### PR TITLE
ci: re-include README.md in the dotnetall path filter

### DIFF
--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -6,14 +6,27 @@ on:
     - '**'
     tags-ignore:
     - '**'
-    paths-ignore:
-    - '**.md'
+    # `paths` with negations instead of `paths-ignore`, because only `paths`
+    # can re-include README.md: it is pack input (PackageReadmeFile), and the
+    # "Prepare README.md" guard below must turn red on the README-only push
+    # that introduces heading drift. All other Markdown plus .gitignore and
+    # .gitattributes cannot affect build, test, or pack. Last match wins.
+    paths:
+    - '**'
+    - '!**.md'
+    - 'README.md'
+    - '!.gitignore'
+    - '!.gitattributes'
   pull_request:
     branches:
     - develop
     - main
-    paths-ignore:
-    - '**.md'
+    paths:
+    - '**'
+    - '!**.md'
+    - 'README.md'
+    - '!.gitignore'
+    - '!.gitattributes'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/dotnetall.yml
+++ b/.github/workflows/dotnetall.yml
@@ -9,14 +9,15 @@ on:
     # `paths` with negations instead of `paths-ignore`, because only `paths`
     # can re-include README.md: it is pack input (PackageReadmeFile), and the
     # "Prepare README.md" guard below must turn red on the README-only push
-    # that introduces heading drift. All other Markdown plus .gitignore and
-    # .gitattributes cannot affect build, test, or pack. Last match wins.
+    # that introduces heading drift. Other Markdown and .gitignore cannot
+    # affect build, test, or pack; .gitattributes can (checkout applies its
+    # eol / working-tree-encoding / filter rules while materializing the
+    # sources), so it stays a trigger. Last match wins.
     paths:
     - '**'
     - '!**.md'
     - 'README.md'
     - '!.gitignore'
-    - '!.gitattributes'
   pull_request:
     branches:
     - develop
@@ -26,7 +27,6 @@ on:
     - '!**.md'
     - 'README.md'
     - '!.gitignore'
-    - '!.gitattributes'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problem

`dotnetall.yml` filters both triggers with `paths-ignore: '**.md'`. That skips exactly the README-only pushes that the *Prepare README.md for NuGet package* heading guard exists to catch — its comment promises heading drift "turns red on every push", but the push that introduces drift (editing only `README.md`) never triggered the workflow. Drift therefore surfaced only on the next non-Markdown push, or worst case first in the release workflow. `README.md` is also pack input via `PackageReadmeFile`, hence build-relevant.

## Fix

Switch `push` and `pull_request` from `paths-ignore` to `paths` with negations — only `paths` supports re-including a previously excluded pattern (last match wins):

```yaml
paths:
- '**'
- '!**.md'
- 'README.md'
- '!.gitignore'
```

- All Markdown stays ignored, except `README.md`, which triggers again.
- `.gitignore` is newly excluded — a fresh CI checkout of tracked files never consults it.
- `.gitattributes` deliberately stays a trigger (an initial exclusion was reverted after the Codex review finding): checkout applies its eol / working-tree-encoding / filter rules while materializing the sources, so an attributes-only push can alter or break the build inputs.

## Safety

`dotnetall` is not a required status check on develop/main (only CodeQL is), so a path-skipped run cannot block a merge. CodeQL stays deliberately unfiltered for the same reason.

This PR touches the workflow file itself, so the push runs already exercise the new trigger block.
