### PR TITLE
test: cover reconstruction when the security level refits downward

### DIFF
--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingTest.cs
@@ -396,4 +396,90 @@ public class ShamirsSecretSharingTest
         // Assert
         Assert.Equal(1.0, (double)ok / total);
     }
+
+    /// <summary>
+    /// Deterministic Tier-1 regression for the reconstruction path on which
+    /// <see cref="SecurityLevelManager{TNumber}.AdjustSecurityLevel"/> refits the level to a
+    /// <em>smaller</em> Mersenne prime than the one the secret was split with. A share carries no
+    /// record of the splitting modulus, so <see cref="IReconstructionUseCase{TNumber}.Reconstruction"/>
+    /// derives the level from the maximum share value alone; whenever every share value happens to
+    /// fall below a smaller prime, interpolation runs in that smaller field. Reconstruction must
+    /// still return the original secret, because the integer Lagrange combination is bounded by the
+    /// small share values and therefore pinned to the constant term exactly, which makes the
+    /// reduction modulo the smaller prime a no-op. The seeds are pinned because reaching this path
+    /// is a low-probability event a Monte Carlo run may miss entirely.
+    /// Mirror of the SecureBigInteger-side theory of the same name.
+    /// </summary>
+    /// <param name="seed">Seed driving both the secret's mark byte and the polynomial coefficients.</param>
+    /// <param name="securityLevel">Mersenne exponent the secret is split with.</param>
+    /// <param name="expectedAdjustedLevel">Smaller exponent the reconstruction is expected to refit to.</param>
+    [Theory]
+    [InlineData(28, 17, 13)]
+    [InlineData(45, 17, 13)]
+    [InlineData(62, 17, 13)]
+    [InlineData(15, 19, 17)]
+    [InlineData(42, 19, 17)]
+    [InlineData(152, 31, 19)]
+    public void ReconstructionRoundTrip_WhenSecurityLevelRefitsToSmallerPrime_RestoresOriginal(
+        int seed, int securityLevel, int expectedAdjustedLevel)
+    {
+        // Arrange
+        using var secret = new Secret<BigInteger>([0x2A], 1, new DeterministicRandomSource(seed));
+        using var secretSplitter = new SecretSplitter<BigInteger>(new DeterministicRandomSource(seed));
+        secretSplitter.SecurityLevel = securityLevel;
+        using var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+
+        // Act
+        using var shares = secretSplitter.MakeShares(2, 2, secret);
+        using var reconstructedSecret = secretReconstructor.Reconstruction(shares);
+
+        // Assert
+        Assert.Equal(securityLevel, secretSplitter.SecurityLevel);
+        Assert.Equal(expectedAdjustedLevel, secretReconstructor.SecurityLevel);
+        Assert.Equal(secret, reconstructedSecret);
+    }
+
+    /// <summary>
+    /// Tier-2 sweep for the same concern: across a range of security levels and share
+    /// configurations, a split followed by a reconstruction always restores the original secret —
+    /// whether or not the level is refitted downward on the way back. Tier-1 above pins the refit
+    /// path deterministically; this theory covers breadth, so a regression that only shows up at a
+    /// level or share shape not enumerated above still turns the suite red.
+    /// Mirror of the SecureBigInteger-side theory of the same name.
+    /// </summary>
+    /// <param name="securityLevel">Mersenne exponent the secrets are split with.</param>
+    /// <param name="k">Reconstruction threshold.</param>
+    /// <param name="n">Number of shares created.</param>
+    [Theory]
+    [InlineData(13, 2, 2)]
+    [InlineData(17, 2, 2)]
+    [InlineData(19, 2, 3)]
+    [InlineData(31, 3, 5)]
+    public void ReconstructionRoundTrip_AcrossSecurityLevels_AlwaysRestoresOriginal(int securityLevel, int k, int n)
+    {
+        // Arrange
+        const int total = 1000;
+        int ok = 0;
+        var rng = new Random(securityLevel);
+        using var secretReconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+
+        // Act
+        for (int i = 0; i < total; i++)
+        {
+            var message = new byte[rng.Next(1, 5)];
+            rng.NextBytes(message);
+            using var secret = new Secret<BigInteger>(message);
+            using var secretSplitter = new SecretSplitter<BigInteger>();
+            secretSplitter.SecurityLevel = securityLevel;
+            using var shares = secretSplitter.MakeShares(k, n, secret);
+            using var reconstructedSecret = secretReconstructor.Reconstruction(shares);
+            if (secret.Equals(reconstructedSecret))
+            {
+                ok++;
+            }
+        }
+
+        // Assert
+        Assert.Equal(total, ok);
+    }
 }

