### PR TITLE
fix: make SharesEnumerator<TNumber> internal (A6 public-API boundary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SecretReconstructor<TNumber>.Reconstruction` now throws `ReconstructionException` (duplicate share indices, no maximum y-value, or a zero / non-invertible denominator during interpolation) instead of `ArgumentException`. `ReconstructionException` derives from `SecretSharingException` (not from `ArgumentException`), so `catch (ArgumentException)` around reconstruction must be updated.
 - Updated `Microsoft.SourceLink.GitHub` from `10.0.300` to `10.0.301` (build-time dependency; moves the transitive `System.IO.Hashing` from `10.0.8` to `10.0.10`).
 - Updated `Microsoft.NET.Test.Sdk` and `Microsoft.TestPlatform.ObjectModel` from `18.7.0` to `18.8.1`, and `Microsoft.Extensions.DependencyInjection` from `10.0.9` to `10.0.10` (test and sample dependencies).
+- `Shares<TNumber>.GetEnumerator()` now returns `IEnumerator<Share<TNumber>>` instead of the concrete `SharesEnumerator<TNumber>`. `foreach` and LINQ over a `Shares<TNumber>` are unaffected; only code that captured the result in a `SharesEnumerator<TNumber>`-typed variable must switch to `var` or `IEnumerator<Share<TNumber>>`.
+
+### Removed
+- `SharesEnumerator<TNumber>` is no longer public; it is now an `internal` implementation detail of `Shares<TNumber>.GetEnumerator()`. Iterate a `Shares<TNumber>` with `foreach` or through its `IEnumerator<Share<TNumber>>`. This also removes the public `SharesEnumerator<TNumber>(Collection<Share<TNumber>>)` constructor.
 
 ### Fixed
 - Share-index de-duplication in `SecretReconstructor` is O(n) again on the `SecureBigInteger` backend. After the `GetHashCode` metadata hardening every small positive one-limb index hashed identically, collapsing the distinctness `HashSet` into one bucket (O(n²)); an internal public-value comparer restores O(n). No public API change; the secret-hash hardening is unchanged.

--- a/src/Cryptography/Shares.cs
+++ b/src/Cryptography/Shares.cs
@@ -382,17 +382,6 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection, 
     /// <summary>
     /// Returns an enumerator that iterates through a <see cref="Shares{TNumber}"/> collection.
     /// </summary>
-    /// <returns>An enumerator that can be used to iterate through the <see cref="Shares{TNumber}"/> collection.</returns>
-    /// <exception cref="ObjectDisposedException">Thrown when the collection has been disposed.</exception>
-    IEnumerator<Share<TNumber>> IEnumerable<Share<TNumber>>.GetEnumerator()
-    {
-        this.ThrowIfDisposed();
-        return this.GetEnumerator();
-    }
-
-    /// <summary>
-    /// Returns an enumerator that iterates through a <see cref="Shares{TNumber}"/> collection.
-    /// </summary>
     /// <returns>An <see cref="IEnumerator"/> object that can be used to iterate through the <see cref="Shares{TNumber}"/> collection.</returns>
     /// <exception cref="ObjectDisposedException">Thrown when the collection has been disposed.</exception>
     IEnumerator IEnumerable.GetEnumerator()
@@ -402,11 +391,12 @@ public sealed class Shares<TNumber> : ICollection<Share<TNumber>>, ICollection, 
     }
 
     /// <summary>
-    /// Returns an <see cref="SharesEnumerator{TNumber}"/> that iterates through the <see cref="Shares{TNumber}"/> collection.
+    /// Returns an <see cref="IEnumerator{T}"/> of <see cref="Share{TNumber}"/> that iterates through the <see cref="Shares{TNumber}"/> collection.
     /// </summary>
-    /// <returns>An <see cref="SharesEnumerator{TNumber}"/> that can be used to iterate through the <see cref="Shares{TNumber}"/> collection.</returns>
+    /// <returns>An <see cref="IEnumerator{T}"/> of <see cref="Share{TNumber}"/> that can be used to iterate through the <see cref="Shares{TNumber}"/> collection.</returns>
+    /// <remarks>This method also provides the <see cref="IEnumerable{T}"/> implementation of <see cref="Share{TNumber}"/> for the collection.</remarks>
     /// <exception cref="ObjectDisposedException">Thrown when the collection has been disposed.</exception>
-    public SharesEnumerator<TNumber> GetEnumerator()
+    public IEnumerator<Share<TNumber>> GetEnumerator()
     {
         this.ThrowIfDisposed();
         return new SharesEnumerator<TNumber>(this.shareList);

--- a/src/Cryptography/SharesEnumerator.cs
+++ b/src/Cryptography/SharesEnumerator.cs
@@ -41,7 +41,7 @@ using System.Collections.ObjectModel;
 /// </summary>
 /// <typeparam name="TNumber">The type of integer that is used by the <see cref="Share{TNumber}"/> items of the
 /// <see cref="Shares{TNumber}"/> collection.</typeparam>
-public sealed class SharesEnumerator<TNumber> : IEnumerator<Share<TNumber>>
+internal sealed class SharesEnumerator<TNumber> : IEnumerator<Share<TNumber>>
 {
     /// <summary>
     /// Saves a list of <see cref="Share{TNumber}"/>.
@@ -58,7 +58,7 @@ public sealed class SharesEnumerator<TNumber> : IEnumerator<Share<TNumber>>
     /// </summary>
     /// <param name="shares">A collection of <see cref="Share{TNumber}"/> items representing the shares.</param>
     /// <exception cref="T:System.ArgumentNullException"><paramref name="shares"/> is <see langword="null"/></exception>
-    public SharesEnumerator(Collection<Share<TNumber>> shares)
+    internal SharesEnumerator(Collection<Share<TNumber>> shares)
     {
         _ = shares ?? throw new ArgumentNullException(nameof(shares));
         this.shareList = new ReadOnlyCollection<Share<TNumber>>(shares);


### PR DESCRIPTION
## What
Removes `SharesEnumerator<TNumber>` from the public API surface (A6 / T3). The type and its constructor become `internal`, and `Shares<TNumber>.GetEnumerator()` is narrowed to return `IEnumerator<Share<TNumber>>`.

## Why
`SharesEnumerator<TNumber>` was public but has no standalone use case — it is only produced by `Shares<TNumber>.GetEnumerator()`. As a sealed *class* (not a struct) it provides none of the stack-allocation / non-virtual-call benefit that justifies the BCL public-enumerator pattern, so exposing it publicly only froze an implementation detail into the v1.0 surface. The earlier rationale for keeping it public (a public `Shares(Collection<Share<TNumber>>)` constructor) no longer holds — that constructor has been `internal` since the share-ownership fix.

## Change
- `SharesEnumerator<TNumber>` and its constructor are now `internal`.
- `Shares<TNumber>.GetEnumerator()` returns `IEnumerator<Share<TNumber>>` (a public method may not return a less-accessible type). The public method now implicitly implements `IEnumerable<Share<TNumber>>.GetEnumerator()`, so the redundant explicit generic implementation is dropped; the explicit non-generic `IEnumerable.GetEnumerator()` is unchanged.
- CHANGELOG: `### Changed` (return-type narrowing) and `### Removed` (type no longer public).

## Compatibility
Breaking only for code that named the concrete type (`SharesEnumerator<TNumber> e = shares.GetEnumerator();`) or constructed it directly via `new SharesEnumerator<TNumber>(...)`. `foreach` and LINQ over a `Shares<TNumber>` are unaffected. Landed in the pre-GA window where the public surface is not yet frozen.

## Verification
- Build: 8 src TFMs + 6 test TFMs (Release) — 0 errors (only pre-existing SourceLink and CS0419 warnings).
- Tests: 6 TFMs, single-threaded — all green (1706 on net8.0/net9.0/net10.0, 1692 on net4x, 0 failed).
- Security-neutral: the disposal cascade, the borrowed-enumerator no-op `Dispose`, sort order, and the `ObjectDisposedException` guard on all three `GetEnumerator` paths are unchanged.
