### PR TITLE
chore: prepare v1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.1] - 2026-08-24
 
 ### Added
 - Added a domain exception hierarchy rooted at `SecretSharingException` (derives from `Exception`): `InvalidShareException` for a malformed share and `ReconstructionException` for a set of individually valid shares that cannot be reconstructed. Catching `SecretSharingException` handles any Shamir-domain failure uniformly.
@@ -348,7 +348,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LICENSE.md`
 - Added `README.md`
 
-[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc02...develop
+[1.0.1]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc02...v1.0.1
 [1.0.1-rc02]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc01...v1.0.1-rc02
 [1.0.1-rc01]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.14.0...v1.0.1-rc01
 [0.14.0]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.13.0...v0.14.0

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ A C# implementation of Shamir's Secret Sharing.
   <tbody>
       <tr>
           <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml" target="_blank"><img src="https://github.com/shinji-san/SecretSharingDotNet/actions/workflows/publishing.yml/badge.svg" alt="SecretSharingDotNet - NuGet Publishing"/></a></td>
-          <td rowspan=8><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 1.0.1-rc02"/></a></td>
-          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v1.0.1-rc02" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-1.0.1--rc02-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
+          <td rowspan=8><a href="https://badge.fury.io/nu/SecretSharingDotNet" target="_blank"><img src="https://badge.fury.io/nu/SecretSharingDotNet.svg" alt="NuGet Version 1.0.1"/></a></td>
+          <td rowspan=8><a href="https://github.com/shinji-san/SecretSharingDotNet/tree/v1.0.1" target="_blank"><img src="https://img.shields.io/badge/SecretSharingDotNet-1.0.1-green.svg?logo=github&logoColor=959da5&color=2ebb4e&labelColor=2b3137" alt="Tag"/></a></td>
           <td>Standard 2.0</td>
       </tr>
       <tr>
@@ -88,10 +88,10 @@ A C# implementation of Shamir's Secret Sharing.
 
 1. Open a console and switch to the directory containing your project file.
 
-2. Use the following command to install version 1.0.1-rc02 of the SecretSharingDotNet package:
+2. Use the following command to install version 1.0.1 of the SecretSharingDotNet package:
 
     ```dotnetcli
-    dotnet add package SecretSharingDotNet -v 1.0.1-rc02 -f <FRAMEWORK>
+    dotnet add package SecretSharingDotNet -v 1.0.1 -f <FRAMEWORK>
     ```
 
 3. After the completion of the command, look at the project file to make sure that the package is successfully installed.
@@ -100,7 +100,7 @@ A C# implementation of Shamir's Secret Sharing.
 
     ```xml
     <ItemGroup>
-      <PackageReference Include="SecretSharingDotNet" Version="1.0.1-rc02" />
+      <PackageReference Include="SecretSharingDotNet" Version="1.0.1" />
     </ItemGroup>
     ```
 ## Remove SecretSharingDotNet package 📤
@@ -119,7 +119,7 @@ A C# implementation of Shamir's Secret Sharing.
 
 # Usage 🔧
 > [!IMPORTANT]
-> Breaking changes in v1.0.1-rc02 (major version bump from v0.14.0). Highlights for migrating consumers — see [`CHANGELOG.md`](./CHANGELOG.md) for the full list.
+> Breaking changes in v1.0.1 (major version bump from v0.14.0). Highlights for migrating consumers — see [`CHANGELOG.md`](./CHANGELOG.md) for the full list.
 >
 > - **Text I/O is pinned-buffer-only.** The `string`-based entry points are gone. Wrap a `string` in `.ToPinnedSecure()` and use the pinned factories: `Secret<TNumber>.FromText(PinnedPoolArray<char>)`, `new Share<TNumber>(PinnedPoolArray<char>)`, `Shares<TNumber>.FromText(...)`, `Shares<TNumber>.FromTextLines(...)`. Read back via the matching `ToCharArray()` methods on `Secret`, `Share`, and `Shares`.
 > - **`Reconstruction(string)` and `Reconstruction(string[])` removed.** Build a `Shares<TNumber>` through one of the pinned factories above and pass that.

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -18,7 +18,7 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("1.0.1")]
 [assembly: AssemblyFileVersion("1.0.1")]
-[assembly: AssemblyInformationalVersion("1.0.1-rc02")]
+[assembly: AssemblyInformationalVersion("1.0.1")]
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: System.CLSCompliant(true)]

--- a/src/SecretSharingDotNet.csproj
+++ b/src/SecretSharingDotNet.csproj
@@ -11,14 +11,14 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <PackageId>SecretSharingDotNet</PackageId>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v1.0.1-rc02/CHANGELOG.md</PackageReleaseNotes>
+        <PackageReleaseNotes>Changelog: https://github.com/shinji-san/SecretSharingDotNet/blob/v1.0.1/CHANGELOG.md</PackageReleaseNotes>
         <PackageDescription>An C# implementation of Shamir's Secret Sharing</PackageDescription>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>secret sharing;shamir secret sharing;cryptography</PackageTags>
         <PackageProjectUrl>https://github.com/shinji-san/SecretSharingDotNet</PackageProjectUrl>
         <RepositoryUrl>https://github.com/shinji-san/SecretSharingDotNet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Version>1.0.1-rc02</Version>
+        <Version>1.0.1</Version>
         <Authors>Sebastian Walther</Authors>
         <Company>Private Person</Company>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## chore: prepare v1.0.1 release — develop sync

Companion to the **Release v1.0.1** PR into `main` (#391). Merges the same `chore-prepare-v1.0.1-release` branch into `develop` so the version bump (`1.0.1-rc02` → `1.0.1`) is reflected there too.

The delta versus `develop` is the single version-bump commit — no source changes.

### Follow-up (separate PR, not included here)
After both PRs are merged, re-add an empty `## [Unreleased]` section at the top of `CHANGELOG.md` (with a `compare/v1.0.1...develop` link) so future `develop` entries have a landing spot.