--- a/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/BigInteger/ShamirsSecretSharingTest.cs
@@ -403,11 +403,14 @@ public class ShamirsSecretSharingTest
     /// <em>smaller</em> Mersenne prime than the one the secret was split with. A share carries no
     /// record of the splitting modulus, so <see cref="IReconstructionUseCase{TNumber}.Reconstruction"/>
     /// derives the level from the maximum share value alone; whenever every share value happens to
-    /// fall below a smaller prime, interpolation runs in that smaller field. Reconstruction must
-    /// still return the original secret, because the integer Lagrange combination is bounded by the
-    /// small share values and therefore pinned to the constant term exactly, which makes the
-    /// reduction modulo the smaller prime a no-op. The seeds are pinned because reaching this path
-    /// is a low-probability event a Monte Carlo run may miss entirely.
+    /// fall below a smaller prime, interpolation runs in that smaller field. The integer Lagrange
+    /// combination is bounded by the small share values and pinned to the constant term exactly,
+    /// so the reduction modulo the smaller prime is a no-op <em>as long as the constant term is
+    /// itself below that prime</em> — which is the case for the vectors below, and is why they
+    /// round-trip. It does <b>not</b> hold in general: see
+    /// <c>Reconstruction_WhenConstantTermReachesTheRefittedPrime_LosesTheSecret</c> for the
+    /// boundary where it fails. The seeds are pinned because reaching this path at all is a
+    /// low-probability event a Monte Carlo run may miss entirely.
     /// Mirror of the SecureBigInteger-side theory of the same name.
     /// </summary>
     /// <param name="seed">Seed driving both the secret's mark byte and the polynomial coefficients.</param>
@@ -481,5 +484,57 @@ public class ShamirsSecretSharingTest
 
         // Assert
         Assert.Equal(total, ok);
