### PR TITLE
ci: gate releases on an exact SemVer tag check

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -2,21 +2,19 @@ name: SecretSharingDotNet - NuGet Publishing
 
 on:
   push:
-    # Only well-formed SemVer release tags publish: vMAJOR.MINOR.PATCH plus an
-    # optional pre-release suffix (v1.0.1, v1.0.2-rc01, v2.0.0-beta1). Filter
-    # glob semantics: `+` = one-or-more of the preceding character, the class
-    # after '-' demands at least one identifier character -- alphanumeric or
-    # hyphen, since SemVer identifiers may start with '-' (v1.2.3--canary) --
-    # so a bare 'v1.0.1-' stays out, and a pattern must match the whole tag
-    # name. The suffix is otherwise deliberately open -- a stricter -rc[0-9]+
-    # would silently skip a future -beta tag. Near-misses a glob cannot reject
-    # (v01.0.1, v1.0.1-rc.) still start a run and die red in the
-    # version-lockstep check below. Trade-off: a malformed tag (v1.0, vNext)
-    # no longer starts a run at all, where the old catch-all 'v*' at least
-    # died red in that check.
+    # Coarse gate: only tags shaped like a SemVer release (vMAJOR.MINOR.PATCH
+    # with anything after) start a run; v1, v1.0, or vNext never do. In this
+    # filter `+` means one-or-more of the preceding character and the pattern
+    # must match the whole tag name. Exact SemVer validation deliberately does
+    # NOT live here, because GitHub's filter globs cannot express it: a
+    # literal '-' inside a character class is impossible in any spelling
+    # (trailing, leading, or escaped -- each renders the whole workflow file
+    # invalid, surfacing as jobless startup-failure runs on every push), and
+    # near-misses like v01.0.1 or v1.0.1-rc. pass any glob. The authoritative
+    # check is the "Require a SemVer release tag" step below, which fails
+    # loud instead of silently skipping the release.
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+'
-    - 'v[0-9]+.[0-9]+.[0-9]+-[0-9A-Za-z-]*'
+    - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 # Keep a tag from racing itself: a re-pushed tag or a re-run queues behind the run
 # already publishing that version instead of pushing it twice at once. Never cancel in
@@ -48,6 +46,21 @@ jobs:
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
+    # The trigger glob above only gates coarsely; this is the exact SemVer
+    # check (official semver.org grammar as ERE; build metadata '+' rejected
+    # on purpose -- NuGet versions cannot carry it). Runs before checkout so
+    # a malformed tag fails within seconds. shell: bash resolves to Git for
+    # Windows' bash on the hosted Windows image.
+    - name: Require a SemVer release tag
+      shell: bash
+      run: |
+        semver_ere='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?$'
+        if [[ ! "$GITHUB_REF_NAME" =~ $semver_ere ]]; then
+          echo "::error::Tag ${GITHUB_REF_NAME} is not a well-formed SemVer release tag (vMAJOR.MINOR.PATCH plus optional -prerelease); refusing to publish."
+          exit 1
+        fi
+        echo "Tag ${GITHUB_REF_NAME} is a well-formed SemVer release tag."
+
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup .NET SDKs


### PR DESCRIPTION
## Problem — develop is release-broken

The `[0-9A-Za-z-]` character class introduced in #380 (96ac897, accepted from a Codex finding) is **invalid to GitHub's workflow parser**: since the merge, every push of any ref carrying the file surfaces a jobless startup-failure run named `.github/workflows/publishing.yml` (seen on the develop merge push and on rebased Dependabot branches), and the next `v*` release tag would fail the same way instead of publishing.

Probe pushes (throwaway branch, one candidate workflow file each) established the parser rules empirically:

| Class spelling | Parser verdict |
|---|---|
| `[0-9A-Za-z-]` (trailing) | ❌ invalid |
| `[0-9A-Za-z\-]` (escaped) | ❌ invalid |
| `[-0-9A-Za-z]` (leading) | ❌ invalid |
| `-*[0-9A-Za-z]` (no literal `-` in class) | ✅ valid |

So a literal `-` inside a filter character class is impossible in any spelling. Note: **actionlint 1.7.7 accepts the invalid class** — local linting cannot catch this defect; only a real push exercises GitHub's parser.

## Fix — stop approximating SemVer in the trigger

Filter globs can't validate SemVer anyway (`v01.0.1`, `v1.0.1-rc.` pass any glob). The trigger keeps a single coarse shape gate, and a new first step of `test-windows` performs the exact check against the official semver.org grammar:

```yaml
tags:
- 'v[0-9]+.[0-9]+.[0-9]+*'
```

```yaml
- name: Require a SemVer release tag
  shell: bash
  run: |
    semver_ere='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?$'
    if [[ ! "$GITHUB_REF_NAME" =~ $semver_ere ]]; then
      echo "::error::Tag ${GITHUB_REF_NAME} is not a well-formed SemVer release tag (vMAJOR.MINOR.PATCH plus optional -prerelease); refusing to publish."
      exit 1
    fi
```

Behavior:

- Junk tags (`v1`, `v1.0`, `vNext`) never start a run.
- Near-SemVer tags (`v1.0.1-`, `v01.0.1`, `v1.0.1-rc.`) start a run and **fail loud within seconds** with a precise error — before checkout, before any test minute is spent, and before the `build` job (gated via `needs`) can touch the signing key.
- All valid SemVer prereleases publish, including hyphen-leading identifiers (`v1.2.3--canary`) from the #380 Codex finding.
- Build metadata (`v1.2.3+build`) is rejected on purpose: NuGet versions cannot carry `+`.

## Verification

- Live probe on `windows-2025`: `shell: bash` resolves to Git for Windows' bash 5.3.15, and the ERE accepted/rejected all 12 sample tags as intended (6 valid including `--canary`/`-x-`/`--`, 6 invalid including `v1.0.1-`/`v01.0.1`/`v1.0.1-rc.`).
- The push of this branch itself is the parser probe for the new trigger line: it produced **no** jobless startup-failure run (the broken develop state produces one on every push).
- `actionlint` + YAML parse clean; `publishing.yml` never runs in PR checks, so the gate step is first exercised for real on the next release tag.
