### PR TITLE
fix: guard CompareUnsigned against JIT reordering like its siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `SecureBigInteger.CompareUnsigned` now carries `MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization`, the guard every other branchless helper in that type already had (`FixedTimeLimbsEqual`, `SubtractInPlace`, `AddMaskedInPlace`, `ShiftLeftByOneBitInPlace`, `ShiftRightByPLimbs`). The omission mattered most on that method: it deliberately avoids the `(b - a) >> 63` bit-fold, which is wrong for limbs with bit 63 set, and relies instead on the C# `<` and `>` operators on `ulong` lowering to branchless comparisons — an assumption about code generation, which is what the attribute pins down. No public API change and no behavioural change; the attribute constrains the JIT only. Found by an audit of every method the documentation lists as constant-time.
+
 ## [1.0.1] - 2026-08-24
 
 ### Added

--- a/src/Math/Numerics/SecureBigInteger.cs
+++ b/src/Math/Numerics/SecureBigInteger.cs
@@ -2103,6 +2103,7 @@ public sealed class SecureBigInteger : IDisposable, IEquatable<SecureBigInteger>
     /// non-zero limb encountered determines the result — exactly the lexicographic
     /// MSB-first ordering required.
     /// </remarks>
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
     private static int CompareUnsigned(SecureBigInteger left, SecureBigInteger right)
     {
         int leftCount = left.LimbCount;


### PR DESCRIPTION
`CompareUnsigned` was the only branchless helper in `SecureBigInteger` without `MethodImplOptions.NoInlining | NoOptimization`. `FixedTimeLimbsEqual`, `SubtractInPlace`, `AddMaskedInPlace`, `ShiftLeftByOneBitInPlace` and `ShiftRightByPLimbs` all carry it.

The omission matters most on that method. Its own `<remarks>` explain that it deliberately avoids the naive `(b - a) >> 63` bit-fold — wrong for limbs with bit 63 set — and relies instead on the C# `<` and `>` operators on `ulong` lowering to `setb`/`seta`. That is an assumption about code generation, and pinning code generation is what the attribute is for.

No behavioural change: the attribute only constrains the JIT. Full `net8.0` suite green at 1706/1706, and all eight library target frameworks compile.

Found by a self-audit of `SecureBigInteger` carried out during review of #399, which walked every method the architecture documentation lists as constant-time. The documentation-side findings from that audit are in #399; this is the only one that is a code change.