+    }
+
+    /// <summary>
+    /// Boundary case for the downward security-level refit, and a characterisation of a known
+    /// defect rather than of intended behaviour. Reconstruction derives the level from the maximum
+    /// share value, which cannot reveal whether the constant term exceeded the smaller prime. When
+    /// it did, interpolation in the refitted field returns <c>a₀ mod P_small</c> instead of
+    /// <c>a₀</c>, and the shares are untampered and individually valid throughout.
+    /// <para>
+    /// Seed 12 encodes the one-byte secret <c>0xFF</c> with mark byte <c>0x1F</c>, giving the
+    /// coefficient 8191 — exactly <c>M13</c>. Splitter seed 171 at level 17 yields the shares
+    /// 7476 and 6761, both below 8191, so the level refits to 13. The integer combination
+    /// <c>2·7476 − 6761</c> is 8191, and 8191 mod 8191 is zero, which decodes to an empty secret
+    /// and throws.
+    /// </para>
+    /// <para>
+    /// The silent variant needs a coefficient strictly between the refitted prime and twice it,
+    /// which a one-byte secret cannot reach: seed 16 encodes <c>0xFF 0xFF</c> as 786431, and at
+    /// level 31 splitter seed 3544 yields 504116 and 221801, both below <c>M19</c>. Reconstruction
+    /// refits to 19 and returns 786431 mod 524287 = 262144 — a different secret, with no exception.
+    /// </para>
+    /// <para>
+    /// <b>These assertions pin current behaviour, not desired behaviour.</b> When the refit is
+    /// fixed, both cases must round-trip and this test has to be inverted.
+    /// </para>
+    /// Mirror of the SecureBigInteger-side fact of the same name.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_WhenConstantTermReachesTheRefittedPrime_LosesTheSecret()
+    {
+        // Arrange — coefficient exactly M13; every share below it.
+        using var secretAtPrime = new Secret<BigInteger>(new byte[] { 0xFF }, 1, new DeterministicRandomSource(12));
+        using var splitterAtPrime = new SecretSplitter<BigInteger>(new DeterministicRandomSource(171));
+        splitterAtPrime.SecurityLevel = 17;
+        using var reconstructor = new SecretReconstructor<BigInteger>(new ExtendedEuclideanAlgorithm<BigInteger>());
+
+        // Act & Assert — the refitted field maps the coefficient to zero, so no secret survives.
+        using var sharesAtPrime = splitterAtPrime.MakeShares(2, 2, secretAtPrime);
+        Assert.Throws<ArgumentException>(() => reconstructor.Reconstruction(sharesAtPrime));
+
+        // Arrange — coefficient above the refitted prime but below twice it.
+        using var secretAbovePrime = new Secret<BigInteger>(new byte[] { 0xFF, 0xFF }, 2, new DeterministicRandomSource(16));
+        using var splitterAbovePrime = new SecretSplitter<BigInteger>(new DeterministicRandomSource(3544));
+        splitterAbovePrime.SecurityLevel = 31;
+
+        // Act
+        using var sharesAbovePrime = splitterAbovePrime.MakeShares(2, 2, secretAbovePrime);
+        using var reconstructed = reconstructor.Reconstruction(sharesAbovePrime);
+
+        // Assert — reconstruction succeeds and returns the wrong secret.
+        Assert.Equal(19, reconstructor.SecurityLevel);
+        Assert.NotEqual(secretAbovePrime, reconstructed);
     }
 }

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingTest.cs
@@ -411,4 +411,96 @@ public class ShamirsSecretSharingTest
         // Assert
         Assert.Equal(1.0, (double)ok / total);
     }
