### PR TITLE
chore: re-add empty [Unreleased] section to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.0.1] - 2026-08-24
 
 ### Added
@@ -348,6 +350,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LICENSE.md`
 - Added `README.md`
 
+[Unreleased]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1...develop
 [1.0.1]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc02...v1.0.1
 [1.0.1-rc02]: https://github.com/shinji-san/SecretSharingDotNet/compare/v1.0.1-rc01...v1.0.1-rc02
 [1.0.1-rc01]: https://github.com/shinji-san/SecretSharingDotNet/compare/v0.14.0...v1.0.1-rc01


### PR DESCRIPTION
Restores an empty `## [Unreleased]` section at the top of `CHANGELOG.md` after the **v1.0.1** release, with a `compare/v1.0.1...develop` link, so future `develop` changes have a landing spot (per Keep a Changelog).

Follow-up to the v1.0.1 release cut (#391 / #392). CHANGELOG-only, no code changes.
