### PR TITLE
ci: restrict publishing to well-formed SemVer tags

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -2,8 +2,20 @@ name: SecretSharingDotNet - NuGet Publishing
 
 on:
   push:
+    # Only well-formed SemVer release tags publish: vMAJOR.MINOR.PATCH plus an
+    # optional pre-release suffix (v1.0.1, v1.0.2-rc01, v2.0.0-beta1). Filter
+    # glob semantics: `+` = one-or-more of the preceding character, the class
+    # after '-' demands at least one alphanumeric character (so a bare
+    # 'v1.0.1-' stays out), and a pattern must match the whole tag name. The
+    # suffix is otherwise deliberately open -- a stricter -rc[0-9]+ would
+    # silently skip a future -beta tag. Near-misses a glob cannot reject
+    # (v01.0.1, v1.0.1-rc.) still start a run and die red in the
+    # version-lockstep check below. Trade-off: a malformed tag (v1.0, vNext)
+    # no longer starts a run at all, where the old catch-all 'v*' at least
+    # died red in that check.
     tags:
-    - 'v*'
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+-[0-9A-Za-z]*'
 
 # Keep a tag from racing itself: a re-pushed tag or a re-run queues behind the run
 # already publishing that version instead of pushing it twice at once. Never cancel in

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -5,17 +5,18 @@ on:
     # Only well-formed SemVer release tags publish: vMAJOR.MINOR.PATCH plus an
     # optional pre-release suffix (v1.0.1, v1.0.2-rc01, v2.0.0-beta1). Filter
     # glob semantics: `+` = one-or-more of the preceding character, the class
-    # after '-' demands at least one alphanumeric character (so a bare
-    # 'v1.0.1-' stays out), and a pattern must match the whole tag name. The
-    # suffix is otherwise deliberately open -- a stricter -rc[0-9]+ would
-    # silently skip a future -beta tag. Near-misses a glob cannot reject
+    # after '-' demands at least one identifier character -- alphanumeric or
+    # hyphen, since SemVer identifiers may start with '-' (v1.2.3--canary) --
+    # so a bare 'v1.0.1-' stays out, and a pattern must match the whole tag
+    # name. The suffix is otherwise deliberately open -- a stricter -rc[0-9]+
+    # would silently skip a future -beta tag. Near-misses a glob cannot reject
     # (v01.0.1, v1.0.1-rc.) still start a run and die red in the
     # version-lockstep check below. Trade-off: a malformed tag (v1.0, vNext)
     # no longer starts a run at all, where the old catch-all 'v*' at least
     # died red in that check.
     tags:
     - 'v[0-9]+.[0-9]+.[0-9]+'
-    - 'v[0-9]+.[0-9]+.[0-9]+-[0-9A-Za-z]*'
+    - 'v[0-9]+.[0-9]+.[0-9]+-[0-9A-Za-z-]*'
 
 # Keep a tag from racing itself: a re-pushed tag or a re-run queues behind the run
 # already publishing that version instead of pushing it twice at once. Never cancel in


### PR DESCRIPTION
## Problem

`publishing.yml` triggers on the catch-all `v*`, so any v-prefixed tag (`v1.0`, `vNext`, `v1.0.1rc1`) starts a publishing run and relies on the version-lockstep check (#361) to kill it red.

## Fix

Trigger only on well-formed SemVer tags — `vMAJOR.MINOR.PATCH` plus an optional pre-release suffix:

```yaml
tags:
- 'v[0-9]+.[0-9]+.[0-9]+'
- 'v[0-9]+.[0-9]+.[0-9]+-[0-9A-Za-z-]*'
```

Filter glob semantics (per the [filter pattern cheat sheet](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet), whose own example is `v[12].[0-9]+.[0-9]+`): `+` means one-or-more of the preceding character, character classes may combine `0-9`/`a-z`/`A-Z` ranges, and a pattern must match the whole tag name.

Design decisions:

- **v-prefix required.** All 21 historical tags are v-prefixed; the lockstep check and PackageReleaseNotes convention build on it.
- **Pre-release suffix open beyond the first character.** A stricter `-rc[0-9]+` would silently skip a future `v2.0.0-beta1` — the silent-non-publish trap class. The class after `-` demands at least one identifier character — alphanumeric or hyphen, since SemVer identifiers may start with `-` (`v1.2.3--canary`; Codex review finding) — so a degenerate `v1.0.1-` does not trigger.
- **Near-misses a glob cannot reject** (`v01.0.1` leading zero, `v1.0.1-rc.` empty identifier) still start a run and die red in the lockstep check — the filter is a coarse gate, the check remains the authoritative guard.

Trade-off, accepted deliberately: a malformed tag (`v1.0`, `vNext`) no longer starts a run at all, where the old `v*` at least died red in the lockstep check.

## Verification

`publishing.yml` never runs in PR checks — validated locally (YAML parse, pattern review against the documented glob semantics). The filter is first exercised for real on the next `v*` release tag, which already carries the first-exercise duties for the `test-windows` gate and the OIDC login.