+
+    /// <summary>
+    /// Deterministic Tier-1 regression for the reconstruction path on which
+    /// <see cref="SecurityLevelManager{TNumber}.AdjustSecurityLevel"/> refits the level to a
+    /// <em>smaller</em> Mersenne prime than the one the secret was split with. A share carries no
+    /// record of the splitting modulus, so <see cref="IReconstructionUseCase{TNumber}.Reconstruction"/>
+    /// derives the level from the maximum share value alone; whenever every share value happens to
+    /// fall below a smaller prime, interpolation runs in that smaller field. Reconstruction must
+    /// still return the original secret, because the integer Lagrange combination is bounded by the
+    /// small share values and therefore pinned to the constant term exactly, which makes the
+    /// reduction modulo the smaller prime a no-op. The seeds are pinned because reaching this path
+    /// is a low-probability event a Monte Carlo run may miss entirely.
+    /// Mirror of the BigInteger-side theory of the same name.
+    /// </summary>
+    /// <param name="seed">Seed driving both the secret's mark byte and the polynomial coefficients.</param>
+    /// <param name="securityLevel">Mersenne exponent the secret is split with.</param>
+    /// <param name="expectedAdjustedLevel">Smaller exponent the reconstruction is expected to refit to.</param>
+    [Theory]
+    [InlineData(28, 17, 13)]
+    [InlineData(45, 17, 13)]
+    [InlineData(62, 17, 13)]
+    [InlineData(15, 19, 17)]
+    [InlineData(42, 19, 17)]
+    [InlineData(152, 31, 19)]
+    public void ReconstructionRoundTrip_WhenSecurityLevelRefitsToSmallerPrime_RestoresOriginal(
+        int seed, int securityLevel, int expectedAdjustedLevel)
+    {
+        // Arrange
+        using var secret = new Secret<SecureBigInteger>([0x2A], 1, new DeterministicRandomSource(seed));
+        using var secretSplitter = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(seed));
+        secretSplitter.SecurityLevel = securityLevel;
+        using var secretReconstructor = new SecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>());
+
+        // Act
+        using var shares = secretSplitter.MakeShares(2, 2, secret);
+        using var reconstructedSecret = secretReconstructor.Reconstruction(shares);
+
+        // Assert
+        Assert.Equal(securityLevel, secretSplitter.SecurityLevel);
+        Assert.Equal(expectedAdjustedLevel, secretReconstructor.SecurityLevel);
+        Assert.Equal(secret, reconstructedSecret);
+    }
+
+    /// <summary>
+    /// Tier-2 sweep for the same concern: across a range of security levels and share
+    /// configurations, a split followed by a reconstruction always restores the original secret —
+    /// whether or not the level is refitted downward on the way back. Tier-1 above pins the refit
+    /// path deterministically; this theory covers breadth, so a regression that only shows up at a
+    /// level or share shape not enumerated above still turns the suite red.
+    /// The loop runs 20 iterations per case rather than the 1000 on the BigInteger backend: the
+    /// SecureBigInteger arithmetic and the constant-time Bernstein-Yang divsteps in
+    /// <c>MersenneSafeGcdAlgorithm</c> are deliberately slower than the value-type backend, so the
+    /// budget is scaled to keep the runtime tolerable. The refit path itself is covered with
+    /// probability 1 by the pinned Tier-1 vectors above, which makes this loop defense-in-depth
+    /// rather than the primary guard.
+    /// Mirror of the BigInteger-side theory of the same name.
+    /// </summary>
+    /// <param name="securityLevel">Mersenne exponent the secrets are split with.</param>
+    /// <param name="k">Reconstruction threshold.</param>
+    /// <param name="n">Number of shares created.</param>
+    [Theory]
+    [InlineData(13, 2, 2)]
+    [InlineData(17, 2, 2)]
+    [InlineData(19, 2, 3)]
+    [InlineData(31, 3, 5)]
+    public void ReconstructionRoundTrip_AcrossSecurityLevels_AlwaysRestoresOriginal(int securityLevel, int k, int n)
+    {
+        // Arrange
+        const int total = 20;
+        int ok = 0;
+        var rng = new Random(securityLevel);
+        using var secretReconstructor = new SecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>());
+
+        // Act
+        for (int i = 0; i < total; i++)
+        {
+            var message = new byte[rng.Next(1, 5)];
+            rng.NextBytes(message);
+            using var secret = new Secret<SecureBigInteger>(message);
+            using var secretSplitter = new SecretSplitter<SecureBigInteger>();
+            secretSplitter.SecurityLevel = securityLevel;
+            using var shares = secretSplitter.MakeShares(k, n, secret);
+            using var reconstructedSecret = secretReconstructor.Reconstruction(shares);
+            if (secret.Equals(reconstructedSecret))
+            {
+                ok++;
+            }
+        }
+
+        // Assert
+        Assert.Equal(total, ok);
+    }
 }

--- a/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingTest.cs
+++ b/tests/Cryptography/ShamirsSecretSharing/SecureBigInteger/ShamirsSecretSharingTest.cs
@@ -418,11 +418,14 @@ public class ShamirsSecretSharingTest
     /// <em>smaller</em> Mersenne prime than the one the secret was split with. A share carries no
     /// record of the splitting modulus, so <see cref="IReconstructionUseCase{TNumber}.Reconstruction"/>
     /// derives the level from the maximum share value alone; whenever every share value happens to
-    /// fall below a smaller prime, interpolation runs in that smaller field. Reconstruction must
-    /// still return the original secret, because the integer Lagrange combination is bounded by the
-    /// small share values and therefore pinned to the constant term exactly, which makes the
-    /// reduction modulo the smaller prime a no-op. The seeds are pinned because reaching this path
-    /// is a low-probability event a Monte Carlo run may miss entirely.
+    /// fall below a smaller prime, interpolation runs in that smaller field. The integer Lagrange
+    /// combination is bounded by the small share values and pinned to the constant term exactly,
+    /// so the reduction modulo the smaller prime is a no-op <em>as long as the constant term is
+    /// itself below that prime</em> — which is the case for the vectors below, and is why they
+    /// round-trip. It does <b>not</b> hold in general: see
+    /// <c>Reconstruction_WhenConstantTermReachesTheRefittedPrime_LosesTheSecret</c> for the
+    /// boundary where it fails. The seeds are pinned because reaching this path at all is a
+    /// low-probability event a Monte Carlo run may miss entirely.
     /// Mirror of the BigInteger-side theory of the same name.
     /// </summary>
     /// <param name="seed">Seed driving both the secret's mark byte and the polynomial coefficients.</param>
@@ -502,5 +505,57 @@ public class ShamirsSecretSharingTest
 
         // Assert
         Assert.Equal(total, ok);
+    }
+
+    /// <summary>
+    /// Boundary case for the downward security-level refit, and a characterisation of a known
+    /// defect rather than of intended behaviour. Reconstruction derives the level from the maximum
+    /// share value, which cannot reveal whether the constant term exceeded the smaller prime. When
+    /// it did, interpolation in the refitted field returns <c>a₀ mod P_small</c> instead of
+    /// <c>a₀</c>, and the shares are untampered and individually valid throughout.
+    /// <para>
+    /// Seed 12 encodes the one-byte secret <c>0xFF</c> with mark byte <c>0x1F</c>, giving the
+    /// coefficient 8191 — exactly <c>M13</c>. Splitter seed 171 at level 17 yields the shares
+    /// 7476 and 6761, both below 8191, so the level refits to 13. The integer combination
+    /// <c>2·7476 − 6761</c> is 8191, and 8191 mod 8191 is zero, which decodes to an empty secret
+    /// and throws.
+    /// </para>
+    /// <para>
+    /// The silent variant needs a coefficient strictly between the refitted prime and twice it,
+    /// which a one-byte secret cannot reach: seed 16 encodes <c>0xFF 0xFF</c> as 786431, and at
+    /// level 31 splitter seed 3544 yields 504116 and 221801, both below <c>M19</c>. Reconstruction
+    /// refits to 19 and returns 786431 mod 524287 = 262144 — a different secret, with no exception.
+    /// </para>
+    /// <para>
+    /// <b>These assertions pin current behaviour, not desired behaviour.</b> When the refit is
+    /// fixed, both cases must round-trip and this test has to be inverted.
+    /// </para>
+    /// Mirror of the BigInteger-side fact of the same name.
+    /// </summary>
+    [Fact]
+    public void Reconstruction_WhenConstantTermReachesTheRefittedPrime_LosesTheSecret()
+    {
+        // Arrange — coefficient exactly M13; every share below it.
+        using var secretAtPrime = new Secret<SecureBigInteger>(new byte[] { 0xFF }, 1, new DeterministicRandomSource(12));
+        using var splitterAtPrime = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(171));
+        splitterAtPrime.SecurityLevel = 17;
+        using var reconstructor = new SecretReconstructor<SecureBigInteger>(new MersenneSafeGcdAlgorithm<SecureBigInteger>());
+
+        // Act & Assert — the refitted field maps the coefficient to zero, so no secret survives.
+        using var sharesAtPrime = splitterAtPrime.MakeShares(2, 2, secretAtPrime);
+        Assert.Throws<ArgumentException>(() => reconstructor.Reconstruction(sharesAtPrime));
+
+        // Arrange — coefficient above the refitted prime but below twice it.
+        using var secretAbovePrime = new Secret<SecureBigInteger>(new byte[] { 0xFF, 0xFF }, 2, new DeterministicRandomSource(16));
+        using var splitterAbovePrime = new SecretSplitter<SecureBigInteger>(new DeterministicRandomSource(3544));
+        splitterAbovePrime.SecurityLevel = 31;
+
+        // Act
+        using var sharesAbovePrime = splitterAbovePrime.MakeShares(2, 2, secretAbovePrime);
+        using var reconstructed = reconstructor.Reconstruction(sharesAbovePrime);
+
+        // Assert — reconstruction succeeds and returns the wrong secret.
+        Assert.Equal(19, reconstructor.SecurityLevel);
+        Assert.NotEqual(secretAbovePrime, reconstructed);
     }
 }


### PR DESCRIPTION
Covers a reconstruction path that no test reached — the one on which the security level is refitted *downward* on the way back — and pins the boundary at which that path loses the secret.

## The path

A share carries no record of the modulus it was split with. `Reconstruction` therefore derives the level from the maximum share value via `SecurityLevelManager.AdjustSecurityLevel`, which walks down to the smallest Mersenne prime still above that value. Whenever every share value happens to fall below a smaller prime, interpolation runs in a smaller field than the split did.

Usually that is harmless: the integer Lagrange combination is congruent to the constant term modulo the splitting prime, and while the constant term is itself below the smaller prime the reduction is a no-op. It is **not** harmless in general. Once the constant term reaches the refitted prime, interpolation returns `a₀ mod P_small` — either an empty secret and an exception, or a different secret and no exception at all. That defect is tracked as #403.

## What is added

**Tier-1, deterministic.** A theory driving both the secret's mark byte and the polynomial coefficients from a pinned seed through the existing `DeterministicRandomSource` seam, with six vectors spanning the 17→13, 19→17 and 31→19 refits. It asserts the adjusted level alongside the round trip, so the test cannot silently stop exercising the path it exists to guard. The same seeds reach the same refits on both backends, which makes the mirrored pair a genuine cross-backend agreement check rather than two independent tests.

**Two failure characterisations.** A fact pinning both severities of #403 deterministically: a constant term exactly at `M13`, which decodes to an empty secret and throws; and a constant term between `M19` and twice it, which returns a different secret with no exception. **These assertions pin current behaviour, not desired behaviour** — they are the inversion point for the fix.

**Tier-2, breadth.** A sweep over requested security levels and share shapes, at the same iteration ratio the existing Monte Carlo loop already uses between the two backends (1000 on `BigInteger`, 20 on `SecureBigInteger`). Every input is pinned — message, mark byte and coefficients alike — because the round trip is not universal today, so a loop drawing from `CryptoRandomSource` would assert a property that is false in general and go red at random. The theory also asserts which levels it actually exercises: `MakeShares` raises the level to fit the secret including its mark byte and never lowers it, so the requested level is a floor rather than the level used.

Both follow the tiered pattern already established in these files by the bug #60 regressions, and the `SecureBigInteger` side pairs `MersenneSafeGcdAlgorithm` as the rest of that file does.

## What a green run means

That today's documented behaviour is unchanged — the successful downward refits **and** the two failure vectors alike. It is not a statement that the scheme round-trips in general; #403 says it does not.

## Verification

Mutating a pinned vector or an expected level set turns the theory red, so the assertions carry weight. Full `net8.0` suite green at 1728/1728; all six test TFMs compile.

## Origin

Raised by review of #399. An automated reviewer claimed this path can return a different constant term; I declined it there on the strength of a 180,000-split sweep. The sweep never reached the boundary, because that needs the constant term to reach the refitted prime, which random secrets essentially never produce. The reviewer was right, the retraction is posted on #399, and the mechanism is now tracked as #403. These tests pin what the library does today, so the fix has something to invert.
